### PR TITLE
Pegging GRPC version to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "extend": "^3.0.1",
     "functional-red-black-tree": "^1.0.1",
     "google-gax": "^0.14.1",
-    "grpc": "^1.6.0",
+    "grpc": "1.7.1",
     "is": "^3.2.0",
     "safe-buffer": "^5.1.1",
     "through2": "^2.0.3"


### PR DESCRIPTION
GRPC 1.8.0 seems to cause 'Stream Removed' Errors on Firebase Functions: https://github.com/grpc/grpc-node/issues/130