### PR TITLE
Adding getCollections() to Typescript typings.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -516,8 +516,8 @@ class Firestore extends commonGrpc.Service {
    * Fetches the root collections that are associated with this Firestore
    * database.
    *
-   * @returns {Promise.<Array.<CollectionReference>>} A Promise that
-   * contains an array with CollectionReferences.
+   * @returns {Promise.<Array.<CollectionReference>>} A Promise that resolves
+   * with an array of CollectionReferences.
    *
    * @example
    * firestore.getCollections().then(collections => {

--- a/src/reference.js
+++ b/src/reference.js
@@ -293,7 +293,7 @@ class DocumentReference {
   /**
    * Fetches the subcollections that are direct children of this document.
    *
-   * @returns {Promise.<Array.<CollectionReference>>}  A Promise that resolves
+   * @returns {Promise.<Array.<CollectionReference>>} A Promise that resolves
    * with an array of CollectionReferences.
    *
    * @example

--- a/src/reference.js
+++ b/src/reference.js
@@ -293,8 +293,8 @@ class DocumentReference {
   /**
    * Fetches the subcollections that are direct children of this document.
    *
-   * @returns {Promise.<Array.<CollectionReference>>} A Promise that
-   * contains an array with CollectionReferences.
+   * @returns {Promise.<Array.<CollectionReference>>}  A Promise that resolves
+   * with an array of CollectionReferences.
    *
    * @example
    * let documentRef = firestore.doc('col/doc');

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -49,6 +49,8 @@ xdescribe('firestore.d.ts', function() {
     firestore.getAll(docRef1, docRef2).then(
         (docs: DocumentSnapshot[]) => {
         });
+    firestore.getCollections().then((collections:CollectionReference[]) => {
+    });
     const transactionResult: Promise<string> = firestore.runTransaction(
         (updateFunction: Transaction) => {
           return Promise.resolve("string")
@@ -119,6 +121,8 @@ xdescribe('firestore.d.ts', function() {
     const parent: CollectionReference = docRef.parent;
     const path: string = docRef.path;
     const subcollection: CollectionReference = docRef.collection('coll');
+    docRef.getCollections().then((collections:CollectionReference[]) => {
+    });
     docRef.get().then((snapshot: DocumentSnapshot) => {
     });
     docRef.create(documentData).then(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "noStrictGenericChecks": true
   },
   "include": [
-    "src/**/*.js",
     "src/**/*.ts",
     "test/typescript.ts",
     "types/firestore.d.ts"

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -78,6 +78,14 @@ declare namespace FirebaseFirestore {
     getAll(...documentRef: DocumentReference[]): Promise<DocumentSnapshot[]>;
 
     /**
+     * Fetches the root collections that are associated with this Firestore
+     * database.
+     *
+     * @returns A Promise that resolves with an array of CollectionReferences.
+     */
+    getCollections() : Promise<CollectionReference[]>;
+
+    /**
      * Executes the given updateFunction and commits the changes applied within
      * the transaction.
      *
@@ -399,6 +407,13 @@ declare namespace FirebaseFirestore {
      * @return The `CollectionReference` instance.
      */
     collection(collectionPath: string): CollectionReference;
+
+    /**
+     * Fetches the subcollections that are direct children of this document.
+     *
+     * @returns A Promise that resolves with an array of CollectionReferences.
+     */
+    getCollections() : Promise<CollectionReference[]>;
 
     /**
      * Creates a document referred to by this `DocumentReference` with the


### PR DESCRIPTION
This also makes 'ntsc -p .' work with test/typescript.d.ts by removing the source dependency on *.js (as it duplicates the namespace)

Fixes: https://github.com/googleapis/nodejs-firestore/issues/52