### PR TITLE
Adding toString() to GeoPoint

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -122,6 +122,16 @@ class GeoPoint {
   }
 
   /**
+   * Returns a string representation for this GeoPoint.
+   *
+   * @return {string} The string representation.
+   */
+  toString() {
+    return `GeoPoint { latitude: ${this.latitude}, longitude: ${this
+      .longitude} }`;
+  }
+
+  /**
    * Converts the GeoPoint to a google.type.LatLng proto.
    * @private
    */

--- a/test/index.js
+++ b/test/index.js
@@ -490,8 +490,12 @@ describe('snapshot_() method', function() {
 
     // We specifically test the GeoPoint properties to ensure 100% test
     // coverage.
-    assert.equal(50.1430847, data.geoPointValue.latitude);
-    assert.equal(-122.947778, data.geoPointValue.longitude);
+    assert.equal(data.geoPointValue.latitude, 50.1430847);
+    assert.equal(data.geoPointValue.longitude, -122.947778);
+    assert.equal(
+      data.geoPointValue.toString(),
+      'GeoPoint { latitude: 50.1430847, longitude: -122.947778 }'
+    );
   }
 
   beforeEach(function() {


### PR DESCRIPTION
Before console.log('' + geoPoint) would print: GeoPoint { _latitude: 11, _longitude: 12 }
Now it prints: GeoPoint { latitude: 11, longitude: 12 }

