### PR TITLE
Reject conflict updates for nested maps

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -122,6 +122,16 @@ class GeoPoint {
   }
 
   /**
+   * Returns a string representation for this GeoPoint.
+   *
+   * @return {string} The string representation.
+   */
+  toString() {
+    return `GeoPoint { latitude: ${this.latitude}, longitude: ${this
+      .longitude} }`;
+  }
+
+  /**
    * Converts the GeoPoint to a google.type.LatLng proto.
    * @private
    */

--- a/src/document.js
+++ b/src/document.js
@@ -680,7 +680,7 @@ class DocumentSnapshot {
    * This functions turns { foo.bar : foobar } into { foo { bar : foobar }}
    *
    * @private
-   * @param {Map.<string|FieldPath, *>} data - The field/value map to expand.
+   * @param {Map.<FieldPath, *>} data - The field/value map to expand.
    * @returns {DocumentData} The expanded JavaScript object.
    */
   static expandMap(data) {
@@ -701,30 +701,17 @@ class DocumentSnapshot {
           target[key] = {};
           merge(target[key], value, path, pos + 1);
         }
-      } else if (isPlainObject(target[key])) {
-        if (isLast) {
-          // The existing object has deeper nesting that the value we are trying
-          // to merge.
-          throw new Error(
-            `Field "${new FieldPath(path)}" has conflicting definitions.`
-          );
-        } else {
-          merge(target[key], value, path, pos + 1);
-        }
       } else {
-        // We are trying to merge an object with a primitive.
-        throw new Error(
-          `Field "${new FieldPath(
-            path.slice(0, pos + 1)
-          )}" has conflicting definitions.`
-        );
+        validate.isPlainObject(typeof target[key], target[key]);
+        assert(!isLast, "Can't merge current value into a nested object");
+        merge(target[key], value, path, pos + 1);
       }
     }
 
     let res = {};
 
     data.forEach((value, key) => {
-      let components = FieldPath.fromArgument(key).toArray();
+      let components = key.toArray();
       merge(res, value, components, 0);
     });
 
@@ -1167,6 +1154,7 @@ module.exports = DocumentRefType => {
   DocumentReference = DocumentRefType;
   validate = require('./validate')({
     FieldPath: FieldPath.validateFieldPath,
+    PlainObject: isPlainObject,
   });
   return {
     DocumentMask,

--- a/src/document.js
+++ b/src/document.js
@@ -706,7 +706,7 @@ class DocumentSnapshot {
           // The existing object has deeper nesting that the value we are trying
           // to merge.
           throw new Error(
-            `Field "${path.join('.')}" has conflicting definitions.`
+            `Field "${new FieldPath(path)}" has conflicting definitions.`
           );
         } else {
           merge(target[key], value, path, pos + 1);
@@ -714,8 +714,9 @@ class DocumentSnapshot {
       } else {
         // We are trying to merge an object with a primitive.
         throw new Error(
-          `Field "${path.slice(0, pos + 1).join('.')}" has ` +
-            `conflicting definitions.`
+          `Field "${new FieldPath(
+            path.slice(0, pos + 1)
+          )}" has conflicting definitions.`
         );
       }
     }

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -370,6 +370,8 @@ class WriteBatch {
       }
     }
 
+    validate.isUpdateMap('dataOrField', updateMap);
+
     let documentMask = DocumentMask.fromMap(updateMap);
     let expandedObject = DocumentSnapshot.expandMap(updateMap);
     let document = new DocumentSnapshot(
@@ -523,6 +525,34 @@ class WriteBatch {
   }
 }
 
+/*!
+ * Validates that the update data does not contain any ambiguous field
+ * definitions (such as 'a.b' and 'a').
+ *
+ * @param {Map.<FieldPath, *>} data - An update map with field/value pairs.
+ * @returns {boolean} 'true' if the input is a valid update map.
+ */
+function validateUpdateMap(data) {
+  if (!is.instance(data, Map)) {
+    throw new Error('Input is not a map.');
+  }
+
+  const fields = [];
+  data.forEach((value, key) => {
+    fields.push(key);
+  });
+
+  fields.sort((left, right) => left.compareTo(right));
+
+  for (let i = 1; i < fields.length; ++i) {
+    if (fields[i - 1].isPrefixOf(fields[i])) {
+      throw new Error(`Field "${fields[i - 1]}" has conflicting definitions.`);
+    }
+  }
+
+  return true;
+}
+
 module.exports = (
   FirestoreType,
   DocumentReferenceType,
@@ -540,6 +570,7 @@ module.exports = (
     FieldPath: FieldPath.validateFieldPath,
     Precondition: document.validatePrecondition,
     SetOptions: document.validateSetOptions,
+    UpdateMap: validateUpdateMap,
   });
   return {
     WriteBatch,

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -533,10 +533,6 @@ class WriteBatch {
  * @returns {boolean} 'true' if the input is a valid update map.
  */
 function validateUpdateMap(data) {
-  if (!is.instance(data, Map)) {
-    throw new Error('Input is not a map.');
-  }
-
   const fields = [];
   data.forEach((value, key) => {
     fields.push(key);

--- a/test/document.js
+++ b/test/document.js
@@ -1305,47 +1305,53 @@ describe('update document', function() {
         foo: 'foobar',
         'foo.bar': 'foobar',
       });
-    }, /Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         foo: 'foobar',
         'foo.bar.foobar': 'foobar',
       });
-    }, /Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         'foo.bar': 'foobar',
         foo: 'foobar',
       });
-    }, /Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         'foo.bar': 'foobar',
         'foo.bar.foo': 'foobar',
       });
-    }, /Field "foo.bar" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" has conflicting definitions\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         'foo.bar': {foo: 'foobar'},
         'foo.bar.foo': 'foobar',
       });
-    }, /Field "foo.bar.foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" has conflicting definitions\./);
 
     assert.throws(() => {
       firestore
         .doc('collectionId/documentId')
         .update('foo.bar', 'foobar', 'foo', 'foobar');
-    }, /Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
 
     assert.throws(() => {
       firestore
         .doc('collectionId/documentId')
-        .update('foo', 'foobar', 'foo.bar', 'foobar');
-    }, /Field "foo" has conflicting definitions\./);
+        .update('foo', {foobar: 'foobar'}, 'foo.bar', {foobar: 'foobar'});
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
+
+    assert.throws(() => {
+      firestore
+        .doc('collectionId/documentId')
+        .update('foo', {foobar: 'foobar'}, 'foo.bar', {foobar: 'foobar'});
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
   });
 
   it('with valid field paths', function() {

--- a/test/document.js
+++ b/test/document.js
@@ -1334,6 +1334,18 @@ describe('update document', function() {
         'foo.bar.foo': 'foobar',
       });
     }, /Field "foo.bar.foo" has conflicting definitions\./);
+
+    assert.throws(() => {
+      firestore
+        .doc('collectionId/documentId')
+        .update('foo.bar', 'foobar', 'foo', 'foobar');
+    }, /Field "foo" has conflicting definitions\./);
+
+    assert.throws(() => {
+      firestore
+        .doc('collectionId/documentId')
+        .update('foo', 'foobar', 'foo.bar', 'foobar');
+    }, /Field "foo" has conflicting definitions\./);
   });
 
   it('with valid field paths', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -490,8 +490,12 @@ describe('snapshot_() method', function() {
 
     // We specifically test the GeoPoint properties to ensure 100% test
     // coverage.
-    assert.equal(50.1430847, data.geoPointValue.latitude);
-    assert.equal(-122.947778, data.geoPointValue.longitude);
+    assert.equal(data.geoPointValue.latitude, 50.1430847);
+    assert.equal(data.geoPointValue.longitude, -122.947778);
+    assert.equal(
+      data.geoPointValue.toString(),
+      'GeoPoint { latitude: 50.1430847, longitude: -122.947778 }'
+    );
   }
 
   beforeEach(function() {


### PR DESCRIPTION
This adds validation to reject updates for update("foo", {}, "foo.bar", {}).