### PR TITLE
Bumping release version to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
     "test": "repo-tools test run --cmd npm -- run ava"
   },
   "dependencies": {
-    "@google-cloud/firestore": "0.8.2"
+    "@google-cloud/firestore": "0.10.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "2.1.0",


### PR DESCRIPTION
This release includes:

- https://github.com/googleapis/nodejs-firestore/pull/57  (breaking due to new validation)
- https://github.com/googleapis/nodejs-firestore/pull/60
- https://github.com/googleapis/nodejs-firestore/pull/62
- https://github.com/googleapis/nodejs-firestore/pull/65
- https://github.com/googleapis/nodejs-firestore/pull/69 (breaking due to new validation)
- https://github.com/googleapis/nodejs-firestore/pull/70