### PR TITLE
Adding Transactions.getAll()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -566,28 +566,25 @@ class Firestore extends commonGrpc.Service {
    * @private
    * @param {Array.<DocumentReference>} docRefs - The documents
    * to receive.
-   * @param {object=} readOptions - The options to use for this request.
-   * @param {bytes|null} readOptions.transactionId - The transaction ID to use
+   * @param {bytes=} transactionId - transactionId - The transaction ID to use
    * for this read.
-   * @returns {Array.<DocumentSnapshot>} A Promise that contains an array with
+   * @returns {Promise<Array.<DocumentSnapshot>>} A Promise that contains an array with
    * the resulting documents.
    */
-  getAll_(docRefs, readOptions) {
+  getAll_(docRefs, transactionId) {
     const requestedDocuments = new Set();
     const retrievedDocuments = new Map();
 
     let request = {
       database: this.formattedName,
+      transaction: transactionId
     };
 
     for (let docRef of docRefs) {
       requestedDocuments.add(docRef.formattedName);
     }
-    request.documents = Array.from(requestedDocuments);
 
-    if (readOptions && readOptions.transactionId) {
-      request.transaction = readOptions.transactionId;
-    }
+    request.documents = Array.from(requestedDocuments);
 
     let self = this;
 

--- a/src/index.js
+++ b/src/index.js
@@ -577,7 +577,7 @@ class Firestore extends commonGrpc.Service {
 
     let request = {
       database: this.formattedName,
-      transaction: transactionId
+      transaction: transactionId,
     };
 
     for (let docRef of docRefs) {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -18,7 +18,8 @@
 
 const is = require('is');
 
-const validate = require('./validate')();
+/*! Injected. */
+let validate;
 
 /*!
  * Injected.
@@ -90,7 +91,7 @@ class Transaction {
 
     if (is.instance(refOrQuery, DocumentReference)) {
       return this._firestore
-        .getAll_([refOrQuery], {transactionId: this._transactionId})
+        .getAll_([refOrQuery], this._transactionId)
         .then(res => {
           return Promise.resolve(res[0]);
         });
@@ -101,6 +102,40 @@ class Transaction {
     }
 
     throw new Error('Argument "refOrQuery" must be a DocumentRef or a Query.');
+  }
+
+  /**
+   * Retrieves multiple documents from Firestore. Holds a pessimistic lock on
+   * all returned documents.
+   *
+   * @param {...DocumentReference} documents - The document references
+   * to receive.
+   * @returns {Promise<Array.<DocumentSnapshot>>} A Promise that
+   * contains an array with the resulting document snapshots.
+   *
+   * @example
+   * let firstDoc = firestore.doc('col/doc1');
+   * let secondDoc = firestore.doc('col/doc2');
+   * let resultDoc = firestore.doc('col/doc2');
+   *
+   * firestore.runTransaction(transaction => {
+   *   return transaction.getAll(firstDoc, secondDoc).then(docs => {
+   *     transaction.set(resultDoc, {
+   *       sum: docs[1].get('count') + docs[2].get('count')
+   *     });
+   *   });
+   * });
+   */
+  getAll(documents) {
+    documents = is.array(arguments[0])
+      ? arguments[0].slice()
+      : Array.prototype.slice.call(arguments);
+
+    for (let i = 0; i < documents.length; ++i) {
+      validate.isDocumentReference(i, documents[i]);
+    }
+
+    return this._firestore.getAll_(documents, this._transactionId );
   }
 
   /**
@@ -297,11 +332,8 @@ module.exports = FirestoreType => {
   let reference = require('./reference')(FirestoreType);
   DocumentReference = reference.DocumentReference;
   Query = reference.Query;
-  let document = require('./document')(DocumentReference);
-  require('./validate')({
-    Document: document.validateDocumentData,
+  validate = require('./validate')({
     DocumentReference: reference.validateDocumentReference,
-    Precondition: document.validatePrecondition,
   });
   return Transaction;
 };

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -35,6 +35,13 @@ let DocumentReference;
  */
 let Query;
 
+/*!
+ * Error message for transactional reads that were executed after performing
+ * writes.
+ */
+const WRITE_AFTER_READ_ERR_MSG =
+  'Firestore transactions require all reads to be executed before all writes.';
+
 /**
  * A reference to a transaction.
  *
@@ -83,10 +90,7 @@ class Transaction {
    */
   get(refOrQuery) {
     if (!this._writeBatch.isEmpty) {
-      throw new Error(
-        'Firestore transactions require all reads to be ' +
-          'executed before all writes.'
-      );
+      throw new Error(WRITE_AFTER_READ_ERR_MSG);
     }
 
     if (is.instance(refOrQuery, DocumentReference)) {
@@ -127,6 +131,10 @@ class Transaction {
    * });
    */
   getAll(documents) {
+    if (!this._writeBatch.isEmpty) {
+      throw new Error(WRITE_AFTER_READ_ERR_MSG);
+    }
+
     documents = is.array(arguments[0])
       ? arguments[0].slice()
       : Array.prototype.slice.call(arguments);

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -135,7 +135,7 @@ class Transaction {
       validate.isDocumentReference(i, documents[i]);
     }
 
-    return this._firestore.getAll_(documents, this._transactionId );
+    return this._firestore.getAll_(documents, this._transactionId);
   }
 
   /**

--- a/system-test/firestore.js
+++ b/system-test/firestore.js
@@ -1302,6 +1302,22 @@ describe('Transaction class', function() {
       });
   });
 
+  it('has getAll() method', function() {
+    let ref1 = randomCol.doc('doc1');
+    let ref2 = randomCol.doc('doc2');
+    return Promise.all([ref1.set({}), ref2.set({})])
+      .then(() => {
+        return firestore.runTransaction(updateFunction => {
+          return updateFunction.getAll(ref1, ref2).then(docs => {
+            return Promise.resolve(docs.length);
+          });
+        });
+      })
+      .then(res => {
+        assert.equal(2, res);
+      });
+  });
+
   it('has get() with query', function() {
     let ref = randomCol.doc('doc');
     let query = randomCol.where('foo', '==', 'bar');

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -539,6 +539,23 @@ describe('transaction operations', function() {
     );
   });
 
+  it('enforce that getAll come before writes', function() {
+    return runTransaction(transaction => {
+      transaction.set(docRef, {foo: 'bar'});
+      return transaction.getAll(docRef);
+    }, begin())
+      .then(() => {
+        throw new Error('Unexpected success in Promise');
+      })
+      .catch(err => {
+        assert.equal(
+          err.message,
+          'Firestore transactions require all reads to ' +
+            'be executed before all writes.'
+        );
+      });
+  });
+
   it('support create', function() {
     let create = {
       currentDocument: {

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -67,9 +67,11 @@ xdescribe('firestore.d.ts', function() {
 
   it('has typings for Transaction', () => {
     return firestore.runTransaction((transaction: Transaction) => {
+      transaction.get(collRef).then((snapshot: QuerySnapshot) => {
+      });
       transaction.get(docRef).then((doc: DocumentSnapshot) => {
       });
-      transaction.get(collRef).then((snapshot: QuerySnapshot) => {
+      transaction.getAll(docRef, docRef).then((docs: DocumentSnapshot[]) => {
       });
       transaction = transaction.create(docRef, documentData);
       transaction = transaction.set(docRef, documentData);

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -141,6 +141,16 @@ declare namespace FirebaseFirestore {
   export class Transaction {
     private constructor();
 
+
+    /**
+     * Retrieves a query result. Holds a pessimistic lock on all returned
+     * documents.
+     *
+     * @param query A query to execute.
+     * @return A QuerySnapshot for the retrieved data.
+     */
+    get(query: Query): Promise<QuerySnapshot>;
+
     /**
      * Reads the document referenced by the provided `DocumentReference.`
      * Holds a pessimistic lock on the returned document.
@@ -151,13 +161,14 @@ declare namespace FirebaseFirestore {
     get(documentRef: DocumentReference): Promise<DocumentSnapshot>;
 
     /**
-     * Retrieves a query result. Holds a pessimistic lock on the returned
-     * documents.
+     * Retrieves multiple documents from Firestore. Holds a pessimistic lock on
+     * all returned documents.
      *
-     * @param query A query to execute.
-     * @return A QuerySnapshot for the retrieved data.
+     * @param documentRef The `DocumentReferences` to receive.
+     * @return A Promise that resolves with an array of resulting document
+     * snapshots.
      */
-    get(query: Query): Promise<QuerySnapshot>;
+    getAll(...documentRef: DocumentReference[]): Promise<DocumentSnapshot[]>;
 
     /**
      * Create the document referred to by the provided `DocumentReference`.


### PR DESCRIPTION
This adds support for a Transactions.getAll() call that lets users receive multiple documents in a Transaction, similar to what we already support with Firestore.getAll().