### PR TITLE
RFC: Improving SDK interoperability

### DIFF
--- a/src/field-value.js
+++ b/src/field-value.js
@@ -20,13 +20,13 @@
  * Sentinel value for a field delete.
  *
  */
-const DELETE_SENTINEL = {};
+let DELETE_SENTINEL;
 
 /*!
  * Sentinel value for a server timestamp.
  *
  */
-const SERVER_TIMESTAMP_SENTINEL = {};
+let SERVER_TIMESTAMP_SENTINEL;
 
 /**
  * Sentinel values that can be used when writing documents with set() or
@@ -35,6 +35,7 @@ const SERVER_TIMESTAMP_SENTINEL = {};
  * @class
  */
 class FieldValue {
+  constructor() {}
   /**
    * Returns a sentinel used with update() to mark a field for deletion.
    *
@@ -75,6 +76,18 @@ class FieldValue {
     return SERVER_TIMESTAMP_SENTINEL;
   }
 }
+
+/*!
+ * Sentinel value for a field delete.
+ *
+ */
+ DELETE_SENTINEL = new FieldValue();
+
+/*!
+ * Sentinel value for a server timestamp.
+ *
+ */
+ SERVER_TIMESTAMP_SENTINEL = new FieldValue();
 
 module.exports = FieldValue;
 module.exports.DELETE_SENTINEL = DELETE_SENTINEL;

--- a/src/index.js
+++ b/src/index.js
@@ -1147,6 +1147,31 @@ Transaction = require('./transaction')(Firestore);
  * region_tag:firestore_quickstart
  * Full quickstart example:
  */
+
+const version = require('../package.json').version;
+
+if (!is.defined(global.__FIRESTORE_DATA)) {
+  global.__FIRESTORE_DATA = {
+    version: version,
+    path: __dirname,
+  };
+} else if (is.defined(global.__FIRESTORE_DATA)) {
+  if (global.__FIRESTORE_DATA.version !== version) {
+    console.warn(
+      `Importing multiple versions @google-cloud/firestore can cause unexpected ` +
+        `behavior. If you are using Firestore through a transitive ` +
+        `dependency (such as the Firebase Admin SDK), please ensure that your ` +
+        `dependency versions match (found ${
+          global.__FIRESTORE_DATA.version
+        } and ` +
+        `${version}). For more information, see http://goo.gl/...`
+    );
+  } else if (__dirname !== global.__FIRESTORE_DATA.path) {
+    module.exports = require(global.__FIRESTORE_DATA.path);
+    return;
+  }
+}
+
 module.exports = Firestore;
 module.exports.default = Firestore;
 module.exports.Firestore = Firestore;

--- a/src/path.js
+++ b/src/path.js
@@ -483,6 +483,8 @@ class FieldPath extends Path {
    */
   static validateFieldPath(fieldPath) {
     if (!is.instanceof(fieldPath, FieldPath)) {
+      validate.throwVersionMismatchErrorIfType(fieldPath, FieldPath);
+
       if (!is.string(fieldPath)) {
         throw new Error(`Paths must be strings or FieldPath objects.`);
       }

--- a/src/reference.js
+++ b/src/reference.js
@@ -2089,7 +2089,11 @@ function validateComparisonOperator(str, val) {
  * @returns 'true' is value is an instance of DocumentReference.
  */
 function validateDocumentReference(value) {
-  return is.instanceof(value, DocumentReference);
+  if (is.instanceof(value, DocumentReference)) {
+    return true;
+  }
+  validate.verifyConstructorName(value, DocumentReference);
+  return false;
 }
 
 module.exports = FirestoreType => {

--- a/src/validate.js
+++ b/src/validate.js
@@ -140,5 +140,15 @@ module.exports = validators => {
     return true;
   };
 
+  exports.throwVersionMismatchErrorIfType = (obj, classType) => {
+    if (is.object(obj) && obj.constructor.name === classType.name) {
+      throw new Error(
+        `Detected an object of type '${
+          obj.constructor.name
+        }' that doesn't match the expected version for this Firestore instance. For more information, please visit: http://go...`
+      );
+    }
+  };
+
   return exports;
 };


### PR DESCRIPTION
This aims to address a common user error in GCF:  It is easy to read from Firestore using the Firestore triggers (via the Admin SDK), and straightforward to write to Firestore using the GCloud Firestore SDK.  Unfortunately, lots of stuff breaks in subtle ways when users mix and match SDK versions.  The real solution to this problem is of course to not use the GCloud Firestore SDK directly, but instead import it from the Admin SDK (as pointed out in our docs).

This PR aims to help to get the non-doc readers help on the right track.

As an example, the offending code can be as concise as follows:

```
const admin = require('firebase-admin');
const firestore = require('@google-cloud/firestore');

admin.initializeApp({
  credential: admin.credential.cert()...),
});

const ref = admin.firestore().doc('foo/bar');
return ref
  .set({time: firestore.FieldValue.serverTimestamp()}) <-- Wrong type
  .then(() => ref.get())
  .then(snap => console.log(snap.get('time')));
```

In the current version of the SDK, this prints... you guessed it... '{}'. firestore.FieldValue.serverTimestamp() is just seen as a plain old object (the sentinel value is {}) and the equals comparison fails.

With this PR, if users pull in the same version of the SDK via GCloud and Firebase Admin, everything just works. We simply pull the version of the SDK that was used first.

If they pull in two different versions, first we log a warning (on import):

```
Importing multiple versions @google-cloud/firestore can cause unexpected behavior. If you are using Firestore through a transitive dependency (such as the Firebase Admin SDK),   please ensure that your dependency versions match (found 0.10.0 and 0.11.2). For more information, see http://goo.gl/...
```

We then throw an error when they use the wrong type:

```
Error: Argument "data" is not a valid Document. Detected an object of type 'FieldValue' that doesn't match the expected version for this Firestore instance. For more information, please visit: http://go...
```

This PR is missing tests, comments, proper names, and more... but it would be nice to get some initial thoughts on the general idea behind it.
