### PR TITLE
Ignore Firestore types in object traversal

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -1096,7 +1096,7 @@ function validateDocumentData(obj, usesPaths, depth) {
   }
 
   if (!isPlainObject(obj)) {
-    throw new Error('Input is not a JavaScript object.');
+    throw new Error('Input is not a plain JavaScript object.');
   }
 
   for (let prop in obj) {
@@ -1169,24 +1169,17 @@ function validateSetOptions(options) {
 }
 
 /*!
- * Verifies that 'obj' is a plain JavaScript object that does not have a custom
- * encoding format. Objects that pass this check are encoded as 'Maps' in
- * Firestore.
+ * Verifies that 'obj' is a plain JavaScript object that can be encoded as a
+ * 'Map' in Firestore.
  *
- * @param {*} The argument to verify.
+ * @param {*} input - The argument to verify.
  * @returns {boolean} 'true' if the input can be a treated as a plain object.
  */
-function isPlainObject(obj) {
+function isPlainObject(input) {
   return (
-    is.object(obj) &&
-    !is.array(obj) &&
-    !is.date(obj) &&
-    !is.instance(obj, Firestore) &&
-    !is.instance(obj, DocumentReference) &&
-    !is.instance(obj, ResourcePath) &&
-    !is.instance(obj, GeoPoint) &&
-    !is.instance(obj, Buffer) &&
-    !is.instance(obj, Uint8Array)
+    typeof input === 'object' &&
+    input !== null &&
+    Object.getPrototypeOf(input) === Object.prototype
   );
 }
 

--- a/src/document.js
+++ b/src/document.js
@@ -43,13 +43,6 @@ const FieldValue = require('./field-value');
  */
 let DocumentReference;
 
-/*!
- * Injected.
- *
- * @see {Firestore}
- */
-let Firestore;
-
 /*! Injected. */
 let validate;
 
@@ -1183,10 +1176,9 @@ function isPlainObject(input) {
   );
 }
 
-module.exports = (FirestoreType, DocumentRefType) => {
-  Firestore = FirestoreType;
+module.exports = DocumentRefType => {
   DocumentReference = DocumentRefType;
-  validate = require('./validate.js')({
+  validate = require('./validate')({
     FieldPath: FieldPath.validateFieldPath,
   });
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -1071,10 +1071,10 @@ Firestore.setLogFunction = function(logger) {
 let reference = require('./reference')(Firestore);
 CollectionReference = reference.CollectionReference;
 DocumentReference = reference.DocumentReference;
-let document = require('./document')(Firestore, DocumentReference);
+let document = require('./document')(DocumentReference);
 DocumentSnapshot = document.DocumentSnapshot;
 GeoPoint = document.GeoPoint;
-validate = require('./validate.js')({
+validate = require('./validate')({
   DocumentReference: reference.validateDocumentReference,
   ResourcePath: ResourcePath.validateResourcePath,
 });

--- a/src/reference.js
+++ b/src/reference.js
@@ -1889,15 +1889,15 @@ function validateDocumentReference(value) {
 
 module.exports = FirestoreType => {
   Firestore = FirestoreType;
-  let document = require('./document.js')(DocumentReference);
+  let document = require('./document')(DocumentReference);
   DocumentSnapshot = document.DocumentSnapshot;
-  Watch = require('./watch.js')(
+  Watch = require('./watch')(
     FirestoreType,
     DocumentChange,
     DocumentReference,
     DocumentSnapshot
   );
-  WriteBatch = require('./write-batch.js')(
+  WriteBatch = require('./write-batch')(
     FirestoreType,
     DocumentReference,
     validateDocumentReference

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -293,8 +293,8 @@ module.exports = FirestoreType => {
   let reference = require('./reference')(FirestoreType);
   DocumentReference = reference.DocumentReference;
   Query = reference.Query;
-  let document = require('./document.js')(FirestoreType, DocumentReference);
-  require('./validate.js')({
+  let document = require('./document')(DocumentReference);
+  require('./validate')({
     Document: document.validateDocumentData,
     DocumentReference: reference.validateDocumentReference,
     Precondition: document.validatePrecondition,

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -509,7 +509,7 @@ module.exports = (
   DocumentReferenceType,
   validateDocumentReference
 ) => {
-  let document = require('./document.js')(Firestore, DocumentReferenceType);
+  let document = require('./document')(DocumentReferenceType);
   Firestore = FirestoreType;
   DocumentMask = document.DocumentMask;
   DocumentSnapshot = document.DocumentSnapshot;

--- a/test/document.js
+++ b/test/document.js
@@ -568,7 +568,7 @@ describe('serialize document', function() {
     }, new RegExp('Argument "dataOrField" is not a valid Document. Input object is deeper than 20 levels or contains a cycle.'));
   });
 
-  it("doesn't traverse cyclic references", function() {
+  it('is able to write a document reference with cycles', function() {
     firestore.api.Firestore._commit = function(request, options, callback) {
       requestEquals(
         request,
@@ -584,6 +584,9 @@ describe('serialize document', function() {
       callback(null, defaultWriteResult);
     };
 
+    // The Firestore Admin SDK adds a cyclic reference to the 'Firestore' type.
+    // We emulate this behavior in this test to verify that we can properly
+    // serialize types that contain references to a cyclic Firestore type.
     let ref = firestore.doc('collectionId/documentId');
     ref.firestore.firestore = firestore;
     return ref.set({ref});

--- a/test/document.js
+++ b/test/document.js
@@ -388,22 +388,6 @@ describe('serialize document', function() {
     }, /Cannot encode type/);
   });
 
-  it("doesn't serialize inherited properties", function() {
-    firestore.api.Firestore._commit = function(request, options, callback) {
-      requestEquals(
-        request,
-        update(document('member', 'bar'), updateMask('member'))
-      );
-      callback(null, defaultWriteResult);
-    };
-
-    let base = {inherited: 'foo'};
-    let instance = Object.create(base);
-    instance.member = 'bar';
-
-    return firestore.doc('collectionId/documentId').update(instance);
-  });
-
   it('serializes date before 1970', function() {
     firestore.api.Firestore._commit = function(request, options, callback) {
       requestEquals(
@@ -584,9 +568,11 @@ describe('serialize document', function() {
       callback(null, defaultWriteResult);
     };
 
-    // The Firestore Admin SDK adds a cyclic reference to the 'Firestore' type.
-    // We emulate this behavior in this test to verify that we can properly
-    // serialize types that contain references to a cyclic Firestore type.
+    // The Firestore Admin SDK adds a cyclic reference to the 'Firestore' member
+    // of 'DocumentReference'. We emulate this behavior in this test to verify
+    // that we can properly serialize DocumentReference instances, even if they
+    // have cyclic references (we shouldn't try to validate them beyond the
+    // instanceof check).
     let ref = firestore.doc('collectionId/documentId');
     ref.firestore.firestore = firestore;
     return ref.set({ref});
@@ -1059,13 +1045,13 @@ describe('set document', function() {
   it('requires an object', function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').set(null);
-    }, new RegExp('Argument "data" is not a valid Document. Input is not a ' + 'JavaScript object.'));
+    }, new RegExp('Argument "data" is not a valid Document. Input is not a plain JavaScript object.'));
   });
 
   it("doesn't accept arrays", function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').set([42]);
-    }, new RegExp('Argument "data" is not a valid Document. Input is not a ' + 'JavaScript object.'));
+    }, new RegExp('Argument "data" is not a valid Document. Input is not a plain JavaScript object.'));
   });
 });
 
@@ -1140,13 +1126,13 @@ describe('create document', function() {
   it('requires an object', function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').create(null);
-    }, new RegExp('Argument "data" is not a valid Document. Input is not a ' + 'JavaScript object.'));
+    }, new RegExp('Argument "data" is not a valid Document. Input is not a plain JavaScript object.'));
   });
 
   it("doesn't accept arrays", function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').create([42]);
-    }, new RegExp('Argument "data" is not a valid Document. Input is not a ' + 'JavaScript object.'));
+    }, new RegExp('Argument "data" is not a valid Document. Input is not a plain JavaScript object.'));
   });
 });
 
@@ -1499,13 +1485,13 @@ describe('update document', function() {
   it('accepts an object', function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update(null);
-    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is ' + 'not a JavaScript object.'));
+    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.'));
   });
 
   it("doesn't accept arrays", function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update([42]);
-    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is ' + 'not a JavaScript object.'));
+    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.'));
   });
 
   it('with field delete', function() {

--- a/test/order.js
+++ b/test/order.js
@@ -23,7 +23,7 @@ const grpc = require('grpc');
 const Firestore = require('../');
 const DocumentReference = require('../src/reference')(Firestore)
   .DocumentReference;
-const document = require('../src/document')(Firestore, DocumentReference);
+const document = require('../src/document')(DocumentReference);
 const DocumentSnapshot = document.DocumentSnapshot;
 const GeoPoint = document.GeoPoint;
 const order = require('../src/order');

--- a/test/query.js
+++ b/test/query.js
@@ -25,10 +25,8 @@ const through = require('through2');
 const Firestore = require('../');
 const reference = require('../src/reference')(Firestore);
 const DocumentReference = reference.DocumentReference;
-const DocumentSnapshot = require('../src/document')(
-  Firestore,
-  DocumentReference
-).DocumentSnapshot;
+const DocumentSnapshot = require('../src/document')(DocumentReference)
+  .DocumentSnapshot;
 const ResourcePath = require('../src/path').ResourcePath;
 
 const DATABASE_ROOT = 'projects/test-project/databases/(default)';

--- a/test/watch.js
+++ b/test/watch.js
@@ -25,10 +25,8 @@ const through = require('through2');
 const Firestore = require('../');
 const reference = require('../src/reference')(Firestore);
 const DocumentReference = reference.DocumentReference;
-const DocumentSnapshot = require('../src/document')(
-  Firestore,
-  DocumentReference
-).DocumentSnapshot;
+const DocumentSnapshot = require('../src/document')(DocumentReference)
+  .DocumentSnapshot;
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});

--- a/test/write-batch.js
+++ b/test/write-batch.js
@@ -50,7 +50,7 @@ describe('set() method', function() {
     assert.throws(function() {
       writeBatch.set(firestore.doc('sub/doc'));
     }, new RegExp(
-      'Argument "data" is not a valid Document. Input is not a ' +
+      'Argument "data" is not a valid Document. Input is not a plain ' +
         'JavaScript object.'
     ));
   });
@@ -100,7 +100,7 @@ describe('update() method', function() {
   it('requires object', function() {
     assert.throws(() => {
       writeBatch.update(firestore.doc('sub/doc'));
-    }, new RegExp('Argument "dataOrField" is not a valid Document. ' + 'Input is not a JavaScript object.'));
+    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.'));
   });
 
   it('accepts preconditions', function() {
@@ -131,7 +131,7 @@ describe('create() method', function() {
     assert.throws(function() {
       writeBatch.create(firestore.doc('sub/doc'));
     }, new RegExp(
-      'Argument "data" is not a valid Document. Input is not a ' +
+      'Argument "data" is not a valid Document. Input is not a plain ' +
         'JavaScript object.'
     ));
   });


### PR DESCRIPTION
Fixes https://stackoverflow.com/questions/46565208/setting-a-documentreference-in-document-on-firestore-nodejs?noredirect=1#comment80108029_46565208

The underlying problem is that the Firebase Admin SDK introduces a cyclic reference that causes us to reach the nesting limit of 20 during the validateDocumentData() call (in the Admin SDK, a 'firestore' property of DocumentReference contains a cyclic reference to itself). 

This PR special cases internal Firestore types to no longer do this traversal and changes all logic that traverses nested maps to ignore Firestore special types.