### PR TITLE
Keeping non-empty nested objects

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -217,7 +217,6 @@ class DocumentSnapshot {
   static fromObject(ref, obj) {
     return new DocumentSnapshot(ref, DocumentSnapshot.encodeFields(obj));
   }
-
   /**
    * Creates a DocumentSnapshot from an UpdateMap.
    *

--- a/src/document.js
+++ b/src/document.js
@@ -272,7 +272,7 @@ class DocumentSnapshot {
             target[key] = childNode;
             return target;
           } else {
-            return null;
+            return !is.empty(target) ? target : null;
           }
         }
       } else {

--- a/test/document.js
+++ b/test/document.js
@@ -1455,31 +1455,47 @@ describe('update document', function() {
       requestEquals(
         request,
         update(
-          document('foo', {
+          document('a', {
             mapValue: {
               fields: {
-                bar: {
-                  stringValue: 'include',
-                  valueType: 'stringValue',
+                b: {
+                  valueType: 'mapValue',
+                  mapValue: {
+                    fields: {
+                      keep: {
+                        stringValue: 'keep',
+                        valueType: 'stringValue',
+                      },
+                    },
+                  },
+                },
+                c: {
+                  valueType: 'mapValue',
+                  mapValue: {
+                    fields: {
+                      keep: {
+                        stringValue: 'keep',
+                        valueType: 'stringValue',
+                      },
+                    },
+                  },
                 },
               },
             },
             valueType: 'mapValue',
           }),
-          updateMask('foo.bar', 'foo.delete')
+          updateMask('a.b.delete', 'a.b.keep', 'a.c.delete', 'a.c.keep')
         )
       );
 
       callback(null, writeResult(1));
     };
-    return firestore
-      .doc('collectionId/documentId')
-      .update(
-        'foo.bar',
-        'include',
-        'foo.delete',
-        Firestore.FieldValue.delete()
-      );
+    return firestore.doc('collectionId/documentId').update({
+      'a.b.delete': Firestore.FieldValue.delete(),
+      'a.b.keep': 'keep',
+      'a.c.delete': Firestore.FieldValue.delete(),
+      'a.c.keep': 'keep',
+    });
   });
 
   it('with field with dot ', function() {

--- a/test/order.js
+++ b/test/order.js
@@ -177,7 +177,7 @@ describe('Order', function() {
       [resource('projects/p1/databases/d1/documents/c10/doc1')],
       [resource('projects/p1/databases/dkkkkklkjnjkkk1/documents/c2/doc1')],
       [resource('projects/p2/databases/d2/documents/c1/doc1')],
-      [resource('projects/p2/databases/d2/documents/cl-/doc1')],
+      [resource('projects/p2/databases/d2/documents/c1-/doc1')],
 
       // geo points
       [geopoint(-90, -180)],


### PR DESCRIPTION
This fixes https://github.com/googleapis/nodejs-firestore/issues/157

There is an edge case in merge() that the specified example hits. When we parse `'o.c.x': firebase.firestore.FieldValue.delete()`, we replace the entire contents of the current target object with `null`. That means that both `o.b` and `o.c` no longer exist when we try to append to `o.c`. We need to preserve the existing data if the object is non-empty.

This is basically the same fix as #119, but expanded to also apply at any level within an object.