### PR TITLE
Adding isEqual to the public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@google-cloud/common": "^0.16.0",
     "@google-cloud/common-grpc": "^0.5.3",
     "bun": "^0.0.12",
+    "deep-equal": "^1.0.1",
     "extend": "^3.0.1",
     "functional-red-black-tree": "^1.0.1",
     "google-gax": "^0.14.3",

--- a/src/document.js
+++ b/src/document.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const assert = require('assert');
+const deepEqual = require('deep-equal');
 const is = require('is');
 
 const path = require('./path');
@@ -130,6 +131,21 @@ class GeoPoint {
     return `GeoPoint { latitude: ${this.latitude}, longitude: ${
       this.longitude
     } }`;
+  }
+
+  /**
+   * Returns true if this `GeoPoint` is equal to the provided value.
+   *
+   * @param {*} other The value to compare against.
+   * @return {boolean} true if this `GeoPoint` is equal to the provided one.
+   */
+  isEqual(other) {
+    return (
+      this === other ||
+      (is.instanceof(other, GeoPoint) &&
+        this.latitude === other.latitude &&
+        this.longitude === other.longitude)
+    );
   }
 
   /**
@@ -598,6 +614,23 @@ class DocumentSnapshot {
         fields: this._fieldsProto,
       },
     };
+  }
+
+  /**
+   * Returns true if the document's data and path in this `DocumentSnapshot` is
+   * equal to the provided one.
+   *
+   * @param {*} other The value to compare against.
+   * @return {boolean} true if this `DocumentSnapshot` is equal to the provided
+   * value.
+   */
+  isEqual(other) {
+    return (
+      this === other ||
+      (is.instance(other, DocumentSnapshot) &&
+        this._ref.isEqual(other._ref) &&
+        deepEqual(this._fieldsProto, other._fieldsProto))
+    );
   }
 
   /**

--- a/src/field-value.js
+++ b/src/field-value.js
@@ -80,6 +80,16 @@ class FieldValue {
   static serverTimestamp() {
     return SERVER_TIMESTAMP_SENTINEL;
   }
+
+  /**
+   * Returns true if this `FieldValue` is equal to the provided one.
+   *
+   * @param {*} other The value to compare against.
+   * @return {boolean} true if this `FieldValue` is equal to the provided value.
+   */
+  isEqual(other) {
+    return this === other;
+  }
 }
 
 DELETE_SENTINEL = new FieldValue();

--- a/src/path.js
+++ b/src/path.js
@@ -194,6 +194,20 @@ class Path {
   toArray() {
     return this.segments.slice();
   }
+
+  /**
+   * Returns true if this `Path` is equal to the provided value.
+   *
+   * @private
+   * @param {*} other The value to compare against.
+   * @return {boolean} true if this `Path` is equal to the provided value.
+   */
+  isEqual(other) {
+    return (
+      this === other ||
+      (is.instanceof(other, Path) && this.compareTo(other) === 0)
+    );
+  }
 }
 
 /**
@@ -422,6 +436,20 @@ class ResourcePath extends Path {
 
     return super.compareTo(other);
   }
+
+  /**
+   * Returns true if this `ResourcePath` is equal to the provided value.
+   *
+   * @private
+   * @param {*} other The value to compare against.
+   * @return {boolean} true if this `Path` is equal to the provided value.
+   */
+  isEqual(other) {
+    return (
+      this === other ||
+      (is.instanceof(other, ResourcePath) && this.compareTo(other) === 0)
+    );
+  }
 }
 
 /**
@@ -561,6 +589,20 @@ class FieldPath extends Path {
    */
   construct(segments) {
     return new FieldPath(segments);
+  }
+
+  /**
+   * Returns true if this `FieldPath` is equal to the provided value.
+   *
+   * @private
+   * @param {*} other The value to compare against.
+   * @return {boolean} true if this `FieldPath` is equal to the provided value.
+   */
+  isEqual(other) {
+    return (
+      this === other ||
+      (is.instanceof(other, FieldPath) && super.isEqual(other))
+    );
   }
 }
 

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -106,6 +106,20 @@ class WriteResult {
   get writeTime() {
     return this._writeTime;
   }
+
+  /**
+   * Returns true if this `WriteResult` is equal to the provided one.
+   *
+   * @param {*} other The value to compare against.
+   * @return true if this `WriteResult` is equal to the provided value.
+   */
+  isEqual(other) {
+    return (
+      this === other ||
+      (is.instanceof(other, WriteResult) &&
+        this._writeTime === other._writeTime)
+    );
+  }
 }
 
 /**

--- a/test/collection.js
+++ b/test/collection.js
@@ -142,4 +142,12 @@ describe('Collection interface', function() {
       assert.ok(documentRef.id.length, 20);
     });
   });
+
+  it('has equals() method', function() {
+    let coll1 = firestore.collection('coll1');
+    let coll1Equals = firestore.collection('coll1');
+    let coll2 = firestore.collection('coll2');
+    assert.ok(coll1.isEqual(coll1Equals));
+    assert.ok(!coll1.isEqual(coll2));
+  });
 });

--- a/test/document.js
+++ b/test/document.js
@@ -251,6 +251,14 @@ describe('DocumentReference interface', function() {
   it('has parent property', function() {
     assert.equal(documentRef.parent.path, 'collectionId');
   });
+
+  it('has equals() method', function() {
+    let doc1 = firestore.doc('coll/doc1');
+    let doc1Equals = firestore.doc('coll/doc1');
+    let doc2 = firestore.doc('coll/doc1/coll/doc1');
+    assert.ok(doc1.isEqual(doc1Equals));
+    assert.ok(!doc1.isEqual(doc2));
+  });
 });
 
 describe('serialize document', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -503,6 +503,11 @@ describe('instantiation', function() {
     assert.ok(is.defined(Firestore.CollectionReference));
     assert.ok(is.defined(Firestore.FieldValue));
     assert.ok(is.defined(Firestore.FieldPath));
+    assert.ok(
+      !Firestore.FieldValue.serverTimestamp().isEqual(
+        Firestore.FieldValue.delete()
+      )
+    );
   });
 });
 
@@ -555,6 +560,11 @@ describe('snapshot_() method', function() {
     assert.equal(
       data.geoPointValue.toString(),
       'GeoPoint { latitude: 50.1430847, longitude: -122.947778 }'
+    );
+    assert.ok(
+      data.geoPointValue.isEqual(
+        new Firestore.GeoPoint(50.1430847, -122.947778)
+      )
     );
   }
 
@@ -1033,32 +1043,5 @@ describe('getAll() method', function() {
       .then(result => {
         resultEquals(result, found('a'), found('a'), found('b'), found('a'));
       });
-  });
-});
-
-describe('FieldPath', function() {
-  it('encodes field names', function() {
-    let components = [['foo'], ['foo', 'bar'], ['.', '`'], ['\\']];
-
-    let results = ['foo', 'foo.bar', '`.`.`\\``', '`\\\\`'];
-
-    for (let i = 0; i < components.length; ++i) {
-      assert.equal(
-        new Firestore.FieldPath(components[i]).toString(),
-        results[i]
-      );
-    }
-  });
-
-  it("doesn't accept empty path", function() {
-    assert.throws(() => {
-      new Firestore.FieldPath();
-    }, /Function 'FieldPath\(\)' requires at least 1 argument\./);
-  });
-
-  it('only accepts strings', function() {
-    assert.throws(() => {
-      new Firestore.FieldPath('foo', 'bar', 0);
-    }, /Argument at index 2 is not a valid string\./);
   });
 });

--- a/test/path.js
+++ b/test/path.js
@@ -71,6 +71,28 @@ describe('ResourcePath', function() {
 });
 
 describe('FieldPath', function() {
+  it('encodes field names', function() {
+    let components = [['foo'], ['foo', 'bar'], ['.', '`'], ['\\']];
+
+    let results = ['foo', 'foo.bar', '`.`.`\\``', '`\\\\`'];
+
+    for (let i = 0; i < components.length; ++i) {
+      assert.equal(new FieldPath(components[i]).toString(), results[i]);
+    }
+  });
+
+  it("doesn't accept empty path", function() {
+    assert.throws(() => {
+      new FieldPath();
+    }, /Function 'FieldPath\(\)' requires at least 1 argument\./);
+  });
+
+  it('only accepts strings', function() {
+    assert.throws(() => {
+      new FieldPath('foo', 'bar', 0);
+    }, /Argument at index 2 is not a valid string\./);
+  });
+
   it('has append() method', function() {
     let path = new FieldPath('foo');
     path = path.append('bar');
@@ -92,5 +114,13 @@ describe('FieldPath', function() {
     assert.throws(() => {
       new FieldPath('foo', '');
     }, /Argument at index 1 should not be empty./);
+  });
+
+  it('has equals() method', function() {
+    let path1 = new FieldPath('a');
+    let path1Equals = new FieldPath('a');
+    let path2 = new FieldPath('a', 'b', 'a');
+    assert.ok(path1.isEqual(path1Equals));
+    assert.ok(!path1.isEqual(path2));
   });
 });

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -63,6 +63,7 @@ xdescribe('firestore.d.ts', function() {
     const geoPoint: GeoPoint = new GeoPoint(90.0, 90.0);
     const latitude = geoPoint.latitude;
     const longitude = geoPoint.longitude;
+    const equals: boolean = geoPoint.isEqual(geoPoint);
   });
 
   it('has typings for Transaction', () => {
@@ -109,6 +110,7 @@ xdescribe('firestore.d.ts', function() {
   it('has typings for WriteResult', () => {
     docRef.set(documentData).then((result: FirebaseFirestore.WriteResult) => {
       const writeTime: string = result.writeTime;
+      const equals: boolean = result.isEqual(result);
     });
   });
 
@@ -116,6 +118,7 @@ xdescribe('firestore.d.ts', function() {
     const path1: FieldPath = new FieldPath('a');
     const path2: FieldPath = new FieldPath('a', 'b');
     const path3: FieldPath = FieldPath.documentId();
+    const equals: boolean = path1.isEqual(path2);
   });
 
   it('has typings for DocumentReference', () => {
@@ -167,6 +170,7 @@ xdescribe('firestore.d.ts', function() {
     unsubscribe = docRef.onSnapshot((snapshot: DocumentSnapshot) => {
     }, (error: Error) => {
     });
+    const equals: boolean = docRef.isEqual(docRef);
   });
 
   it('has typings for DocumentSnapshot', () => {
@@ -180,6 +184,7 @@ xdescribe('firestore.d.ts', function() {
       const data: DocumentData = snapshot.data()!;
       let value = snapshot.get('foo');
       value = snapshot.get(new FieldPath('foo'));
+      const equals: boolean = snapshot.isEqual(snapshot);
     });
   });
 
@@ -195,6 +200,7 @@ xdescribe('firestore.d.ts', function() {
       const data: DocumentData = snapshot.data();
       let value = snapshot.get('foo');
       value = snapshot.get(new FieldPath('foo'));
+      const equals: boolean = snapshot.isEqual(snapshot);
     });
   });
 
@@ -235,6 +241,7 @@ xdescribe('firestore.d.ts', function() {
       unsubscribe = query.onSnapshot((snapshot: QuerySnapshot) => {
       }, (error: Error) => {
       });
+      const equals: boolean = query.isEqual(query);
     });
   });
 
@@ -250,6 +257,7 @@ xdescribe('firestore.d.ts', function() {
       });
       snapshot.forEach((result: QueryDocumentSnapshot) => {
       }, this);
+      const equals: boolean = snapshot.isEqual(snapshot);
     });
   });
 
@@ -259,6 +267,7 @@ xdescribe('firestore.d.ts', function() {
       const doc: QueryDocumentSnapshot = docChange.doc;
       const oldIndex: number = docChange.oldIndex;
       const newIndex: number = docChange.newIndex;
+      const equals: boolean = docChange.isEqual(docChange);
     });
   });
 
@@ -271,12 +280,14 @@ xdescribe('firestore.d.ts', function() {
     const docRef2: DocumentReference = collRef.doc('doc');
     collRef.add(documentData).then((docRef: DocumentReference) => {
     });
+    const equals: boolean = collRef.isEqual(collRef);
   });
 
   it('has typings for FieldValue', () => {
     const documentData: UpdateData = {
       'foo': FieldValue.serverTimestamp(),
       'bar': FieldValue.delete()
-    }
+    };
+    const equals: boolean = FieldValue.serverTimestamp().isEqual(FieldValue.serverTimestamp());
   });
 });

--- a/test/write-batch.js
+++ b/test/write-batch.js
@@ -322,6 +322,38 @@ describe('batch support', function() {
     return batch.commit().then(() => batch.commit);
   });
 
+  it('can return same write result', function() {
+    firestore.api.Firestore._commit = function(request, options, callback) {
+      callback(null, {
+        commitTime: {
+          nanos: 0,
+          seconds: 0,
+        },
+        writeResults: [
+          {
+            updateTime: {
+              nanos: 0,
+              seconds: 0,
+            },
+          },
+          {
+            updateTime: {},
+          },
+        ],
+      });
+    };
+
+    let documentName = firestore.doc('col/doc');
+
+    let batch = firestore.batch();
+    batch.set(documentName, {});
+    batch.set(documentName, {});
+
+    return batch.commit().then(results => {
+      assert.ok(results[0].isEqual(results[1]));
+    });
+  });
+
   it('uses transactions on GCF', function() {
     // We use this environment variable during initialization to detect whether
     // we are running on GCF.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -130,6 +130,14 @@ declare namespace FirebaseFirestore {
 
     readonly latitude: number;
     readonly longitude: number;
+
+    /**
+     * Returns true if this `GeoPoint` is equal to the provided one.
+     *
+     * @param other The `GeoPoint` to compare against.
+     * @return true if this `GeoPoint` is equal to the provided one.
+     */
+    isEqual(other: GeoPoint): boolean;
   }
 
   /**
@@ -509,6 +517,14 @@ declare namespace FirebaseFirestore {
      */
     onSnapshot(onNext: (snapshot: DocumentSnapshot) => void,
                onError?: (error: Error) => void): () => void;
+
+    /**
+     * Returns true if this `DocumentReference` is equal to the provided one.
+     *
+     * @param other The `DocumentReference` to compare against.
+     * @return true if this `DocumentReference` is equal to the provided one.
+     */
+    isEqual(other: DocumentReference): boolean;
   }
 
   /**
@@ -567,6 +583,15 @@ declare namespace FirebaseFirestore {
      * field exists in the document.
      */
     get(fieldPath: string|FieldPath): any;
+
+    /**
+     * Returns true if the data and document path in this `DocumentSnapshot` is
+     * equal to the provided one.
+     *
+     * @param other The `DocumentSnapshot` to compare against.
+     * @return true if this `DocumentSnapshot` is equal to the provided one.
+     */
+    isEqual(other: DocumentSnapshot): boolean;
   }
 
   /**
@@ -810,6 +835,14 @@ declare namespace FirebaseFirestore {
      */
     onSnapshot(onNext: (snapshot: QuerySnapshot) => void,
                onError?: (error: Error) => void) : () => void;
+
+    /**
+     * Returns true if this `Query` is equal to the provided one.
+     *
+     * @param other The `Query` to compare against.
+     * @return true if this `Query` is equal to the provided one.
+     */
+    isEqual(other: Query): boolean;
   }
 
   /**
@@ -857,6 +890,15 @@ declare namespace FirebaseFirestore {
     forEach(
         callback: (result: QueryDocumentSnapshot) => void, thisArg?: any
     ): void;
+
+    /**
+     * Returns true if the data in this `QuerySnapshot` is equal to the provided
+     * one.
+     *
+     * @param other The `QuerySnapshot` to compare against.
+     * @return true if this `QuerySnapshot` is equal to the provided one.
+     */
+    isEqual(other: QuerySnapshot): boolean;
   }
 
   /**
@@ -933,6 +975,14 @@ declare namespace FirebaseFirestore {
      * newly created document after it has been written to the backend.
      */
     add(data: DocumentData): Promise<DocumentReference>;
+
+    /**
+     * Returns true if this `CollectionReference` is equal to the provided one.
+     *
+     * @param other The `CollectionReference` to compare against.
+     * @return true if this `CollectionReference` is equal to the provided one.
+     */
+    isEqual(other: CollectionReference): boolean;
   }
 
   /**
@@ -952,6 +1002,14 @@ declare namespace FirebaseFirestore {
      * Returns a sentinel for use with update() to mark a field for deletion.
      */
     static delete(): FieldValue;
+
+    /**
+     * Returns true if this `FieldValue` is equal to the provided one.
+     *
+     * @param other The `FieldValue` to compare against.
+     * @return true if this `FieldValue` is equal to the provided one.
+     */
+    isEqual(other: FieldValue): boolean;
   }
 
   /**
@@ -973,6 +1031,14 @@ declare namespace FirebaseFirestore {
      * It can be used in queries to sort or filter by the document ID.
      */
     static documentId(): FieldPath;
+
+    /**
+     * Returns true if this `FieldPath` is equal to the provided one.
+     *
+     * @param other The `FieldPath` to compare against.
+     * @return true if this `FieldPath` is equal to the provided one.
+     */
+    isEqual(other: FieldPath): boolean;
   }
 }
 

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -388,6 +388,14 @@ declare namespace FirebaseFirestore {
      * string.
      */
     readonly writeTime: string;
+
+    /**
+     * Returns true if this `WriteResult` is equal to the provided one.
+     *
+     * @param other The `WriteResult` to compare against.
+     * @return true if this `WriteResult` is equal to the provided one.
+     */
+    isEqual(other: WriteResult): boolean;
   }
 
   /**
@@ -585,8 +593,8 @@ declare namespace FirebaseFirestore {
     get(fieldPath: string|FieldPath): any;
 
     /**
-     * Returns true if the data and document path in this `DocumentSnapshot` is
-     * equal to the provided one.
+     * Returns true if the document's data and path in this `DocumentSnapshot`
+     * is equal to the provided one.
      *
      * @param other The `DocumentSnapshot` to compare against.
      * @return true if this `DocumentSnapshot` is equal to the provided one.
@@ -892,8 +900,8 @@ declare namespace FirebaseFirestore {
     ): void;
 
     /**
-     * Returns true if the data in this `QuerySnapshot` is equal to the provided
-     * one.
+     * Returns true if the document data in this `QuerySnapshot` is equal to the
+     * provided one.
      *
      * @param other The `QuerySnapshot` to compare against.
      * @return true if this `QuerySnapshot` is equal to the provided one.
@@ -931,6 +939,15 @@ declare namespace FirebaseFirestore {
      * Is -1 for 'removed' events.
      */
     readonly newIndex: number;
+
+    /**
+     * Returns true if the data in this `DocumentChange` is equal to the
+     * provided one.
+     *
+     * @param other The `DocumentChange` to compare against.
+     * @return true if this `DocumentChange` is equal to the provided one.
+     */
+    isEqual(other: DocumentChange): boolean;
   }
 
   /**


### PR DESCRIPTION
This adds isEquals to all out public API types, ignoring metadata for all *Snapshots.

The API is mostly a port from Web, with the addition of an isEqulas for WriteResult and DocumentChange.