### PR TITLE
Allowing empty merge calls

### DIFF
--- a/conformance/runner.js
+++ b/conformance/runner.js
@@ -43,7 +43,9 @@ const ignoredRe = [
 ];
 
 /** If non-empty, list the test cases to run exclusively. */
-const exclusiveRe = [];
+const exclusiveRe = [
+  /set: MergeAll cannot be specified with empty data./, // b/73495873
+];
 
 const docRef = function(path) {
   const relativePath = ResourcePath.fromSlashSeparatedString(path).relativeName;

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -266,7 +266,7 @@ class WriteBatch {
 
     validate.isDocumentReference('documentRef', documentRef);
     validate.isDocument('data', data, {
-      allowEmpty: !merge,
+      allowEmpty: true,
       allowDeletes: merge ? 'all' : 'none',
       allowServerTimestamps: true,
     });
@@ -278,11 +278,13 @@ class WriteBatch {
     const transform = DocumentTransform.fromObject(documentRef, data);
     const documentMask = DocumentMask.fromObject(data);
 
+    const hasDocumentData = !document.isEmpty || !documentMask.isEmpty;
+
     let write;
 
     if (!merge) {
       write = document.toProto();
-    } else if (!document.isEmpty || !documentMask.isEmpty) {
+    } else if (hasDocumentData || transform.isEmpty) {
       write = document.toProto();
       write.updateMask = documentMask.toProto();
     }

--- a/test/document.js
+++ b/test/document.js
@@ -971,6 +971,15 @@ describe('set document', function() {
       );
   });
 
+  it('supports empty merge', function() {
+    firestore.api.Firestore._commit = function(request, options, callback) {
+      requestEquals(request, set(document(), updateMask()));
+      callback(null, writeResult(1));
+    };
+
+    return firestore.doc('collectionId/documentId').set({}, {merge: true});
+  });
+
   it('supports nested empty merge', function() {
     firestore.api.Firestore._commit = function(request, options, callback) {
       requestEquals(
@@ -1020,12 +1029,6 @@ describe('set document', function() {
         .doc('collectionId/documentId')
         .set({foo: Firestore.FieldValue.delete()});
     }, /FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
-  });
-
-  it('rejects empty merges', function() {
-    assert.throws(() => {
-      firestore.doc('collectionId/documentId').set({}, {merge: true});
-    }, /At least one field must be updated./);
   });
 
   it("doesn't accept arrays", function() {


### PR DESCRIPTION
This PR allows the call `set({}, merge:true)` since it can be used to ensure that a document exist on the server.

This came up as a valid use case in an internal discussion (b/73495873 - based on customer feedback in b/73132705).

There is currently a conformance test that rejects this call. I excluded the test and will work with @jba on an update.