### PR TITLE
Adding more test cases for conflicting fields

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -122,6 +122,16 @@ class GeoPoint {
   }
 
   /**
+   * Returns a string representation for this GeoPoint.
+   *
+   * @return {string} The string representation.
+   */
+  toString() {
+    return `GeoPoint { latitude: ${this.latitude}, longitude: ${this
+      .longitude} }`;
+  }
+
+  /**
    * Converts the GeoPoint to a google.type.LatLng proto.
    * @private
    */

--- a/src/document.js
+++ b/src/document.js
@@ -706,7 +706,7 @@ class DocumentSnapshot {
           // The existing object has deeper nesting that the value we are trying
           // to merge.
           throw new Error(
-            `Field "${path.join('.')}" has conflicting definitions.`
+            `Field "${new FieldPath(path)}" has conflicting definitions.`
           );
         } else {
           merge(target[key], value, path, pos + 1);
@@ -714,8 +714,9 @@ class DocumentSnapshot {
       } else {
         // We are trying to merge an object with a primitive.
         throw new Error(
-          `Field "${path.slice(0, pos + 1).join('.')}" has ` +
-            `conflicting definitions.`
+          `Field "${new FieldPath(
+            path.slice(0, pos + 1)
+          )}" has conflicting definitions.`
         );
       }
     }

--- a/test/document.js
+++ b/test/document.js
@@ -1334,6 +1334,18 @@ describe('update document', function() {
         'foo.bar.foo': 'foobar',
       });
     }, /Field "foo.bar.foo" has conflicting definitions\./);
+
+    assert.throws(() => {
+      firestore
+        .doc('collectionId/documentId')
+        .update('foo.bar', 'foobar', 'foo', 'foobar');
+    }, /Field "foo" has conflicting definitions\./);
+
+    assert.throws(() => {
+      firestore
+        .doc('collectionId/documentId')
+        .update('foo', 'foobar', 'foo.bar', 'foobar');
+    }, /Field "foo" has conflicting definitions\./);
   });
 
   it('with valid field paths', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -490,8 +490,12 @@ describe('snapshot_() method', function() {
 
     // We specifically test the GeoPoint properties to ensure 100% test
     // coverage.
-    assert.equal(50.1430847, data.geoPointValue.latitude);
-    assert.equal(-122.947778, data.geoPointValue.longitude);
+    assert.equal(data.geoPointValue.latitude, 50.1430847);
+    assert.equal(data.geoPointValue.longitude, -122.947778);
+    assert.equal(
+      data.geoPointValue.toString(),
+      'GeoPoint { latitude: 50.1430847, longitude: -122.947778 }'
+    );
   }
 
   beforeEach(function() {


### PR DESCRIPTION
This adds test cases to verify that updates for both "a.b" : foo, "a" : foo and "a": foo, "a.b": foo get rejected.

It allows uses the canonical string representation in the error message.