### PR TITLE
Accept strings in where(FieldPath.documentId(), ...)

### DIFF
--- a/src/reference.js
+++ b/src/reference.js
@@ -1126,12 +1126,16 @@ class Query {
       );
     }
 
-    let newFilter = new FieldFilter(
-      FieldPath.fromArgument(fieldPath),
-      comparisonOperators[opStr],
-      value
+    fieldPath = FieldPath.fromArgument(fieldPath);
+
+    if (fieldPath === FieldPath._DOCUMENT_ID) {
+      value = this._convertReference(value);
+    }
+
+    let combinedFilters = this._fieldFilters.concat(
+      new FieldFilter(fieldPath, comparisonOperators[opStr], value)
     );
-    let combinedFilters = this._fieldFilters.concat(newFilter);
+
     return new Query(
       this._firestore,
       this._referencePath,
@@ -1395,31 +1399,7 @@ class Query {
       let fieldValue = fieldValues[i];
 
       if (fieldOrders[i].field === FieldPath._DOCUMENT_ID) {
-        if (is.string(fieldValue)) {
-          fieldValue = new DocumentReference(
-            this._firestore,
-            this._referencePath.append(fieldValue)
-          );
-        } else if (is.instance(fieldValue, DocumentReference)) {
-          if (!this._referencePath.isPrefixOf(fieldValue.ref)) {
-            throw new Error(
-              `'${fieldValue.path}' is not part of the query ` +
-                'result set and cannot be used as a query boundary.'
-            );
-          }
-        } else {
-          throw new Error(
-            'The corresponding value for FieldPath.documentId() must be a ' +
-              'string or a DocumentReference.'
-          );
-        }
-
-        if (fieldValue.ref.parent().compareTo(this._referencePath) !== 0) {
-          throw new Error(
-            'Only a direct child can be used as a query boundary. ' +
-              `Found: '${fieldValue.path}'.`
-          );
-        }
+        fieldValue = this._convertReference(fieldValue);
       }
 
       if (DocumentTransform.isTransformSentinel(fieldValue)) {
@@ -1433,6 +1413,47 @@ class Query {
     }
 
     return options;
+  }
+
+  /**
+   * Validates that a value used with FieldValue.documentId() is either a
+   * string or a DocumentReference that is part of the query`s result set.
+   * Throws a validation error or returns a DocumentReference that can
+   * directly be used in the Query.
+   *
+   * @param {*} reference - The value to validate.
+   * @throws If the value cannot be used for this query.
+   * @return {DocumentReference} If valid, returns a DocumentReference that
+   * can be used with the query.
+   * @private
+   */
+  _convertReference(reference) {
+    if (is.string(reference)) {
+      reference = new DocumentReference(
+        this._firestore,
+        this._referencePath.append(reference)
+      );
+    } else if (is.instance(reference, DocumentReference)) {
+      if (!this._referencePath.isPrefixOf(reference.ref)) {
+        throw new Error(
+          `'${reference.path}' is not part of the query result set and ` +
+            'cannot be used as a query boundary.'
+        );
+      }
+    } else {
+      throw new Error(
+        'The corresponding value for FieldPath.documentId() must be a ' +
+          'string or a DocumentReference.'
+      );
+    }
+
+    if (reference.ref.parent().compareTo(this._referencePath) !== 0) {
+      throw new Error(
+        'Only a direct child can be used as a query boundary. ' +
+          `Found: '${reference.path}'.`
+      );
+    }
+    return reference;
   }
 
   /**

--- a/system-test/firestore.js
+++ b/system-test/firestore.js
@@ -854,6 +854,21 @@ describe('Query class', function() {
       });
   });
 
+  it('can query by FieldPath.documentId()', function() {
+    let ref = randomCol.doc('foo');
+
+    return ref
+      .set({})
+      .then(() => {
+        return randomCol
+          .where(Firestore.FieldPath.documentId(), '>=', 'bar')
+          .get();
+      })
+      .then(res => {
+        assert.equal(res.docs.length, 1);
+      });
+  });
+
   it('has orderBy() method', function() {
     let ref1 = randomCol.doc('doc1');
     let ref2 = randomCol.doc('doc2');

--- a/test/query.js
+++ b/test/query.js
@@ -591,6 +591,25 @@ describe('where() interface', function() {
     return query.get();
   });
 
+  it('supports strings for FieldPath.documentId()', function() {
+    firestore.api.Firestore._runQuery = function(request) {
+      requestEquals(
+        request,
+        fieldFilters('__name__', 'EQUAL', {
+          valueType: 'referenceValue',
+          referenceValue:
+            'projects/test-project/databases/(default)/' +
+            'documents/collectionId/foo',
+        })
+      );
+      return stream();
+    };
+
+    let query = firestore.collection('collectionId');
+    query = query.where(Firestore.FieldPath.documentId(), '==', 'foo');
+    return query.get();
+  });
+
   it('supports unary filters', function() {
     firestore.api.Firestore._runQuery = function(request) {
       requestEquals(request, unaryFilters('foo', 'IS_NAN', 'bar', 'IS_NULL'));


### PR DESCRIPTION
We currently support Strings and DocumentReferences for query.orderBy(FieldPath.documentId()).startAt(...), but only DocumentReferences for the corresponding `where()` call.

Addresses: https://stackoverflow.com/questions/48788805/query-by-documentid-in-firebase-function