### PR TITLE
Rejecting 'null' and 'undefined' as arguments for CollectionRef.doc()

### DIFF
--- a/src/reference.js
+++ b/src/reference.js
@@ -1783,10 +1783,10 @@ class CollectionReference extends Query {
    * console.log(`Reference with auto-id: ${documentRefWithAutoId.path}`);
    */
   doc(documentPath) {
-    validate.isOptionalResourcePath('documentPath', documentPath);
-
-    if (!is.defined(documentPath)) {
+    if (arguments.length === 0) {
       documentPath = Firestore.autoId();
+    } else {
+      validate.isResourcePath('documentPath', documentPath);
     }
 
     let path = this._referencePath.append(documentPath);

--- a/test/collection.js
+++ b/test/collection.js
@@ -62,6 +62,10 @@ describe('Collection interface', function() {
       collectionRef.doc(undefined);
     }, /Argument "documentPath" is not a valid ResourcePath. Path is not a string./);
 
+    assert.throws(function() {
+      collectionRef.doc('doc/coll');
+    }, /Argument "documentPath" must point to a document\./);
+
     documentRef = collectionRef.doc('docId/colId/docId');
     assert.ok(is.instance(documentRef, DocumentReference));
   });

--- a/test/collection.js
+++ b/test/collection.js
@@ -52,11 +52,15 @@ describe('Collection interface', function() {
 
     assert.throws(() => {
       collectionRef.doc(false);
-    }, new RegExp('Argument "documentPath" is not a valid ResourcePath. ' + 'Path is not a string.'));
+    }, /Argument "documentPath" is not a valid ResourcePath. Path is not a string./);
 
     assert.throws(() => {
-      collectionRef.doc('doc/col');
-    }, /Argument "documentPath" must point to a document\./);
+      collectionRef.doc(null);
+    }, /Argument "documentPath" is not a valid ResourcePath. Path is not a string./);
+
+    assert.throws(() => {
+      collectionRef.doc(undefined);
+    }, /Argument "documentPath" is not a valid ResourcePath. Path is not a string./);
 
     documentRef = collectionRef.doc('docId/colId/docId');
     assert.ok(is.instance(documentRef, DocumentReference));


### PR DESCRIPTION
This is for Google-internal bug b/67419579:

[Node] .doc(undefined).set() does an add
We should catch "undefined" being passed and say "hey don't do that" not do an add