### PR TITLE
Using Transaction Result from last retry

### DIFF
--- a/test/transaction.js
+++ b/test/transaction.js
@@ -341,16 +341,17 @@ describe('failed transactions', function() {
   });
 
   it('retries on commit failure', function() {
-    let err = new Error('Retryable error');
+    let userResult = ['failure', 'failure', 'success'];
+    let serverError = new Error('Retryable error');
 
     return runTransaction(
       () => {
-        return Promise.resolve('success');
+        return Promise.resolve(userResult.shift());
       },
       begin('foo1'),
-      commit('foo1', [], err),
+      commit('foo1', [], serverError),
       begin('foo2', 'foo1'),
-      commit('foo2', [], err),
+      commit('foo2', [], serverError),
       begin('foo3', 'foo2'),
       commit('foo3')
     ).then(red => {


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-firestore/issues/110

Note that while the diff is pretty big, the change is pretty small: It  moves the final `.then()` callback to transaction.commit(), rather than overwriting the result of the entire runTransaction() function. This allows us to return the result from a recursive execution.