### PR TITLE
Improving error message for multiple conflicting fields

### DIFF
--- a/conformance/runner.js
+++ b/conformance/runner.js
@@ -40,12 +40,11 @@ const firestore = new Firestore({
 const ignoredRe = [
   // Node doesn't support field masks for set().
   /^set-merge: .*$/,
+  /set: MergeAll cannot be specified with empty data./, // b/73495873
 ];
 
 /** If non-empty, list the test cases to run exclusively. */
-const exclusiveRe = [
-  /set: MergeAll cannot be specified with empty data./, // b/73495873
-];
+const exclusiveRe = [];
 
 const docRef = function(path) {
   const relativePath = ResourcePath.fromSlashSeparatedString(path).relativeName;

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -120,7 +120,7 @@ class Transaction {
    * @example
    * let firstDoc = firestore.doc('col/doc1');
    * let secondDoc = firestore.doc('col/doc2');
-   * let resultDoc = firestore.doc('col/doc2');
+   * let resultDoc = firestore.doc('col/doc3');
    *
    * firestore.runTransaction(transaction => {
    *   return transaction.getAll(firstDoc, secondDoc).then(docs => {

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -613,7 +613,7 @@ function validateUpdateMap(data) {
 
   for (let i = 1; i < fields.length; ++i) {
     if (fields[i - 1].isPrefixOf(fields[i])) {
-      throw new Error(`Field "${fields[i - 1]}" has conflicting definitions.`);
+      throw new Error(`Field "${fields[i - 1]}" was specified multiple times.`);
     }
   }
 

--- a/test/document.js
+++ b/test/document.js
@@ -1500,53 +1500,53 @@ describe('update document', function() {
         foo: 'foobar',
         'foo.bar': 'foobar',
       });
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         foo: 'foobar',
         'foo.bar.foobar': 'foobar',
       });
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         'foo.bar': 'foobar',
         foo: 'foobar',
       });
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         'foo.bar': 'foobar',
         'foo.bar.foo': 'foobar',
       });
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" was specified multiple times\./);
 
     assert.throws(() => {
       firestore.doc('collectionId/documentId').update({
         'foo.bar': {foo: 'foobar'},
         'foo.bar.foo': 'foobar',
       });
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" was specified multiple times\./);
 
     assert.throws(() => {
       firestore
         .doc('collectionId/documentId')
         .update('foo.bar', 'foobar', 'foo', 'foobar');
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
 
     assert.throws(() => {
       firestore
         .doc('collectionId/documentId')
         .update('foo', {foobar: 'foobar'}, 'foo.bar', {foobar: 'foobar'});
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
 
     assert.throws(() => {
       firestore
         .doc('collectionId/documentId')
         .update('foo', {foobar: 'foobar'}, 'foo.bar', {foobar: 'foobar'});
-    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" has conflicting definitions\./);
+    }, /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
   });
 
   it('with valid field paths', function() {


### PR DESCRIPTION
This is just a cleanup PR:

- The "conflicting field" error also shows up when a user uses the same field twice in an update call. (update('foo', ..., 'foo', ...). I changed the error message to the one of the Java client as it seems more obvious.

- Updated the Transactions.getAll() sample.

