### PR TITLE
100% Test coverage and misc cleanup

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -1144,7 +1144,7 @@ class DocumentTransform {
           });
         } else {
           throw new Error(
-            'Server timestamps are not supported as array ' + 'values.'
+            'Server timestamps are not supported as array values.'
           );
         }
       } else if (is.array(val)) {
@@ -1319,7 +1319,7 @@ function validateDocumentData(obj, options) {
  * @returns {boolean} 'true' when the object is valid.
  * @throws {Error} when the object is invalid.
  */
-function validateFieldValue(obj, options, depth) {
+function validateFieldValue(val, options, depth) {
   assert(
     ['none', 'root', 'all'].indexOf(options.allowDeletes) !== -1,
     "Expected 'none', 'root', or 'all' for 'options.allowDeletes'"
@@ -1337,17 +1337,17 @@ function validateFieldValue(obj, options, depth) {
     );
   }
 
-  if (is.array(obj)) {
-    for (let prop of obj) {
-      validateFieldValue(obj[prop], options, depth + 1);
+  if (is.array(val)) {
+    for (let prop of val) {
+      validateFieldValue(val[prop], options, depth + 1);
     }
-  } else if (isPlainObject(obj)) {
-    for (let prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
-        validateFieldValue(obj[prop], options, depth + 1);
+  } else if (isPlainObject(val)) {
+    for (let prop in val) {
+      if (val.hasOwnProperty(prop)) {
+        validateFieldValue(val[prop], options, depth + 1);
       }
     }
-  } else if (obj === FieldValue.DELETE_SENTINEL) {
+  } else if (val === FieldValue.DELETE_SENTINEL) {
     if (
       (options.allowDeletes === 'root' && depth > 1) ||
       options.allowDeletes === 'none'
@@ -1356,20 +1356,20 @@ function validateFieldValue(obj, options, depth) {
         'FieldValue.delete() must appear at the top-level and can only be used in update() or set() with {merge:true}.'
       );
     }
-  } else if (obj === FieldValue.SERVER_TIMESTAMP_SENTINEL) {
+  } else if (val === FieldValue.SERVER_TIMESTAMP_SENTINEL) {
     if (!options.allowServerTimestamps) {
       throw new Error(
         'FieldValue.serverTimestamp() can only be used in update(), set() and create().'
       );
     }
-  } else if (is.instanceof(obj, DocumentReference)) {
+  } else if (is.instanceof(val, DocumentReference)) {
     return true;
-  } else if (is.instanceof(obj, GeoPoint)) {
+  } else if (is.instanceof(val, GeoPoint)) {
     return true;
-  } else if (is.instanceof(obj, FieldPath)) {
+  } else if (is.instanceof(val, FieldPath)) {
     throw new Error('Cannot use "FieldPath" as a Firestore type.');
-  } else if (is.object(obj)) {
-    throw validate.customObjectError(obj);
+  } else if (is.object(val)) {
+    throw validate.customObjectError(val);
   }
 
   return true;

--- a/src/reference.js
+++ b/src/reference.js
@@ -2086,13 +2086,13 @@ function validateComparisonOperator(str, val) {
 
     if (typeof val === 'number' && isNaN(val) && op !== 'EQUAL') {
       throw new Error(
-        'Invalid query. You can only perform equals ' + 'comparisons on NaN.'
+        'Invalid query. You can only perform equals comparisons on NaN.'
       );
     }
 
     if (val === null && op !== 'EQUAL') {
       throw new Error(
-        'Invalid query. You can only perform equals ' + 'comparisons on Null.'
+        'Invalid query. You can only perform equals comparisons on Null.'
       );
     }
 

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -353,7 +353,6 @@ class WriteBatch {
         for (let i = 1; i < arguments.length; i += 2) {
           if (i === arguments.length - 1) {
             validate.isUpdatePrecondition(i, arguments[i]);
-            validate.maxNumberOfArguments('update', arguments, i + 1);
             precondition = new Precondition(arguments[i]);
           } else {
             validate.isFieldPath(i, arguments[i]);

--- a/test/document.js
+++ b/test/document.js
@@ -231,7 +231,7 @@ describe('DocumentReference interface', function() {
   it('has collection() method', function() {
     assert.throws(() => {
       documentRef.collection(42);
-    }, new RegExp('Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string.'));
+    }, /Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string./);
 
     let collection = documentRef.collection('col');
     assert.equal(collection.id, 'col');
@@ -448,7 +448,7 @@ describe('serialize document', function() {
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update(obj);
-    }, new RegExp('Argument "dataOrField" is not a valid Document. Input object is deeper than 20 levels or contains a cycle.'));
+    }, /Argument "dataOrField" is not a valid Document. Input object is deeper than 20 levels or contains a cycle./);
   });
 
   it('is able to write a document reference with cycles', function() {
@@ -1125,13 +1125,13 @@ describe('create document', function() {
   it('requires an object', function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').create(null);
-    }, new RegExp('Argument "data" is not a valid Document. Input is not a plain JavaScript object.'));
+    }, /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
   });
 
   it("doesn't accept arrays", function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').create([42]);
-    }, new RegExp('Argument "data" is not a valid Document. Input is not a plain JavaScript object.'));
+    }, /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
   });
 });
 
@@ -1585,13 +1585,13 @@ describe('update document', function() {
   it('accepts an object', function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update(null);
-    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.'));
+    }, /Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object./);
   });
 
   it("doesn't accept arrays", function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update([42]);
-    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.'));
+    }, /Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object./);
   });
 
   it('with field delete', function() {

--- a/test/document.js
+++ b/test/document.js
@@ -844,19 +844,19 @@ describe('delete document', function() {
       return firestore
         .doc('collectionId/documentId')
         .delete({lastUpdateTime: 1337});
-    }, new RegExp('"lastUpdateTime" is not a string.$'));
+    }, /"lastUpdateTime" is not a string./);
   });
 
   it('throws if "exists" is not a boolean', () => {
     assert.throws(() => {
       return firestore.doc('collectionId/documentId').delete({exists: 42});
-    }, new RegExp('"exists" is not a boolean.$'));
+    }, /"exists" is not a boolean./);
   });
 
   it('throws if no delete conditions are provided', () => {
     assert.throws(() => {
       return firestore.doc('collectionId/documentId').delete(42);
-    }, new RegExp('Input is not an object.'));
+    }, /Input is not an object./);
   });
 
   it('throws if more than one condition is provided', () => {
@@ -864,7 +864,7 @@ describe('delete document', function() {
       return firestore
         .doc('collectionId/documentId')
         .delete({exists: false, lastUpdateTime: '1985-03-18T07:20:00.123Z'});
-    }, new RegExp('Input contains more than one condition.'));
+    }, /Input contains more than one condition./);
   });
 });
 
@@ -1572,7 +1572,7 @@ describe('update document', function() {
     assert.throws(() => {
       firestore
         .doc('collectionId/documentId')
-        .update('foo', 'bar', {exists: true}, 'foo');
+        .update('foo', 'bar', {exists: true});
     }, INVALID_ARGUMENTS_TO_UPDATE);
 
     assert.throws(() => {

--- a/test/index.js
+++ b/test/index.js
@@ -1035,30 +1035,3 @@ describe('getAll() method', function() {
       });
   });
 });
-
-describe('FieldPath', function() {
-  it('encodes field names', function() {
-    let components = [['foo'], ['foo', 'bar'], ['.', '`'], ['\\']];
-
-    let results = ['foo', 'foo.bar', '`.`.`\\``', '`\\\\`'];
-
-    for (let i = 0; i < components.length; ++i) {
-      assert.equal(
-        new Firestore.FieldPath(components[i]).toString(),
-        results[i]
-      );
-    }
-  });
-
-  it("doesn't accept empty path", function() {
-    assert.throws(() => {
-      new Firestore.FieldPath();
-    }, /Function 'FieldPath\(\)' requires at least 1 argument\./);
-  });
-
-  it('only accepts strings', function() {
-    assert.throws(() => {
-      new Firestore.FieldPath('foo', 'bar', 0);
-    }, /Argument at index 2 is not a valid string\./);
-  });
-});

--- a/test/index.js
+++ b/test/index.js
@@ -712,10 +712,7 @@ describe('doc() method', function() {
   it("doesn't accept empty components", function() {
     assert.throws(function() {
       firestore.doc('coll//doc');
-    }, new RegExp(
-      'Argument "documentPath" is not a valid ResourcePath. ' +
-        'Paths must not contain //.'
-    ));
+    }, /Argument "documentPath" is not a valid ResourcePath. Paths must not contain \/\/./);
   });
 
   it('must point to document', function() {
@@ -848,7 +845,7 @@ describe('getAll() method', function() {
       .catch(err => {
         assert.equal(
           err.message,
-          'Did not receive document for' + ' "collectionId/documentId".'
+          'Did not receive document for "collectionId/documentId".'
         );
       });
   });

--- a/test/path.js
+++ b/test/path.js
@@ -71,6 +71,28 @@ describe('ResourcePath', function() {
 });
 
 describe('FieldPath', function() {
+  it('encodes field names', function() {
+    let components = [['foo'], ['foo', 'bar'], ['.', '`'], ['\\']];
+
+    let results = ['foo', 'foo.bar', '`.`.`\\``', '`\\\\`'];
+
+    for (let i = 0; i < components.length; ++i) {
+      assert.equal(new FieldPath(components[i]).toString(), results[i]);
+    }
+  });
+
+  it("doesn't accept empty path", function() {
+    assert.throws(() => {
+      new FieldPath();
+    }, /Function 'FieldPath\(\)' requires at least 1 argument\./);
+  });
+
+  it('only accepts strings', function() {
+    assert.throws(() => {
+      new FieldPath('foo', 'bar', 0);
+    }, /Argument at index 2 is not a valid string\./);
+  });
+
   it('has append() method', function() {
     let path = new FieldPath('foo');
     path = path.append('bar');

--- a/test/query.js
+++ b/test/query.js
@@ -709,10 +709,7 @@ describe('where() interface', function() {
     let query = firestore.collection('collectionId');
     assert.throws(function() {
       query = query.orderBy('foo.', '=', 'foobar');
-    }, new RegExp(
-      'Argument "fieldPath" is not a valid FieldPath. Paths must ' +
-        "not start or end with '.'."
-    ));
+    }, /Argument "fieldPath" is not a valid FieldPath. Paths must not start or end with '.'./);
   });
 
   it('verifies operator', function() {
@@ -789,10 +786,7 @@ describe('orderBy() interface', function() {
     let query = firestore.collection('collectionId');
     assert.throws(function() {
       query = query.orderBy('foo.');
-    }, new RegExp(
-      'Argument "fieldPath" is not a valid FieldPath. Paths must ' +
-        "not start or end with '.'."
-    ));
+    }, /Argument "fieldPath" is not a valid FieldPath. Paths must not start or end with '.'./);
   });
 
   it('rejects call after cursor', function() {
@@ -803,40 +797,28 @@ describe('orderBy() interface', function() {
         .orderBy('foo')
         .startAt('foo')
         .orderBy('foo');
-    }, new RegExp(
-      'Cannot specify an orderBy\\(\\) constraint after calling ' +
-        'startAt\\(\\), startAfter\\(\\), endBefore\\(\\) or endAt\\(\\)\\.'
-    ));
+    }, /Cannot specify an orderBy\(\) constraint after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
 
     assert.throws(function() {
       query = query
         .where('foo', '>', 'bar')
         .startAt(snapshot('collectionId/doc', {foo: 'bar'}))
         .where('foo', '>', 'bar');
-    }, new RegExp(
-      'Cannot specify a where\\(\\) filter after calling ' +
-        'startAt\\(\\), startAfter\\(\\), endBefore\\(\\) or endAt\\(\\)\\.'
-    ));
+    }, /Cannot specify a where\(\) filter after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
 
     assert.throws(function() {
       query = query
         .orderBy('foo')
         .endAt('foo')
         .orderBy('foo');
-    }, new RegExp(
-      'Cannot specify an orderBy\\(\\) constraint after calling ' +
-        'startAt\\(\\), startAfter\\(\\), endBefore\\(\\) or endAt\\(\\)\\.'
-    ));
+    }, /Cannot specify an orderBy\(\) constraint after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
 
     assert.throws(function() {
       query = query
         .where('foo', '>', 'bar')
         .endAt(snapshot('collectionId/doc', {foo: 'bar'}))
         .where('foo', '>', 'bar');
-    }, new RegExp(
-      'Cannot specify a where\\(\\) filter after calling ' +
-        'startAt\\(\\), startAfter\\(\\), endBefore\\(\\) or endAt\\(\\)\\.'
-    ));
+    }, /Cannot specify a where\(\) filter after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
   });
 
   it('concatenates orders', function() {
@@ -967,10 +949,7 @@ describe('select() interface', function() {
 
     assert.throws(function() {
       query.select('.');
-    }, new RegExp(
-      'Argument at index 0 is not a valid FieldPath. Paths must ' +
-        "not start or end with '.'."
-    ));
+    }, /Argument at index 0 is not a valid FieldPath. Paths must not start or end with '.'./);
   });
 
   it('uses latest field mask', function() {
@@ -1058,36 +1037,36 @@ describe('startAt() interface', function() {
 
     assert.throws(() => {
       query.orderBy(Firestore.FieldPath.documentId()).startAt(42);
-    }, new RegExp('The corresponding value for FieldPath.documentId\\(\\) must be a string or a DocumentReference\\.'));
+    }, /The corresponding value for FieldPath.documentId\(\) must be a string or a DocumentReference./);
 
     assert.throws(() => {
       query
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc/other/doc'));
-    }, new RegExp("'coll/doc/other/doc' is not part of the query result set and cannot be used as a query boundary."));
+    }, /'coll\/doc\/other\/doc' is not part of the query result set and cannot be used as a query boundary./);
 
     assert.throws(() => {
       query
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc/coll_suffix/doc'));
-    }, new RegExp("'coll/doc/coll_suffix/doc' is not part of the query result set and cannot be used as a query boundary."));
+    }, /'coll\/doc\/coll_suffix\/doc' is not part of the query result set and cannot be used as a query boundary./);
 
     assert.throws(() => {
       query
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc'));
-    }, new RegExp("'coll/doc' is not part of the query result set and cannot be used as a query boundary."));
+    }, /'coll\/doc' is not part of the query result set and cannot be used as a query boundary./);
 
     assert.throws(() => {
       query
         .orderBy(Firestore.FieldPath.documentId())
         .startAt(firestore.doc('coll/doc/coll/doc/coll/doc'));
-    }, new RegExp("Only a direct child can be used as a query boundary. Found: 'coll/doc/coll/doc/coll/doc'."));
+    }, /Only a direct child can be used as a query boundary. Found: 'coll\/doc\/coll\/doc\/coll\/doc'./);
 
     // Validate that we can't pass a reference to a collection.
     assert.throws(() => {
       query.orderBy(Firestore.FieldPath.documentId()).startAt('doc/coll');
-    }, new RegExp("Only a direct child can be used as a query boundary. Found: 'coll/doc/coll/doc/coll'."));
+    }, /Only a direct child can be used as a query boundary. Found: 'coll\/doc\/coll\/doc\/coll'./);
   });
 
   it('can specify document snapshot', function() {
@@ -1292,10 +1271,7 @@ describe('startAt() interface', function() {
     let query = firestore.collection('collectionId');
     assert.throws(function() {
       query.startAt(123);
-    }, new RegExp(
-      'Too many cursor values specified\\. The specified values ' +
-        'must match the orderBy\\(\\) constraints of the query\\.'
-    ));
+    }, /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
   });
 
   it('uses latest value', function() {
@@ -1344,10 +1320,7 @@ describe('startAfter() interface', function() {
     let query = firestore.collection('collectionId');
     assert.throws(function() {
       query.startAfter(123);
-    }, new RegExp(
-      'Too many cursor values specified\\. The specified values ' +
-        'must match the orderBy\\(\\) constraints of the query\\.'
-    ));
+    }, /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
   });
 
   it('uses latest value', function() {
@@ -1400,10 +1373,7 @@ describe('endAt() interface', function() {
     let query = firestore.collection('collectionId');
     assert.throws(function() {
       query.endAt(123);
-    }, new RegExp(
-      'Too many cursor values specified\\. The specified values ' +
-        'must match the orderBy\\(\\) constraints of the query\\.'
-    ));
+    }, /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
   });
 
   it('uses latest value', function() {
@@ -1452,10 +1422,7 @@ describe('endBefore() interface', function() {
     let query = firestore.collection('collectionId');
     assert.throws(function() {
       query.endBefore(123);
-    }, new RegExp(
-      'Too many cursor values specified\\. The specified values ' +
-        'must match the orderBy\\(\\) constraints of the query\\.'
-    ));
+    }, /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
   });
 
   it('uses latest value', function() {

--- a/test/write-batch.js
+++ b/test/write-batch.js
@@ -49,10 +49,7 @@ describe('set() method', function() {
   it('requires object', function() {
     assert.throws(function() {
       writeBatch.set(firestore.doc('sub/doc'));
-    }, new RegExp(
-      'Argument "data" is not a valid Document. Input is not a plain ' +
-        'JavaScript object.'
-    ));
+    }, /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
   });
 
   it('accepts preconditions', function() {
@@ -100,7 +97,7 @@ describe('update() method', function() {
   it('requires object', function() {
     assert.throws(() => {
       writeBatch.update(firestore.doc('sub/doc'), firestore.doc('sub/doc'));
-    }, new RegExp('Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.'));
+    }, /Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object./);
   });
 
   it('accepts preconditions', function() {
@@ -130,10 +127,7 @@ describe('create() method', function() {
   it('requires object', function() {
     assert.throws(function() {
       writeBatch.create(firestore.doc('sub/doc'));
-    }, new RegExp(
-      'Argument "data" is not a valid Document. Input is not a plain ' +
-        'JavaScript object.'
-    ));
+    }, /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
   });
 });
 


### PR DESCRIPTION
This PR brings us back to 100% test coverage (which dropped to an all time low of 99% with https://github.com/googleapis/nodejs-firestore/pull/137) and cleans up some test RegExp syntax since we don't enfore line length anymore in tests.

This also moves the Field Path tests to one consolidated place.

Note: The 100% coverage change is 
```
- .update('foo', 'bar', {exists: true}, 'foo');  
+ .update('foo', 'bar', {exists: true});
```