### PR TITLE
[DO NOT MERGE] fix: pin google-gax to 0.14.3, bump patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
@@ -55,7 +55,7 @@
     "bun": "^0.0.12",
     "extend": "^3.0.1",
     "functional-red-black-tree": "^1.0.1",
-    "google-gax": "^0.14.3",
+    "google-gax": "0.14.3",
     "is": "^3.2.1",
     "safe-buffer": "^5.1.1",
     "through2": "^2.0.3"

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
     "test": "repo-tools test run --cmd npm -- run ava"
   },
   "dependencies": {
-    "@google-cloud/firestore": "0.11.2"
+    "@google-cloud/firestore": "0.11.3"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "2.1.0",


### PR DESCRIPTION
An issue was reported with google-gax v0.14.4 (that upgraded GRPC dependency). Pinning the version to 0.14.3 for now to mitigate.