### PR TITLE
Exporting all API types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1107,17 +1107,18 @@ Firestore.setLogFunction = function(logger) {
 };
 
 // Initializing dependencies that require that Firestore class type.
-let reference = require('./reference')(Firestore);
+const reference = require('./reference')(Firestore);
 CollectionReference = reference.CollectionReference;
 DocumentReference = reference.DocumentReference;
-let document = require('./document')(DocumentReference);
+const document = require('./document')(DocumentReference);
 DocumentSnapshot = document.DocumentSnapshot;
 GeoPoint = document.GeoPoint;
 validate = require('./validate')({
   DocumentReference: reference.validateDocumentReference,
   ResourcePath: ResourcePath.validateResourcePath,
 });
-WriteBatch = require('./write-batch')(Firestore, DocumentReference).WriteBatch;
+const batch = require('./write-batch')(Firestore, DocumentReference);
+WriteBatch = batch.WriteBatch;
 Transaction = require('./transaction')(Firestore);
 
 /**
@@ -1163,24 +1164,6 @@ module.exports.Firestore = Firestore;
 module.exports.v1beta1 = v1beta1;
 
 /**
- * {@link FieldPath} class.
- *
- * @name Firestore.FieldPath
- * @see FieldPath
- * @type {Constructor}
- */
-module.exports.FieldPath = FieldPath;
-
-/**
- * {@link FieldValue} class.
- *
- * @name Firestore.FieldValue
- * @see FieldValue
- * @type {Constructor}
- */
-module.exports.FieldValue = FieldValue;
-
-/**
  * {@link GeoPoint} class.
  *
  * @name Firestore.GeoPoint
@@ -1188,3 +1171,129 @@ module.exports.FieldValue = FieldValue;
  * @type {Constructor}
  */
 module.exports.GeoPoint = GeoPoint;
+
+/**
+ * {@link Transaction} class.
+ *
+ * @name Firestore.Transaction
+ * @see Transaction
+ * @type Transaction
+ */
+module.exports.Transaction = Transaction;
+
+/**
+ * {@link WriteBatch} class.
+ *
+ * @name Firestore.WriteBatch
+ * @see WriteBatch
+ * @type WriteBatch
+ */
+module.exports.WriteBatch = WriteBatch;
+
+/**
+ * {@link DocumentReference} class.
+ *
+ * @name Firestore.DocumentReference
+ * @see DocumentReference
+ * @type DocumentReference
+ */
+module.exports.DocumentReference = DocumentReference;
+
+/**
+ * {@link WriteResult} class.
+ *
+ * @name Firestore.WriteResult
+ * @see WriteResult
+ * @type WriteResult
+ */
+module.exports.WriteResult = batch.WriteResult;
+
+/**
+ * {@link DocumentSnapshot} DocumentSnapshot.
+ *
+ * @name Firestore.DocumentSnapshot
+ * @see DocumentSnapshot
+ * @type DocumentSnapshot
+ */
+module.exports.DocumentSnapshot = DocumentSnapshot;
+
+/**
+ * {@link QueryDocumentSnapshot} class.
+ *
+ * @name Firestore.QueryDocumentSnapshot
+ * @see QueryDocumentSnapshot
+ * @type QueryDocumentSnapshot
+ */
+module.exports.QueryDocumentSnapshot = document.QueryDocumentSnapshot;
+
+/**
+ * {@link Query} class.
+ *
+ * @name Firestore.Query
+ * @see Query
+ * @type Query
+ */
+module.exports.Query = document.Query;
+
+/**
+ * {@link CollectionReference} class.
+ *
+ * @name Firestore.CollectionReference
+ * @see CollectionReference
+ * @type CollectionReference
+ */
+module.exports.CollectionReference = CollectionReference;
+
+/**
+ * {@link QuerySnapshot} class.
+ *
+ * @name Firestore.QuerySnapshot
+ * @see QuerySnapshot
+ * @type QuerySnapshot
+ */
+module.exports.QuerySnapshot = reference.QuerySnapshot;
+
+/**
+ * {@link DocumentChange} class.
+ *
+ * @name Firestore.DocumentChange
+ * @see DocumentChange
+ * @type DocumentChange
+ */
+module.exports.DocumentChange = document.DocumentChange;
+
+/**
+ * {@link Query} class.
+ *
+ * @name Firestore.Query
+ * @see Query
+ * @type Query
+ */
+module.exports.Query = reference.Query;
+
+/**
+ * {@link CollectionReference} class.
+ *
+ * @name Firestore.CollectionReference
+ * @see CollectionReference
+ * @type CollectionReference
+ */
+module.exports.Query = CollectionReference;
+
+/**
+ * {@link FieldValue} class.
+ *
+ * @name Firestore.FieldValue
+ * @see FieldValue
+ * @type FieldValue
+ */
+module.exports.FieldValue = FieldValue;
+
+/**
+ * {@link FieldPath} class.
+ *
+ * @name Firestore.FieldPath
+ * @see FieldPath
+ * @type {Constructor}
+ */
+module.exports.FieldPath = FieldPath;

--- a/src/reference.js
+++ b/src/reference.js
@@ -2118,6 +2118,7 @@ module.exports = FirestoreType => {
   });
   return {
     CollectionReference,
+    DocumentChange,
     DocumentReference,
     Query,
     QuerySnapshot,

--- a/test/index.js
+++ b/test/index.js
@@ -296,6 +296,23 @@ describe('instantiation', function() {
 
     assert.equal(calledWith.service, 'firestore');
   });
+
+  it('exports all types', function() {
+    // Ordering as per firestore.d.ts
+    assert.ok(is.defined(Firestore.Firestore));
+    assert.ok(is.defined(Firestore.GeoPoint));
+    assert.ok(is.defined(Firestore.Transaction));
+    assert.ok(is.defined(Firestore.WriteBatch));
+    assert.ok(is.defined(Firestore.DocumentReference));
+    assert.ok(is.defined(Firestore.WriteResult));
+    assert.ok(is.defined(Firestore.DocumentSnapshot));
+    assert.ok(is.defined(Firestore.QueryDocumentSnapshot));
+    assert.ok(is.defined(Firestore.Query));
+    assert.ok(is.defined(Firestore.QuerySnapshot));
+    assert.ok(is.defined(Firestore.CollectionReference));
+    assert.ok(is.defined(Firestore.FieldValue));
+    assert.ok(is.defined(Firestore.FieldPath));
+  });
 });
 
 describe('snapshot_() method', function() {


### PR DESCRIPTION
This PR exports all public types to allow end user to use them in their code directly, e.g. for instanceof checks.

b/72759064
https://stackoverflow.com/questions/48552183/how-to-get-firestore-documentreference-class
