### PR TITLE
Handle API JSON format

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "google-gax": "^0.14.1",
     "grpc": "^1.6.0",
     "is": "^3.2.0",
+    "safe-buffer": "^5.1.1",
     "through2": "^2.0.3"
   },
   "devDependencies": {
@@ -66,7 +67,6 @@
     "power-assert": "^1.4.4",
     "prettier": "^1.7.2",
     "proxyquire": "^1.7.11",
-    "safe-buffer": "^5.1.1",
     "typescript": "^2.5.2"
   },
   "scripts": {

--- a/src/convert.js
+++ b/src/convert.js
@@ -38,10 +38,12 @@ const validate = require('./validate')();
  *
  * @private
  * @param {*=} timestampValue - The value to convert.
+ * @param {string=} argumentName - The argument name to use in the error message
+ * if the conversion fails. If omitted, 'timestampValue' is used.
  * @return {{nanos,seconds}|undefined} The value as expected by Protobuf JS or
  * undefined if no input was provided.
  */
-function convertTimestamp(timestampValue) {
+function convertTimestamp(timestampValue, argumentName) {
   let timestampProto = undefined;
 
   if (is.string(timestampValue)) {
@@ -62,11 +64,9 @@ function convertTimestamp(timestampValue) {
     }
 
     if (isNaN(seconds) || isNaN(nanos)) {
-      // This error should only ever be thrown if the end-user specifies an
-      // invalid 'lastUpdateTime' in a precondition (hence we use
-      // 'lastUpdateTime' here instead of the actual argument name).
+      argumentName = argumentName || 'timestampValue';
       throw new Error(
-        'Specify a valid ISO 8601 timestamp for "lastUpdateTime".'
+        `Specify a valid ISO 8601 timestamp for "${argumentName}".`
       );
     }
 

--- a/src/convert.js
+++ b/src/convert.js
@@ -21,8 +21,20 @@ const is = require('is');
 
 const validate = require('./validate')();
 
+/*!
+ * @module firestore/convert
+ * @private
+ *
+ * This module contains utility functions to convert
+ * `firestore.v1beta1.Documents` from Proto3 JSON to their equivalent
+ * representation in Protobuf JS. Protobuf JS is the only encoding supported by
+ * this client, and dependencies that use Proto3 JSON (such as the Google Cloud
+ * Functions SDK) are supported through this conversion and its usage in
+ * {@see Firestore#snapshot_}.
+ */
+
 /**
- * Converts an ISO 8601 or Protobuf JS 'timestampValue' into Protobuf JS.
+ * Converts an ISO 8601 or google.protobuf.Timestamp proto into Protobuf JS.
  *
  * @private
  * @param {*=} timestampValue - The value to convert.
@@ -51,7 +63,8 @@ function convertTimestamp(timestampValue) {
 
     if (isNaN(seconds) || isNaN(nanos)) {
       // This error should only ever be thrown if the end-user specifies an
-      // invalid 'lastUpdateTime'.
+      // invalid 'lastUpdateTime' in a precondition (hence we use
+      // 'lastUpdateTime' here instead of the actual argument name).
       throw new Error(
         'Specify a valid ISO 8601 timestamp for "lastUpdateTime".'
       );
@@ -73,7 +86,7 @@ function convertTimestamp(timestampValue) {
 }
 
 /**
- * Converts an API JSON or Protobuf JS 'bytesValue' field into Protobuf JS.
+ * Converts a Proto3 JSON 'bytesValue' field into Protobuf JS.
  *
  * @private
  * @param {*} bytesValue - The value to convert.
@@ -88,10 +101,10 @@ function convertBytes(bytesValue) {
 }
 
 /**
- * Detects 'valueType' from an API JSON or Protobuf JS 'Field' proto.
+ * Detects 'valueType' from a Proto3 JSON `firestore.v1beta1.Value` proto.
  *
  * @private
- * @param {object} proto - The 'field' proto.
+ * @param {object} proto - The `firestore.v1beta1.Value` proto.
  * @return {string} - The string value for 'valueType'.
  */
 function detectValueType(proto) {
@@ -145,12 +158,13 @@ function detectValueType(proto) {
 }
 
 /**
- * Converts an API JSON or Protobuf JS 'Field' proto into Protobuf JS.
+ * Converts a `firestore.v1beta1.Value` in Proto3 JSON encoding into the
+ * Protobuf JS format expected by this client.
  *
  * @private
- * @param {object} fieldValue - The 'Field' value in API JSON or Protobuf JS
+ * @param {object} fieldValue - The `firestore.v1beta1.Value` in Proto3 JSON
  * format.
- * @return The 'Field' proto in Protobuf JS format.
+ * @return {object} The `firestore.v1beta1.Value` in Protobuf JS format.
  */
 function convertValue(fieldValue) {
   let valueType = detectValueType(fieldValue);
@@ -196,13 +210,16 @@ function convertValue(fieldValue) {
       return Object.assign({valueType}, fieldValue);
   }
 }
+
 /**
- * Converts an API JSON or Protobuf JS 'Document' into Protobuf JS. This
- * conversion creates a copy of underlying document.
+ * Converts a `firestore.v1beta1.Document` in Proto3 JSON encoding into the
+ * Protobuf JS format expected by this client. This conversion creates a copy of
+ * the underlying document.
  *
  * @private
- * @param {object} document - The 'Document' in API JSON or Protobuf JS format.
- * @return {object} The 'Document' in Protobuf JS format.
+ * @param {object} document - The `firestore.v1beta1.Document` in Proto3 JSON
+ * format.
+ * @return {object} The `firestore.v1beta1.Document` in Protobuf JS format.
  */
 function convertDocument(document) {
   let result = {};
@@ -217,6 +234,6 @@ function convertDocument(document) {
 }
 
 module.exports = {
-  convertDocument,
-  convertTimestamp,
+  documentFromJson: convertDocument,
+  timestampFromJson: convertTimestamp,
 };

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,0 +1,217 @@
+/*!
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Buffer = require('safe-buffer').Buffer;
+const is = require('is');
+
+const validate = require('./validate')();
+
+/**
+ * Converts an ISO 8601 or Protobuf JS 'timestampValue' into Protobuf JS.
+ *
+ * @private
+ * @param {*} timestampValue - The value to convert.
+ * @return {{nanos,seconds}} The value as expected by Protobuf JS.
+ */
+function convertTimestamp(timestampValue) {
+  if (is.string(timestampValue)) {
+    let date = new Date(timestampValue);
+    let seconds = Math.floor(date.getTime() / 1000);
+    let nanos = null;
+
+    let nanoString = timestampValue.substring(20, timestampValue.length - 1);
+
+    if (nanoString.length === 3) {
+      nanoString = `${nanoString}000000`;
+    } else if (nanoString.length === 6) {
+      nanoString = `${nanoString}000`;
+    }
+
+    if (nanoString.length === 9) {
+      nanos = parseInt(nanoString);
+    }
+
+    if (isNaN(seconds) || isNaN(nanos)) {
+      // This error should only ever be thrown if the end-user specifies an
+      // invalid 'lastUpdateTime'.
+      throw new Error(
+        'Specify a valid ISO 8601 timestamp for "lastUpdateTime".'
+      );
+    }
+
+    return {
+      seconds: seconds,
+      nanos: nanos,
+    };
+  } else {
+    validate.isObject('timestampValue', timestampValue);
+    return {
+      seconds: timestampValue.seconds || 0,
+      nanos: timestampValue.nanos || 0,
+    };
+  }
+}
+
+/**
+ * Converts an API JSON or Protobuf JS 'bytesValue' field into Protobuf JS.
+ *
+ * @private
+ * @param {*} bytesValue - The value to convert.
+ * @return {Buffer} The value as expected by Protobuf JS.
+ */
+function convertBytes(bytesValue) {
+  if (typeof bytesValue === 'string') {
+    return Buffer.from(bytesValue, 'base64');
+  } else {
+    return bytesValue;
+  }
+}
+
+/**
+ * Detects 'valueType' from an API JSON or Protobuf JS 'Field' proto.
+ *
+ * @private
+ * @param {object} proto - The 'field' proto.
+ * @return {string} - The string value for 'valueType'.
+ */
+function detectValueType(proto) {
+  if (proto.valueType) {
+    return proto.valueType;
+  }
+
+  let detectedValues = [];
+
+  if (is.defined(proto.stringValue)) {
+    detectedValues.push('stringValue');
+  }
+  if (is.defined(proto.booleanValue)) {
+    detectedValues.push('booleanValue');
+  }
+  if (is.defined(proto.integerValue)) {
+    detectedValues.push('integerValue');
+  }
+  if (is.defined(proto.doubleValue)) {
+    detectedValues.push('doubleValue');
+  }
+  if (is.defined(proto.timestampValue)) {
+    detectedValues.push('timestampValue');
+  }
+  if (is.defined(proto.referenceValue)) {
+    detectedValues.push('referenceValue');
+  }
+  if (is.defined(proto.arrayValue)) {
+    detectedValues.push('arrayValue');
+  }
+  if (is.defined(proto.nullValue)) {
+    detectedValues.push('nullValue');
+  }
+  if (is.defined(proto.mapValue)) {
+    detectedValues.push('mapValue');
+  }
+  if (is.defined(proto.geoPointValue)) {
+    detectedValues.push('geoPointValue');
+  }
+  if (is.defined(proto.bytesValue)) {
+    detectedValues.push('bytesValue');
+  }
+
+  if (detectedValues.length !== 1) {
+    throw new Error(
+      `Unable to infer type value fom '${JSON.stringify(proto)}'.`
+    );
+  }
+
+  return detectedValues[0];
+}
+
+/**
+ * Converts an API JSON or Protobuf JS 'Field' proto into Protobuf JS.
+ *
+ * @private
+ * @param {object} fieldValue - The 'Field' value in API JSON or Protobuf JS
+ * format.
+ * @return The 'Field' proto in Protobuf JS format.
+ */
+function convertValue(fieldValue) {
+  let valueType = detectValueType(fieldValue);
+
+  switch (valueType) {
+    case 'timestampValue':
+      return {
+        valueType: 'timestampValue',
+        timestampValue: convertTimestamp(fieldValue.timestampValue),
+      };
+    case 'bytesValue':
+      return {
+        valueType: 'bytesValue',
+        bytesValue: convertBytes(fieldValue.bytesValue),
+      };
+    case 'arrayValue': {
+      let arrayValue = [];
+      for (let value of fieldValue.arrayValue.values) {
+        arrayValue.push(convertValue(value));
+      }
+      return {
+        valueType: 'arrayValue',
+        arrayValue: {
+          values: arrayValue,
+        },
+      };
+    }
+    case 'mapValue': {
+      let mapValue = {};
+      for (let prop in fieldValue.mapValue.fields) {
+        if (fieldValue.mapValue.fields.hasOwnProperty(prop)) {
+          mapValue[prop] = convertValue(fieldValue.mapValue.fields[prop]);
+        }
+      }
+      return {
+        valueType: 'mapValue',
+        mapValue: {
+          fields: mapValue,
+        },
+      };
+    }
+    default:
+      return Object.assign({valueType}, fieldValue);
+  }
+}
+/**
+ * Converts an API JSON or Protobuf JS 'Document' into Protobuf JS. This
+ * conversion creates a copy of underlying document.
+ *
+ * @private
+ * @param {object} document - The 'Document' in API JSON or Protobuf JS format.
+ * @return {object} The 'Document' in Protobuf JS format.
+ */
+function convertDocument(document) {
+  let result = {};
+
+  for (let prop in document) {
+    if (document.hasOwnProperty(prop)) {
+      result[prop] = convertValue(document[prop]);
+    }
+  }
+
+  return result;
+}
+
+module.exports = {
+  convertDocument,
+  convertTimestamp,
+};

--- a/src/convert.js
+++ b/src/convert.js
@@ -25,10 +25,13 @@ const validate = require('./validate')();
  * Converts an ISO 8601 or Protobuf JS 'timestampValue' into Protobuf JS.
  *
  * @private
- * @param {*} timestampValue - The value to convert.
- * @return {{nanos,seconds}} The value as expected by Protobuf JS.
+ * @param {*=} timestampValue - The value to convert.
+ * @return {{nanos,seconds}|undefined} The value as expected by Protobuf JS or
+ * undefined if no input was provided.
  */
 function convertTimestamp(timestampValue) {
+  let timestampProto = undefined;
+
   if (is.string(timestampValue)) {
     let date = new Date(timestampValue);
     let seconds = Math.floor(date.getTime() / 1000);
@@ -54,17 +57,19 @@ function convertTimestamp(timestampValue) {
       );
     }
 
-    return {
+    timestampProto = {
       seconds: seconds,
       nanos: nanos,
     };
-  } else {
+  } else if (is.defined(timestampValue)) {
     validate.isObject('timestampValue', timestampValue);
-    return {
+    timestampProto = {
       seconds: timestampValue.seconds || 0,
       nanos: timestampValue.nanos || 0,
     };
   }
+
+  return timestampProto;
 }
 
 /**

--- a/src/document.js
+++ b/src/document.js
@@ -1033,7 +1033,10 @@ class Precondition {
     let proto = {};
 
     if (is.defined(this._lastUpdateTime)) {
-      proto.updateTime = timestampFromJson(this._lastUpdateTime);
+      proto.updateTime = timestampFromJson(
+        this._lastUpdateTime,
+        'lastUpdateTime'
+      );
     } else if (is.defined(this._exists)) {
       proto.exists = this._exists;
     }

--- a/src/document.js
+++ b/src/document.js
@@ -20,6 +20,7 @@ const assert = require('assert');
 const is = require('is');
 
 const path = require('./path');
+const convertTimestamp = require('./convert').convertTimestamp;
 
 /*!
  * @see {ResourcePath}
@@ -327,7 +328,7 @@ class DocumentSnapshot {
   }
 
   /**
-   * Returns the underlying Firestore 'Fields' Protobuf.
+   * Returns the underlying Firestore 'Fields' Protobuf in Protobuf JS format.
    *
    * @private
    * @returns {Object} The Protobuf encoded document.
@@ -373,7 +374,7 @@ class DocumentSnapshot {
   }
 
   /**
-   * Retrieves the field specified by 'fieldPath' in its Protobuf
+   * Retrieves the field specified by 'fieldPath' in its Protobuf JS
    * representation.
    *
    * @private
@@ -1053,14 +1054,11 @@ class Precondition {
 
       if (isNaN(seconds) || isNaN(nanos)) {
         throw new Error(
-          'Specify a valid ISO 8601 timestamp for' + ' "lastUpdateTime".'
+          'Specify a valid ISO 8601 timestamp for "lastUpdateTime".'
         );
       }
 
-      proto.updateTime = {
-        seconds: seconds,
-        nanos: nanos,
-      };
+      proto.updateTime = convertTimestamp(this._lastUpdateTime);
     } else if (is.defined(this._exists)) {
       proto.exists = this._exists;
     }

--- a/src/document.js
+++ b/src/document.js
@@ -20,7 +20,7 @@ const assert = require('assert');
 const is = require('is');
 
 const path = require('./path');
-const convertTimestamp = require('./convert').convertTimestamp;
+const timestampFromJson = require('./convert').timestampFromJson;
 
 /*!
  * @see {ResourcePath}
@@ -1033,32 +1033,7 @@ class Precondition {
     let proto = {};
 
     if (is.defined(this._lastUpdateTime)) {
-      let date = new Date(this._lastUpdateTime);
-      let seconds = Math.floor(date.getTime() / 1000);
-      let nanos = null;
-
-      let nanoString = this._lastUpdateTime.substring(
-        20,
-        this._lastUpdateTime.length - 1
-      );
-
-      if (nanoString.length === 3) {
-        nanoString = `${nanoString}000000`;
-      } else if (nanoString.length === 6) {
-        nanoString = `${nanoString}000`;
-      }
-
-      if (nanoString.length === 9) {
-        nanos = parseInt(nanoString);
-      }
-
-      if (isNaN(seconds) || isNaN(nanos)) {
-        throw new Error(
-          'Specify a valid ISO 8601 timestamp for "lastUpdateTime".'
-        );
-      }
-
-      proto.updateTime = convertTimestamp(this._lastUpdateTime);
+      proto.updateTime = timestampFromJson(this._lastUpdateTime);
     } else if (is.defined(this._exists)) {
       proto.exists = this._exists;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -333,7 +333,7 @@ class Firestore extends commonGrpc.Service {
 
   /**
    * Creates a [DocumentSnapshot]{@link DocumentSnapshot} from a
-   * `firestore.v1beta1lDocument` proto (or from a resource name for missing
+   * `firestore.v1beta1.Document` proto (or from a resource name for missing
    * documents).
    *
    * This API is used by Google Cloud Functions and can be called with both
@@ -383,14 +383,16 @@ class Firestore extends commonGrpc.Service {
         ? convertDocument(documentOrName.fields)
         : {};
       document.createTime = DocumentSnapshot.toISOTime(
-        convertTimestamp(documentOrName.createTime)
+        convertTimestamp(documentOrName.createTime, 'documentOrName.createTime')
       );
       document.updateTime = DocumentSnapshot.toISOTime(
-        convertTimestamp(documentOrName.updateTime)
+        convertTimestamp(documentOrName.updateTime, 'documentOrName.updateTime')
       );
     }
 
-    document.readTime = DocumentSnapshot.toISOTime(convertTimestamp(readTime));
+    document.readTime = DocumentSnapshot.toISOTime(
+      convertTimestamp(readTime, 'readTime')
+    );
 
     return document.build();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ const v1beta1 = require('./v1beta1');
 const libVersion = require('../package.json').version;
 
 const path = require('./path');
+const convert = require('./convert');
 
 /*!
  * DO NOT REMOVE THE FOLLOWING NAMESPACE DEFINITIONS
@@ -59,6 +60,9 @@ const FieldPath = path.FieldPath;
  * @see FieldValue
  */
 const FieldValue = require('./field-value');
+
+const convertTimestamp = convert.convertTimestamp;
+const convertDocument = convert.convertDocument;
 
 /*!
  * @see CollectionReference
@@ -351,21 +355,24 @@ class Firestore extends commonGrpc.Service {
         this,
         ResourcePath.fromSlashSeparatedString(documentOrName)
       );
-      document.readTime = DocumentSnapshot.toISOTime(readTime);
     } else {
       document.ref = new DocumentReference(
         this,
         ResourcePath.fromSlashSeparatedString(documentOrName.name)
       );
-      document.fieldsProto = documentOrName.fields || {};
+      document.fieldsProto = documentOrName.fields
+        ? convertDocument(documentOrName.fields)
+        : {};
       document.createTime = DocumentSnapshot.toISOTime(
-        documentOrName.createTime
+        convertTimestamp(documentOrName.createTime)
       );
       document.updateTime = DocumentSnapshot.toISOTime(
-        documentOrName.updateTime
+        convertTimestamp(documentOrName.updateTime)
       );
-      document.readTime = DocumentSnapshot.toISOTime(readTime);
     }
+
+    document.readTime = DocumentSnapshot.toISOTime(convertTimestamp(readTime));
+
     return document.build();
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -363,7 +363,7 @@ class Firestore extends commonGrpc.Service {
     } else {
       throw new Error(
         `Unsupported encoding format. Expected 'json' or 'protobufJS', ` +
-          `but was ${encoding}.`
+          `but was '${encoding}'.`
       );
     }
 

--- a/test/document.js
+++ b/test/document.js
@@ -24,9 +24,6 @@ const is = require('is');
 const through = require('through2');
 
 const Firestore = require('../');
-const reference = require('../src/reference')(Firestore);
-const DocumentReference = reference.DocumentReference;
-const ResourcePath = require('../src/path').ResourcePath;
 
 const DATABASE_ROOT = 'projects/test-project/databases/(default)';
 
@@ -194,127 +191,6 @@ function stream() {
   return stream;
 }
 
-const allSupportedTypesProtobufJs = document(
-  'arrayValue',
-  {
-    valueType: 'arrayValue',
-    arrayValue: {
-      values: [
-        {
-          valueType: 'stringValue',
-          stringValue: 'foo',
-        },
-        {
-          valueType: 'integerValue',
-          integerValue: 42,
-        },
-        {
-          valueType: 'stringValue',
-          stringValue: 'bar',
-        },
-      ],
-    },
-  },
-  'dateValue',
-  {
-    valueType: 'timestampValue',
-    timestampValue: {
-      nanos: 123000000,
-      seconds: 479978400,
-    },
-  },
-  'doubleValue',
-  {
-    valueType: 'doubleValue',
-    doubleValue: 0.1,
-  },
-  'falseValue',
-  {
-    valueType: 'booleanValue',
-    booleanValue: false,
-  },
-  'infinityValue',
-  {
-    valueType: 'doubleValue',
-    doubleValue: Infinity,
-  },
-  'integerValue',
-  {
-    valueType: 'integerValue',
-    integerValue: 0,
-  },
-  'negativeInfinityValue',
-  {
-    valueType: 'doubleValue',
-    doubleValue: -Infinity,
-  },
-  'nilValue',
-  {
-    valueType: 'nullValue',
-    nullValue: 'NULL_VALUE',
-  },
-  'objectValue',
-  {
-    valueType: 'mapValue',
-    mapValue: {
-      fields: {
-        foo: {
-          valueType: 'stringValue',
-          stringValue: 'bar',
-        },
-      },
-    },
-  },
-  'pathValue',
-  {
-    valueType: 'referenceValue',
-    referenceValue: `${DATABASE_ROOT}/documents/collection/document`,
-  },
-  'stringValue',
-  {
-    valueType: 'stringValue',
-    stringValue: 'a',
-  },
-  'trueValue',
-  {
-    valueType: 'booleanValue',
-    booleanValue: true,
-  },
-  'geoPointValue',
-  {
-    valueType: 'geoPointValue',
-    geoPointValue: {
-      latitude: 50.1430847,
-      longitude: -122.947778,
-    },
-  },
-  'bytesValue',
-  {
-    valueType: 'bytesValue',
-    bytesValue: Buffer.from('AQI=', 'base64'),
-  }
-);
-
-const allSupportedTypesObject = {
-  stringValue: 'a',
-  trueValue: true,
-  falseValue: false,
-  integerValue: 0,
-  doubleValue: 0.1,
-  infinityValue: Infinity,
-  negativeInfinityValue: -Infinity,
-  objectValue: {foo: 'bar'},
-  dateValue: new Date('Mar 18, 1985 08:20:00.123 GMT+0100 (CET)'),
-  pathValue: new DocumentReference(
-    {formattedName: DATABASE_ROOT},
-    new ResourcePath('test-project', '(default)', 'collection', 'document')
-  ),
-  arrayValue: ['foo', 42, 'bar'],
-  nilValue: null,
-  geoPointValue: new Firestore.GeoPoint(50.1430847, -122.947778),
-  bytesValue: Buffer.from([0x1, 0x2]),
-};
-
 const defaultWriteResult = {
   commitTime: {
     nanos: 3,
@@ -371,15 +247,23 @@ describe('serialize document', function() {
     firestore = createInstance();
   });
 
-  it('serializes all supported types', function() {
+  it('serializes to Protobuf JS', function() {
     firestore.api.Firestore._commit = function(request, options, callback) {
-      requestEquals(request, set(allSupportedTypesProtobufJs));
+      requestEquals(
+        request,
+        set(
+          document('bytes', {
+            valueType: 'bytesValue',
+            bytesValue: Buffer.from('AG=', 'base64'),
+          })
+        )
+      );
       callback(null, defaultWriteResult);
     };
 
     return firestore
       .doc('collectionId/documentId')
-      .set(allSupportedTypesObject);
+      .set({bytes: Buffer.from('AG=', 'base64')});
   });
 
   it("doesn't serialize unsupported types", function() {
@@ -586,34 +470,24 @@ describe('deserialize document', function() {
     firestore = createInstance();
   });
 
-  function verifyAllSupportedTypes(actualObject) {
-    let expected = extend(true, {}, allSupportedTypesObject);
-    // Deep Equal doesn't support matching instances of DocumentRefs, so we
-    // compare them manually and remove them from the resulting object.
-    assert.equal(
-      actualObject.get('pathValue').formattedName,
-      expected.pathValue.formattedName
-    );
-    let data = actualObject.data();
-    delete data.pathValue;
-    delete expected.pathValue;
-    assert.deepEqual(data, expected);
-
-    // We specifically test the GeoPoint properties here to ensure 100% test
-    // coverage.
-    assert.equal(50.1430847, data.geoPointValue.latitude);
-    assert.equal(-122.947778, data.geoPointValue.longitude);
-  }
-
-  it('deserializes all supported types from Protobuf JS', function() {
+  it('deserializes Protobuf JS', function() {
     firestore.api.Firestore._batchGetDocuments = function() {
-      return stream(found(allSupportedTypesProtobufJs));
+      return stream(
+        found(
+          document('foo', {
+            valueType: 'bytesValue',
+            bytesValue: Buffer.from('AG=', 'base64'),
+          })
+        )
+      );
     };
 
     return firestore
       .doc('collectionId/documentId')
       .get()
-      .then(verifyAllSupportedTypes);
+      .then(res => {
+        assert.deepEqual(res.data(), {foo: Buffer.from('AG=', 'base64')});
+      });
   });
 
   it('ignores intermittent stream failures', function() {

--- a/test/document.js
+++ b/test/document.js
@@ -295,86 +295,6 @@ const allSupportedTypesProtobufJs = document(
   }
 );
 
-const allSupportedTypesApiJson = document(
-  'arrayValue',
-  {
-    arrayValue: {
-      values: [
-        {
-          stringValue: 'foo',
-        },
-        {
-          integerValue: 42,
-        },
-        {
-          stringValue: 'bar',
-        },
-      ],
-    },
-  },
-  'dateValue',
-  {
-    timestampValue: '1985-03-18T07:20:00.123000000Z',
-  },
-  'doubleValue',
-  {
-    doubleValue: 0.1,
-  },
-  'falseValue',
-  {
-    booleanValue: false,
-  },
-  'infinityValue',
-  {
-    doubleValue: Infinity,
-  },
-  'integerValue',
-  {
-    integerValue: 0,
-  },
-  'negativeInfinityValue',
-  {
-    doubleValue: -Infinity,
-  },
-  'nilValue',
-  {
-    nullValue: 'NULL_VALUE',
-  },
-  'objectValue',
-  {
-    mapValue: {
-      fields: {
-        foo: {
-          stringValue: 'bar',
-        },
-      },
-    },
-  },
-  'pathValue',
-  {
-    referenceValue: `${DATABASE_ROOT}/documents/collection/document`,
-  },
-  'stringValue',
-  {
-    stringValue: 'a',
-  },
-  'trueValue',
-  {
-    booleanValue: true,
-  },
-  'geoPointValue',
-  {
-    geoPointValue: {
-      latitude: 50.1430847,
-      longitude: -122.947778,
-    },
-  },
-  'bytesValue',
-  {
-    bytesValue: 'AQI=',
-  }
-);
-
 const allSupportedTypesObject = {
   stringValue: 'a',
   trueValue: true,
@@ -679,7 +599,7 @@ describe('deserialize document', function() {
     delete expected.pathValue;
     assert.deepEqual(data, expected);
 
-    // We specifically test the GeoPoint properties here to get to 100% test
+    // We specifically test the GeoPoint properties here to ensure 100% test
     // coverage.
     assert.equal(50.1430847, data.geoPointValue.latitude);
     assert.equal(-122.947778, data.geoPointValue.longitude);
@@ -688,17 +608,6 @@ describe('deserialize document', function() {
   it('deserializes all supported types from Protobuf JS', function() {
     firestore.api.Firestore._batchGetDocuments = function() {
       return stream(found(allSupportedTypesProtobufJs));
-    };
-
-    return firestore
-      .doc('collectionId/documentId')
-      .get()
-      .then(verifyAllSupportedTypes);
-  });
-
-  it('deserializes all supported types from API JSON', function() {
-    firestore.api.Firestore._batchGetDocuments = function() {
-      return stream(found(allSupportedTypesApiJson));
     };
 
     return firestore

--- a/test/index.js
+++ b/test/index.js
@@ -605,7 +605,7 @@ describe('snapshot_() method', function() {
         '1970-01-01T00:00:05.000000006Z',
         'json'
       );
-    }, /Specify a valid ISO 8601 timestamp for "lastUpdateTime"./);
+    }, /Specify a valid ISO 8601 timestamp for "documentOrName.createTime"./);
   });
 
   it('handles missing document ', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -320,25 +320,35 @@ describe('snapshot_() method', function() {
     assert.equal('1970-01-01T00:00:05.000000006Z', doc.readTime);
   });
 
-  it('handles API JSON', function() {
+  it('handles Proto3 JSON', function() {
+    // Google Cloud Functions must be able to call snapshot_() with Proto3 JSON
+    // data.
     let doc = firestore.snapshot_(
       {
         name: `${DATABASE_ROOT}/documents/collectionId/doc`,
-        fields: {foo: {bytesValue: 'AQI='}},
-        createTime: '1970-01-01T00:00:01.000000002Z',
-        updateTime: '1970-01-01T00:00:03.000000004Z',
+        fields: {
+          a: {bytesValue: 'AQI='},
+          b: {timestampValue: '1985-03-18T07:20:00.000Z'},
+          c: {stringValue: 'foobar'},
+        },
+        createTime: '1970-01-01T00:00:01.002Z',
+        updateTime: '1970-01-01T00:00:03.000004Z',
       },
-      '1970-01-01T00:00:05.000000006Z'
+      '1970-01-01T00:00:05.000000006Z',
+      'json'
     );
 
     assert.equal(true, doc.exists);
-    assert.deepEqual({foo: bytesData}, doc.data());
-    assert.equal('1970-01-01T00:00:01.000000002Z', doc.createTime);
-    assert.equal('1970-01-01T00:00:03.000000004Z', doc.updateTime);
+    assert.deepEqual(
+      {a: bytesData, b: new Date('1985-03-18T07:20:00.000Z'), c: 'foobar'},
+      doc.data()
+    );
+    assert.equal('1970-01-01T00:00:01.002000000Z', doc.createTime);
+    assert.equal('1970-01-01T00:00:03.000004000Z', doc.updateTime);
     assert.equal('1970-01-01T00:00:05.000000006Z', doc.readTime);
   });
 
-  it('handles invalid API JSON', function() {
+  it('handles invalid Proto3 JSON', function() {
     assert.throws(() => {
       firestore.snapshot_(
         {
@@ -347,7 +357,8 @@ describe('snapshot_() method', function() {
           createTime: '1970-01-01T00:00:01.000000002Z',
           updateTime: '1970-01-01T00:00:03.000000004Z',
         },
-        '1970-01-01T00:00:05.000000006Z'
+        '1970-01-01T00:00:05.000000006Z',
+        'json'
       );
     }, /Unable to infer type value fom '{}'./);
 
@@ -359,7 +370,8 @@ describe('snapshot_() method', function() {
           createTime: '1970-01-01T00:00:01.000000002Z',
           updateTime: '1970-01-01T00:00:03.000000004Z',
         },
-        '1970-01-01T00:00:05.000000006Z'
+        '1970-01-01T00:00:05.000000006Z',
+        'json'
       );
     }, /Unable to infer type value fom '{"stringValue":"bar","integerValue":42}'./);
 
@@ -371,7 +383,8 @@ describe('snapshot_() method', function() {
           createTime: '1970-01-01T00:00:01.NaNZ',
           updateTime: '1970-01-01T00:00:03.000000004Z',
         },
-        '1970-01-01T00:00:05.000000006Z'
+        '1970-01-01T00:00:05.000000006Z',
+        'json'
       );
     }, /Specify a valid ISO 8601 timestamp for "lastUpdateTime"./);
   });
@@ -379,7 +392,8 @@ describe('snapshot_() method', function() {
   it('handles missing document ', function() {
     let doc = firestore.snapshot_(
       `${DATABASE_ROOT}/documents/collectionId/doc`,
-      '1970-01-01T00:00:05.000000006Z'
+      '1970-01-01T00:00:05.000000006Z',
+      'json'
     );
 
     assert.equal(false, doc.exists);


### PR DESCRIPTION
This adds API JSON format to our internal snapshot_() API as specified by go/api-json (Sorry, this is Google Internal). This format is used by Firebase Functions, and directly exposing it means that the GCF team does not have to worry about our data format.

This was added as a conversion (rather than just adding it to decodeValue), since the logic in watch.js and order.js relies on the Protobuf JS format.

We can potentially get rid of creating the extra copy of the data, but that would mean that the input to snapshot_() gets modified.