### PR TITLE
Improved error messages for custom types

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -1399,7 +1399,9 @@ function validateFieldValue(val, options, depth) {
   } else if (is.instanceof(val, GeoPoint)) {
     return true;
   } else if (is.instanceof(val, FieldPath)) {
-    throw new Error('Cannot use "FieldPath" as a Firestore type.');
+    throw new Error(
+      'Cannot use object of type "FieldPath" as a Firestore value.'
+    );
   } else if (is.object(val)) {
     throw validate.customObjectError(val);
   }

--- a/src/validate.js
+++ b/src/validate.js
@@ -142,21 +142,22 @@ module.exports = validators => {
 
   exports.customObjectError = val => {
     if (is.object(val) && val.constructor.name !== 'Object') {
-      switch (val.constructor.name) {
+      const typeName = val.constructor.name;
+      switch (typeName) {
         case 'DocumentReference':
         case 'FieldPath':
         case 'FieldValue':
         case 'GeoPoint':
           return new Error(
-            `Detected an object of type "${
-              val.constructor.name
-            }" that doesn't match the expected instance. Please ensure that ` +
-              'the Firestore types you are using are from the same NPM package.'
+            `Detected an object of type "${typeName}" that doesn't match the ` +
+              'expected instance. Please ensure that the Firestore types you ' +
+              'are using are from the same NPM package.'
           );
         default:
           return new Error(
-            "Firestore doesn't support serialization of JavaScript objects " +
-              "that were constructed using the 'new' operator."
+            `Couldn't serialize object of type "${typeName}". Firestore ` +
+              "doesn't support JavaScript objects with custom prototypes " +
+              "(i.e. objects that were created via the 'new' operator)."
           );
       }
     } else {

--- a/src/validate.js
+++ b/src/validate.js
@@ -141,21 +141,28 @@ module.exports = validators => {
   };
 
   exports.customObjectError = val => {
-    let typeName = is.object(val) ? val.constructor.name : typeof val;
-
-    switch (typeName) {
-      case 'DocumentReference':
-      case 'FieldPath':
-      case 'FieldValue':
-      case 'GeoPoint':
-        return new Error(
-          `Detected an object of type "${typeName}" that doesn't match the expected instance. Please ensure that ` +
-            'the Firestore types you are using are from the same NPM package.'
-        );
-      default:
-        return new Error(
-          `Cannot use custom type "${typeName}" as a Firestore type.`
-        );
+    if (is.object(val) && val.constructor.name !== 'Object') {
+      switch (val.constructor.name) {
+        case 'DocumentReference':
+        case 'FieldPath':
+        case 'FieldValue':
+        case 'GeoPoint':
+          return new Error(
+            `Detected an object of type "${
+              val.constructor.name
+            }" that doesn't match the expected instance. Please ensure that ` +
+              'the Firestore types you are using are from the same NPM package.'
+          );
+        default:
+          return new Error(
+            "Firestore doesn't support serialization of JavaScript objects " +
+              "that were constructed using the 'new' operator."
+          );
+      }
+    } else {
+      return new Error(
+        `Invalid use of type "${typeof val}" as a Firestore argument.`
+      );
     }
   };
 

--- a/test/document.js
+++ b/test/document.js
@@ -290,13 +290,13 @@ describe('serialize document', function() {
   it("doesn't serialize unsupported types", function() {
     assert.throws(() => {
       firestore.doc('collectionId/documentId').set({foo: undefined});
-    }, /Cannot use custom type "undefined" as a Firestore type./);
+    }, /Invalid use of type "undefined" as a Firestore argument./);
 
     assert.throws(() => {
       firestore
         .doc('collectionId/documentId')
         .set({foo: Firestore.FieldPath.documentId()});
-    }, /Cannot use "FieldPath" as a Firestore type./);
+    }, /Cannot use object of type "FieldPath" as a Firestore value./);
   });
 
   it('serializes date before 1970', function() {
@@ -780,7 +780,7 @@ describe('get document', function() {
       .then(doc => {
         assert.throws(() => {
           doc.get();
-        }, /Argument "field" is not a valid FieldPath. Cannot use custom type "undefined" as a Firestore type./);
+        }, /Argument "field" is not a valid FieldPath. Invalid use of type "undefined" as a Firestore argument./);
       });
   });
 });

--- a/test/document.js
+++ b/test/document.js
@@ -297,6 +297,11 @@ describe('serialize document', function() {
         .doc('collectionId/documentId')
         .set({foo: Firestore.FieldPath.documentId()});
     }, /Cannot use object of type "FieldPath" as a Firestore value./);
+
+    assert.throws(() => {
+      class Foo {}
+      firestore.doc('collectionId/documentId').set({foo: new Foo()});
+    }, /Argument "data" is not a valid Document. Couldn't serialize object of type "Foo". Firestore doesn't support JavaScript objects with custom prototypes \(i.e. objects that were created via the 'new' operator\)./);
   });
 
   it('serializes date before 1970', function() {

--- a/test/order.js
+++ b/test/order.js
@@ -85,7 +85,7 @@ describe('Order', function() {
   it('throws on invalid value', function() {
     assert.throws(() => {
       order.compare({}, {});
-    }, /Cannot use custom type "Object" as a Firestore type/);
+    }, /Invalid use of type "object" as a Firestore argument./);
   });
 
   it('throws on invalid blob', function() {

--- a/test/query.js
+++ b/test/query.js
@@ -752,7 +752,7 @@ describe('where() interface', function() {
 
     assert.throws(() => {
       query.where('foo', '=', new Foo()).get();
-    }, /Argument "value" is not a valid FieldValue. Firestore doesn't support serialization of JavaScript objects that were constructed using the 'new' operator./);
+    }, /Argument "value" is not a valid FieldValue. Couldn't serialize object of type "Foo". Firestore doesn't support JavaScript objects with custom prototypes \(i.e. objects that were created via the 'new' operator\)./);
 
     assert.throws(() => {
       query.where('foo', '=', new FieldPath()).get();

--- a/test/query.js
+++ b/test/query.js
@@ -709,7 +709,7 @@ describe('where() interface', function() {
       let query = firestore.collection('collectionId');
       query = query.where({}, '=', 'bar');
       return query.get();
-    }, /Argument "fieldPath" is not a valid FieldPath. Cannot use custom type "Object" as a Firestore type./);
+    }, /Argument "fieldPath" is not a valid FieldPath. Invalid use of type "object" as a Firestore argument/);
 
     class FieldPath {}
     assert.throws(() => {
@@ -724,7 +724,7 @@ describe('where() interface', function() {
       let query = firestore.collection('collectionId');
       query = query.where('foo', '=', new Firestore.FieldPath('bar'));
       return query.get();
-    }, /Argument "value" is not a valid FieldValue. Cannot use "FieldPath" as a Firestore type./);
+    }, /Argument "value" is not a valid FieldValue. Cannot use object of type "FieldPath" as a Firestore value./);
   });
 
   it('rejects field transforms as value', function() {
@@ -752,7 +752,7 @@ describe('where() interface', function() {
 
     assert.throws(() => {
       query.where('foo', '=', new Foo()).get();
-    }, /Argument "value" is not a valid FieldValue. Cannot use custom type "Foo" as a Firestore type./);
+    }, /Argument "value" is not a valid FieldValue. Firestore doesn't support serialization of JavaScript objects that were constructed using the 'new' operator./);
 
     assert.throws(() => {
       query.where('foo', '=', new FieldPath()).get();
@@ -1039,7 +1039,7 @@ describe('select() interface', function() {
     let query = firestore.collection('collectionId');
     assert.throws(function() {
       query.select(1);
-    }, /Argument at index 0 is not a valid FieldPath. Cannot use custom type "number" as a Firestore type./);
+    }, /Argument at index 0 is not a valid FieldPath. Invalid use of type "number" as a Firestore argument./);
 
     assert.throws(function() {
       query.select('.');


### PR DESCRIPTION
This addresses https://github.com/googleapis/nodejs-firestore/issues/143

This PR changes two of our error messages:

- When we detect an custom object during serialization, we throw: 'Firestore doesn't support serialization of JavaScript objects that were constructed using the 'new' operator.'
- When we detect an invalid type as method argument, we throw: 'Cannot use object of type "FieldPath" as a Firestore argument.'

There might be much better ways to express this, and the easiest way to figure out if the changes here make sense is to look at the test cases that show these error messages. 

Note that the code tested in `order.js` is not reachable from customer code. The tests exists to allow for 100% coverage (touches line https://github.com/googleapis/nodejs-firestore/blob/463fbfc5f70afa3d776382348f077a0a4b369c29/src/order.js#L82)