### PR TITLE
Make AppVeyor run `npm rebuild`.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ install:
 test_script:
   - node --version
   - npm --version
+  - npm rebuild
   - npm test
 
 build: off


### PR DESCRIPTION
This fixes the build for Node 4 on Windows, which otherwise fails at installing gRPC.