### PR TITLE
Preparing the 0.14.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
     "test": "repo-tools test run --cmd npm -- run ava"
   },
   "dependencies": {
-    "@google-cloud/firestore": "0.13.1"
+    "@google-cloud/firestore": "0.14.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "2.2.3",


### PR DESCRIPTION
This release includes:

- [added] Added new `{ mergeFields: ...[] }` option for `.set()` calls that allows specifying the subset of fields you wish to merge (https://github.com/googleapis/nodejs-firestore/pull/173).
- [fixed] All Protobuf files are now loaded from `google-proto-files`, which resolves a known issue for missing files such as `google/api/annotations.proto` (https://github.com/googleapis/nodejs-firestore/issues/175, https://github.com/googleapis/nodejs-firestore/pull/188).
- [changed] Updated all dependencies to ensure that GRPC pre-builds are available (https://github.com/googleapis/nodejs-firestore/issues/185, https://github.com/googleapis/nodejs-firestore/pull/189)
- [changed] Improved startup performance for calls to `new Firestore()` (https://github.com/googleapis/nodejs-firestore/pull/190).