### PR TITLE
Allow Protobuf arrays with unset values

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -179,8 +179,10 @@ function convertValue(fieldValue) {
       };
     case 'arrayValue': {
       let arrayValue = [];
-      for (let value of fieldValue.arrayValue.values) {
-        arrayValue.push(convertValue(value));
+      if (is.array(fieldValue.arrayValue.values)) {
+        for (let value of fieldValue.arrayValue.values) {
+          arrayValue.push(convertValue(value));
+        }
       }
       return {
         valueType: 'arrayValue',

--- a/src/document.js
+++ b/src/document.js
@@ -537,8 +537,10 @@ class DocumentSnapshot {
       }
       case 'arrayValue': {
         let array = [];
-        for (let i = 0; i < proto.arrayValue.values.length; ++i) {
-          array.push(this._decodeValue(proto.arrayValue.values[i]));
+        if (is.array(proto.arrayValue.values)) {
+          for (let value of proto.arrayValue.values) {
+            array.push(this._decodeValue(value));
+          }
         }
         return array;
       }

--- a/test/index.js
+++ b/test/index.js
@@ -322,6 +322,10 @@ describe('snapshot_() method', function() {
         ],
       },
     },
+    emptyArray: {
+      valueType: 'arrayValue',
+      arrayValue: {},
+    },
     dateValue: {
       valueType: 'timestampValue',
       timestampValue: {
@@ -364,6 +368,10 @@ describe('snapshot_() method', function() {
         },
       },
     },
+    emptyObject: {
+      valueType: 'mapValue',
+      mapValue: {},
+    },
     pathValue: {
       valueType: 'referenceValue',
       referenceValue: `${DATABASE_ROOT}/documents/collection/document`,
@@ -405,6 +413,9 @@ describe('snapshot_() method', function() {
         ],
       },
     },
+    emptyArray: {
+      arrayValue: {},
+    },
     dateValue: {
       timestampValue: '1985-03-18T07:20:00.123000000Z',
     },
@@ -435,6 +446,9 @@ describe('snapshot_() method', function() {
         },
       },
     },
+    emptyObject: {
+      mapValue: {},
+    },
     pathValue: {
       referenceValue: `${DATABASE_ROOT}/documents/collection/document`,
     },
@@ -464,12 +478,14 @@ describe('snapshot_() method', function() {
     infinityValue: Infinity,
     negativeInfinityValue: -Infinity,
     objectValue: {foo: 'bar'},
+    emptyObject: {},
     dateValue: new Date('Mar 18, 1985 08:20:00.123 GMT+0100 (CET)'),
     pathValue: new DocumentReference(
       {formattedName: DATABASE_ROOT},
       new ResourcePath('test-project', '(default)', 'collection', 'document')
     ),
     arrayValue: ['foo', 42, 'bar'],
+    emptyArray: [],
     nilValue: null,
     geoPointValue: new Firestore.GeoPoint(50.1430847, -122.947778),
     bytesValue: Buffer.from([0x1, 0x2]),


### PR DESCRIPTION
It looks like Firebase Functions sometimes send us an Array protobuf that is missing the `values` field altogether, which results in an undefined iterator error.

Fixes https://github.com/googleapis/nodejs-firestore/issues/103
