### PR TITLE
Reject nested values as query boundary

### DIFF
--- a/src/reference.js
+++ b/src/reference.js
@@ -1248,7 +1248,10 @@ class Query {
 
       if (this._fieldOrders[i].field === FieldPath._DOCUMENT_ID) {
         if (is.string(fieldValue)) {
-          fieldValue = this._referencePath.append(fieldValues[i]);
+          fieldValue = new DocumentReference(
+            this._firestore,
+            this._referencePath.append(fieldValues[i])
+          );
         } else if (is.instance(fieldValue, DocumentReference)) {
           if (!this._referencePath.isPrefixOf(fieldValue.ref)) {
             throw new Error(
@@ -1260,6 +1263,13 @@ class Query {
           throw new Error(
             'The corresponding value for FieldPath.documentId() must be a ' +
               'string or a DocumentReference.'
+          );
+        }
+
+        if (fieldValue.ref.parent().compareTo(this._referencePath) !== 0) {
+          throw new Error(
+            'Only a direct child can be used as a query boundary. ' +
+              `Found: '${fieldValue.path}'.`
           );
         }
       }

--- a/test/query.js
+++ b/test/query.js
@@ -958,6 +958,11 @@ describe('startAt() interface', function() {
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc/coll/doc/coll/doc'));
     }, new RegExp("Only a direct child can be used as a query boundary. Found: 'coll/doc/coll/doc/coll/doc'."));
+
+    // Validate that we can't pass a reference to a collection.
+    assert.throws(() => {
+      query.orderBy(Firestore.FieldPath.documentId()).startAt('doc/coll');
+    }, new RegExp("Only a direct child can be used as a query boundary. Found: 'coll/doc/coll/doc/coll'."));
   });
 
   it('requires order by', function() {

--- a/test/query.js
+++ b/test/query.js
@@ -933,25 +933,31 @@ describe('startAt() interface', function() {
 
     assert.throws(() => {
       query.orderBy(Firestore.FieldPath.documentId()).startAt(42);
-    }, new RegExp('The corresponding value for FieldPath.documentId\\(\\) ' + 'must be a string or a DocumentReference\\.'));
+    }, new RegExp('The corresponding value for FieldPath.documentId\\(\\) must be a string or a DocumentReference\\.'));
 
     assert.throws(() => {
       query
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc/other/doc'));
-    }, new RegExp("'coll/doc/other/doc' is not part of the query result " + 'set and cannot be used as a query boundary.'));
+    }, new RegExp("'coll/doc/other/doc' is not part of the query result set and cannot be used as a query boundary."));
 
     assert.throws(() => {
       query
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc/coll_suffix/doc'));
-    }, new RegExp("'coll/doc/coll_suffix/doc' is not part of the query " + 'result set and cannot be used as a query boundary.'));
+    }, new RegExp("'coll/doc/coll_suffix/doc' is not part of the query result set and cannot be used as a query boundary."));
 
     assert.throws(() => {
       query
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc'));
-    }, new RegExp("'coll/doc' is not part of the query result set " + 'and cannot be used as a query boundary.'));
+    }, new RegExp("'coll/doc' is not part of the query result set and cannot be used as a query boundary."));
+
+    assert.throws(() => {
+      query
+        .orderBy(Firestore.FieldPath.documentId())
+        .startAt(firestore.doc('coll/doc/coll/doc/coll/doc'));
+    }, new RegExp("Only a direct child can be used as a query boundary. Found: 'coll/doc/coll/doc/coll/doc'."));
   });
 
   it('requires order by', function() {


### PR DESCRIPTION
This adds validation that a query can only start or end at a document that is a direct child of the query's collection.