### PR TITLE
Making the QuerySnapshot isEqual more efficient

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -665,9 +665,18 @@ class Watch {
           diff.appliedChanges.length,
           diff.updatedTree.length
         );
+
+        let materializedDocs;
+
         onNext(
           readTime,
-          () => diff.updatedTree.keys,
+          () => {
+            if (!materializedDocs) {
+              return diff.updatedTree.keys;
+            }
+
+            return materializedDocs;
+          },
           () => diff.appliedChanges
         );
         hasPushed = true;


### PR DESCRIPTION
This tries to make QuerySnapshot equality more efficient by computing the data for the snapshot outside of the QuerySnapshot itself. The data can the be re-used for comparison.

While I started working on this, I thought more and more than this may not actually have any impact (I can't come up with a case where two different snapshots would share data pointers), but even without this, this PR removes at one duplicate copy of docChanges for regular QuerySnapshots.