### PR TITLE
chore: codecov to dev deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,6 @@ jobs:
               chmod +x "$repo_tools"
             fi
       - run:
-          name: Install codecov.
-          command: npm install codecov
-      - run:
           name: Run unit tests.
           command: npm test
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/firestore",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -81,9 +81,9 @@
       }
     },
     "@google-cloud/common": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.18.5.tgz",
-      "integrity": "sha512-K4yuycZLWa+NoUxA8Xs7zzmK7gVdvZxFsObqxDgwGiPLhK2JOeNw6J0wW5B4yDD++qfSpiksr+luGeH4IfoZeQ==",
+      "version": "0.18.8",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.18.8.tgz",
+      "integrity": "sha512-Iy0G9aFhskZPzHjsESxYqqc4XIew0FtDsmGk8z5z22Qvm09KDHC4owd+Q8RZDvkj8zBUFd0mZxIi4xOR5bCJiA==",
       "requires": {
         "@types/duplexify": "3.5.0",
         "@types/request": "2.47.0",
@@ -92,10 +92,10 @@
         "duplexify": "3.6.0",
         "ent": "2.2.0",
         "extend": "3.0.1",
-        "google-auth-library": "1.4.0",
+        "google-auth-library": "1.5.0",
         "is": "3.2.1",
         "pify": "3.0.0",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "retry-request": "3.3.1",
         "split-array-stream": "2.0.0",
         "stream-events": "1.0.4"
@@ -134,7 +134,7 @@
             "log-driver": "1.2.7",
             "methmeth": "1.1.0",
             "modelo": "4.2.3",
-            "request": "2.85.0",
+            "request": "2.87.0",
             "retry-request": "3.3.1",
             "split-array-stream": "1.0.3",
             "stream-events": "1.0.4",
@@ -147,7 +147,7 @@
           "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
           "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
           "requires": {
-            "async": "2.6.0",
+            "async": "2.6.1",
             "is-stream-ended": "0.1.4"
           }
         }
@@ -1916,6 +1916,11 @@
         "glob-to-regexp": "0.3.0"
       }
     },
+    "@nodelib/fs.stat": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.0.2.tgz",
+      "integrity": "sha512-vCpf75JDcdomXvUd7Rn6DfYAVqPAFI66FVjxiWGwh85OLdvfo3paBoPJaam5keIYRyUolnS7SleS/ZPCidCvzw=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1978,7 +1983,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -1995,7 +2000,7 @@
       "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.5.0.tgz",
       "integrity": "sha512-+aZCCdxuR/Q6n58CBkXyqGqimIqpYUcFLfBXagXv7e9TdJUevqkKhzopBuRz3RB064sQxnJnhttHOkK/O93Ouw==",
       "requires": {
-        "@types/node": "10.0.6"
+        "@types/node": "10.1.2"
       }
     },
     "@types/form-data": {
@@ -2003,7 +2008,7 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "10.0.6"
+        "@types/node": "10.1.2"
       }
     },
     "@types/long": {
@@ -2018,9 +2023,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.6.tgz",
-      "integrity": "sha512-2whhQUfDHRBiZ3L54Ulyl1X+fZWbWabxPYRDAsibgOAtE6adwusD15Xv0Bw/D7cPah35Z/wKTdW3iAKsevw1uw=="
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.2.tgz",
+      "integrity": "sha512-bjk1RIeZBCe/WukrFToIVegOf91Pebr8cXYBwLBIsfiGWVQ+ifwWsT59H3RxrWzWrzd1l/Amk1/ioY5Fq3/bpA=="
     },
     "@types/request": {
       "version": "2.47.0",
@@ -2029,7 +2034,7 @@
       "requires": {
         "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.1",
-        "@types/node": "10.0.6",
+        "@types/node": "10.1.2",
         "@types/tough-cookie": "2.3.3"
       }
     },
@@ -2282,6 +2287,12 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2374,9 +2385,9 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
         "lodash": "4.17.10"
       }
@@ -2466,7 +2477,7 @@
         "lodash.difference": "4.5.0",
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "matcher": "1.1.0",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
@@ -2483,7 +2494,7 @@
         "safe-buffer": "5.1.2",
         "semver": "5.5.0",
         "slash": "1.0.0",
-        "source-map-support": "0.5.5",
+        "source-map-support": "0.5.6",
         "stack-utils": "1.0.1",
         "strip-ansi": "4.0.0",
         "strip-bom-buf": "1.0.0",
@@ -2573,7 +2584,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.4.1",
+        "follow-redirects": "1.5.0",
         "is-buffer": "1.1.6"
       }
     },
@@ -2807,7 +2818,7 @@
         "call-matcher": "1.0.1",
         "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -3094,11 +3105,6 @@
         }
       }
     },
-    "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -3119,14 +3125,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.1"
-      }
     },
     "boxen": {
       "version": "1.3.0",
@@ -3365,7 +3363,7 @@
       "requires": {
         "core-js": "2.5.6",
         "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -3464,7 +3462,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3661,6 +3659,17 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "codecov": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.2.tgz",
+      "integrity": "sha512-9ljtIROIjPIUmMRqO+XuDITDoV8xRrZmA0jcEq6p2hg2+wY9wGmLfreAZGIL72IzUfdEDZaU8+Vjidg1fBQ8GQ==",
+      "dev": true,
+      "requires": {
+        "argv": "0.0.2",
+        "request": "2.87.0",
+        "urlgrey": "0.4.4"
+      }
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3705,9 +3714,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "common-path-prefix": {
@@ -3781,7 +3790,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -3847,24 +3856,6 @@
         "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
       }
     },
     "crypto-random-string": {
@@ -4115,9 +4106,9 @@
       "dev": true
     },
     "domhandler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
         "domelementtype": "1.3.0"
@@ -4173,11 +4164,10 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "base64url": "2.0.0",
         "safe-buffer": "5.1.2"
       }
     },
@@ -4519,9 +4509,9 @@
       "dev": true
     },
     "espower": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/espower/-/espower-2.1.0.tgz",
-      "integrity": "sha1-zh7bPZhwKEH99ZbRy46FvcSujkg=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/espower/-/espower-2.1.1.tgz",
+      "integrity": "sha512-F4TY1qYJB1aUyzB03NsZksZzUQmQoEBaTUjRJGR30GxbkbjKI41NhCyYjrF+bGgWN7x/ZsczYppRpz/0WdI0ug==",
       "dev": true,
       "requires": {
         "array-find": "1.0.0",
@@ -4529,7 +4519,7 @@
         "escodegen": "1.9.1",
         "escope": "3.6.0",
         "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0",
         "source-map": "0.5.7",
         "type-name": "2.0.2",
@@ -4583,7 +4573,7 @@
         "convert-source-map": "1.5.1",
         "empower-assert": "1.1.0",
         "escodegen": "1.9.1",
-        "espower": "2.1.0",
+        "espower": "2.1.1",
         "estraverse": "4.2.0",
         "merge-estraverse-visitors": "1.0.0",
         "multi-stage-sourcemap": "0.2.1",
@@ -4624,9 +4614,9 @@
       "dev": true
     },
     "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
+      "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "requires": {
         "core-js": "2.5.6"
       }
@@ -4887,11 +4877,12 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
-      "integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+      "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.0.2",
         "glob-parent": "3.1.0",
         "is-glob": "4.0.0",
         "merge2": "1.2.2",
@@ -4972,7 +4963,7 @@
       "dev": true,
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -5004,9 +4995,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "requires": {
         "debug": "3.1.0"
       }
@@ -5086,14 +5077,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5174,7 +5165,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5352,7 +5343,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.10.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5363,7 +5354,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -5461,12 +5452,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -5767,7 +5758,7 @@
       "requires": {
         "array-union": "1.0.2",
         "dir-glob": "2.0.0",
-        "fast-glob": "2.2.1",
+        "fast-glob": "2.2.2",
         "glob": "7.1.2",
         "ignore": "3.3.8",
         "pify": "3.0.0",
@@ -5775,14 +5766,14 @@
       }
     },
     "google-auth-library": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.4.0.tgz",
-      "integrity": "sha512-vWRx6pJulK7Y5V/Xyr7MPMlx2mWfmrUVbcffZ7hpq8ElFg5S8WY6PvjMovdcr6JfuAwwpAX4R0I1XOcyWuBcUw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.5.0.tgz",
+      "integrity": "sha512-xpibA/hkq4waBcpIkSJg4GiDAqcBWjJee3c47zj7xP3RQ0A9mc8MP3Vc9sc8SGRoDYA0OszZxTjW7SbcC4pJIA==",
       "requires": {
         "axios": "0.18.0",
         "gcp-metadata": "0.6.3",
         "gtoken": "2.3.0",
-        "jws": "3.1.4",
+        "jws": "3.1.5",
         "lodash.isstring": "4.0.1",
         "lru-cache": "4.1.3",
         "retry-axios": "0.3.2"
@@ -5793,10 +5784,10 @@
       "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
       "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "gcp-metadata": "0.6.3",
-        "google-auth-library": "1.4.0",
-        "request": "2.85.0"
+        "google-auth-library": "1.5.0",
+        "request": "2.87.0"
       }
     },
     "google-gax": {
@@ -5899,9 +5890,9 @@
       "dev": true
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "grpc": {
@@ -5912,7 +5903,7 @@
         "lodash": "4.17.10",
         "nan": "2.10.0",
         "node-pre-gyp": "0.10.0",
-        "protobufjs": "5.0.2"
+        "protobufjs": "5.0.3"
       },
       "dependencies": {
         "abbrev": {
@@ -6203,9 +6194,9 @@
           "bundled": true
         },
         "protobufjs": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
-          "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
           "requires": {
             "ascli": "1.0.1",
             "bytebuffer": "5.0.1",
@@ -6337,7 +6328,7 @@
       "requires": {
         "axios": "0.18.0",
         "google-p12-pem": "1.0.2",
-        "jws": "3.1.4",
+        "jws": "3.1.5",
         "mime": "2.3.1",
         "pify": "3.0.0"
       }
@@ -6456,27 +6447,11 @@
       "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
       "dev": true
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -6501,7 +6476,7 @@
       "dev": true,
       "requires": {
         "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
+        "domhandler": "2.4.2",
         "domutils": "1.7.0",
         "entities": "1.1.1",
         "inherits": "2.0.3",
@@ -6620,7 +6595,7 @@
       "dev": true
     },
     "ink-docstrap": {
-      "version": "git+https://github.com/docstrap/docstrap.git#0fff6c83ab7f9154b27c0996b775f1639037df9b",
+      "version": "git+https://github.com/docstrap/docstrap.git#1e56828b819bcbc9855543bd20809a0aed415a80",
       "dev": true,
       "requires": {
         "moment": "2.22.1",
@@ -7229,23 +7204,21 @@
       "dev": true
     },
     "jwa": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "requires": {
-        "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.9",
+        "ecdsa-sig-formatter": "1.0.10",
         "safe-buffer": "5.1.2"
       }
     },
     "jws": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "base64url": "2.0.0",
-        "jwa": "1.1.5",
+        "jwa": "1.1.6",
         "safe-buffer": "5.1.2"
       }
     },
@@ -7433,9 +7406,9 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
     },
     "lolex": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.4.1.tgz",
-      "integrity": "sha512-8QdNQMqlAE2kkc2YWR3Ld0evgE452mmyYZR4HTh54PeH8UAjDipHYh/FHq6y9cAvM68nxGxj5jAz97+WQ2AQEQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
+      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
       "dev": true
     },
     "long": {
@@ -7484,9 +7457,9 @@
       }
     },
     "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
         "pify": "3.0.0"
@@ -7800,33 +7773,22 @@
       }
     },
     "mocha": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
-      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
+        "commander": "2.15.1",
         "debug": "3.1.0",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
+        "supports-color": "5.4.0"
       }
     },
     "modelo": {
@@ -7933,7 +7895,7 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.4.1",
+        "lolex": "2.6.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -7998,9 +7960,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.7.2.tgz",
-      "integrity": "sha512-gBt7qwsR1vryYfglVjQRx1D+AtMZW5NbUKxb+lZe8SN8KsheGCPGWEsSC9AGQG+r2+te1+10uPHUCahuqm1nGQ==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.8.0.tgz",
+      "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -8249,6 +8211,11 @@
                 "kind-of": "6.0.2"
               }
             },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
             "kind-of": {
               "version": "6.0.2",
               "bundled": true,
@@ -8311,6 +8278,13 @@
             "to-object-path": "0.3.0",
             "union-value": "1.0.0",
             "unset-value": "1.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "caching-transform": {
@@ -8369,6 +8343,11 @@
               "requires": {
                 "is-descriptor": "0.1.6"
               }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
             }
           }
         },
@@ -8509,6 +8488,11 @@
                 "is-data-descriptor": "1.0.0",
                 "kind-of": "6.0.2"
               }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
@@ -8830,6 +8814,13 @@
             "get-value": "2.0.6",
             "has-values": "1.0.0",
             "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "has-values": {
@@ -8841,6 +8832,24 @@
             "kind-of": "4.0.0"
           },
           "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
             "kind-of": {
               "version": "4.0.0",
               "bundled": true,
@@ -8986,6 +8995,13 @@
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "is-stream": {
@@ -9328,6 +9344,16 @@
             "to-regex": "3.0.2"
           },
           "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
             "kind-of": {
               "version": "6.0.2",
               "bundled": true,
@@ -9390,6 +9416,13 @@
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "object.pick": {
@@ -9398,6 +9431,13 @@
           "dev": true,
           "requires": {
             "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "once": {
@@ -9794,6 +9834,11 @@
                 "kind-of": "6.0.2"
               }
             },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
             "kind-of": {
               "version": "6.0.2",
               "bundled": true,
@@ -9959,6 +10004,256 @@
             "object-assign": "4.1.1",
             "read-pkg-up": "1.0.1",
             "require-main-filename": "1.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              }
+            }
           }
         },
         "to-fast-properties": {
@@ -9992,6 +10287,16 @@
           "requires": {
             "is-number": "3.0.0",
             "repeat-string": "1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            }
           }
         },
         "trim-right": {
@@ -10093,6 +10398,11 @@
             },
             "has-values": {
               "version": "0.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "isobject": {
+              "version": "3.0.1",
               "bundled": true,
               "dev": true
             }
@@ -10798,7 +11108,7 @@
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
         "core-js": "2.5.6",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -10953,14 +11263,14 @@
         "@protobufjs/pool": "1.1.0",
         "@protobufjs/utf8": "1.1.0",
         "@types/long": "3.0.32",
-        "@types/node": "8.10.13",
+        "@types/node": "8.10.17",
         "long": "4.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.13.tgz",
-          "integrity": "sha512-AorNXRHoPVxIUIVmr6uJXRnvlPOSNKAJF5jZ1JOj1/IxYMocZzvQooNeLU02Db6kpy1IVIySTOvuIxmUF1HrOg=="
+          "version": "8.10.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
+          "integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg=="
         },
         "long": {
           "version": "4.0.0",
@@ -11142,9 +11452,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -11183,7 +11493,7 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
+        "regenerate": "1.4.0",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -11257,9 +11567,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -11269,7 +11579,6 @@
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
@@ -11279,10 +11588,21 @@
         "performance-now": "2.1.0",
         "qs": "6.5.2",
         "safe-buffer": "5.1.2",
-        "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "require-directory": {
@@ -11398,7 +11718,7 @@
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
       "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
       "requires": {
-        "request": "2.85.0",
+        "request": "2.87.0",
         "through2": "2.0.3"
       }
     },
@@ -11572,7 +11892,7 @@
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.5.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.4.1",
+        "lolex": "2.6.0",
         "nise": "1.3.3",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
@@ -11617,7 +11937,7 @@
         "extend-shallow": "2.0.1",
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
+        "source-map-resolve": "0.5.2",
         "use": "3.1.0"
       },
       "dependencies": {
@@ -11711,14 +12031,6 @@
         }
       }
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.1"
-      }
-    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -11734,9 +12046,9 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
         "atob": "2.1.1",
         "decode-uri-component": "0.2.0",
@@ -11746,9 +12058,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-      "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
         "buffer-from": "1.0.0",
@@ -11929,11 +12241,6 @@
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -12264,6 +12571,13 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "tweetnacl": {
@@ -12547,6 +12861,12 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
     },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
+    },
     "use": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
@@ -12701,7 +13021,7 @@
       "requires": {
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pify": "3.0.0",
         "sort-keys": "2.0.0",
         "write-file-atomic": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@google-cloud/nodejs-repo-tools": "^2.3.0",
     "@types/mocha": "^5.0.0",
     "@types/node": "^10.0.5",
+    "codecov": "^3.0.2",
     "duplexify": "^3.6.0",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -81,15 +81,16 @@
       }
     },
     "@google-cloud/firestore": {
-      "version": "0.13.1",
+      "version": "0.14.0",
       "requires": {
-        "@google-cloud/common": "0.17.0",
+        "@google-cloud/common": "0.18.8",
         "@google-cloud/common-grpc": "0.6.1",
         "bun": "0.0.12",
         "deep-equal": "1.0.1",
         "extend": "3.0.1",
         "functional-red-black-tree": "1.0.1",
         "google-gax": "0.16.1",
+        "google-proto-files": "0.15.1",
         "is": "3.2.1",
         "safe-buffer": "5.1.2",
         "through2": "2.0.3"
@@ -158,27 +159,23 @@
           }
         },
         "@google-cloud/common": {
-          "version": "0.17.0",
+          "version": "0.18.8",
           "bundled": true,
           "requires": {
-            "array-uniq": "1.0.3",
+            "@types/duplexify": "3.5.0",
+            "@types/request": "2.47.0",
             "arrify": "1.0.1",
-            "concat-stream": "1.6.2",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.4",
+            "axios": "0.18.0",
+            "duplexify": "3.6.0",
             "ent": "2.2.0",
             "extend": "3.0.1",
-            "google-auto-auth": "0.10.1",
+            "google-auth-library": "1.5.0",
             "is": "3.2.1",
-            "log-driver": "1.2.7",
-            "methmeth": "1.1.0",
-            "modelo": "4.2.3",
-            "request": "2.85.0",
+            "pify": "3.0.0",
+            "request": "2.87.0",
             "retry-request": "3.3.1",
-            "split-array-stream": "1.0.3",
-            "stream-events": "1.0.4",
-            "string-format-obj": "1.1.1",
-            "through2": "2.0.3"
+            "split-array-stream": "2.0.0",
+            "stream-events": "1.0.4"
           }
         },
         "@google-cloud/common-grpc": {
@@ -187,13 +184,47 @@
           "requires": {
             "@google-cloud/common": "0.17.0",
             "dot-prop": "4.2.0",
-            "duplexify": "3.5.4",
+            "duplexify": "3.6.0",
             "extend": "3.0.1",
-            "grpc": "1.11.0",
+            "grpc": "1.11.3",
             "is": "3.2.1",
             "modelo": "4.2.3",
             "retry-request": "3.3.1",
             "through2": "2.0.3"
+          },
+          "dependencies": {
+            "@google-cloud/common": {
+              "version": "0.17.0",
+              "bundled": true,
+              "requires": {
+                "array-uniq": "1.0.3",
+                "arrify": "1.0.1",
+                "concat-stream": "1.6.2",
+                "create-error-class": "3.0.2",
+                "duplexify": "3.6.0",
+                "ent": "2.2.0",
+                "extend": "3.0.1",
+                "google-auto-auth": "0.10.1",
+                "is": "3.2.1",
+                "log-driver": "1.2.7",
+                "methmeth": "1.1.0",
+                "modelo": "4.2.3",
+                "request": "2.87.0",
+                "retry-request": "3.3.1",
+                "split-array-stream": "1.0.3",
+                "stream-events": "1.0.4",
+                "string-format-obj": "1.1.1",
+                "through2": "2.0.3"
+              }
+            },
+            "split-array-stream": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "async": "2.6.1",
+                "is-stream-ended": "0.1.4"
+              }
+            }
           }
         },
         "@google-cloud/nodejs-repo-tools": {
@@ -1719,6 +1750,10 @@
             "glob-to-regexp": "0.3.0"
           }
         },
+        "@nodelib/fs.stat": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "@protobufjs/aspromise": {
           "version": "1.1.2",
           "bundled": true
@@ -1774,6 +1809,24 @@
             "samsam": "1.3.0"
           }
         },
+        "@types/caseless": {
+          "version": "0.12.1",
+          "bundled": true
+        },
+        "@types/duplexify": {
+          "version": "3.5.0",
+          "bundled": true,
+          "requires": {
+            "@types/node": "10.1.2"
+          }
+        },
+        "@types/form-data": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "@types/node": "10.1.2"
+          }
+        },
         "@types/long": {
           "version": "3.0.32",
           "bundled": true
@@ -1783,7 +1836,21 @@
           "bundled": true
         },
         "@types/node": {
-          "version": "9.6.8",
+          "version": "10.1.2",
+          "bundled": true
+        },
+        "@types/request": {
+          "version": "2.47.0",
+          "bundled": true,
+          "requires": {
+            "@types/caseless": "0.12.1",
+            "@types/form-data": "2.2.1",
+            "@types/node": "10.1.2",
+            "@types/tough-cookie": "2.3.3"
+          }
+        },
+        "@types/tough-cookie": {
+          "version": "2.3.3",
           "bundled": true
         },
         "acorn": {
@@ -1978,6 +2045,10 @@
             "sprintf-js": "1.0.3"
           }
         },
+        "argv": {
+          "version": "0.0.2",
+          "bundled": true
+        },
         "arr-diff": {
           "version": "4.0.0",
           "bundled": true
@@ -2050,7 +2121,7 @@
           "bundled": true
         },
         "async": {
-          "version": "2.6.0",
+          "version": "2.6.1",
           "bundled": true,
           "requires": {
             "lodash": "4.17.10"
@@ -2133,7 +2204,7 @@
             "lodash.difference": "4.5.0",
             "lodash.flatten": "4.4.0",
             "loud-rejection": "1.6.0",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "matcher": "1.1.0",
             "md5-hex": "2.0.0",
             "meow": "3.7.0",
@@ -2150,7 +2221,7 @@
             "safe-buffer": "5.1.2",
             "semver": "5.5.0",
             "slash": "1.0.0",
-            "source-map-support": "0.5.5",
+            "source-map-support": "0.5.6",
             "stack-utils": "1.0.1",
             "strip-ansi": "4.0.0",
             "strip-bom-buf": "1.0.0",
@@ -2223,7 +2294,7 @@
           "version": "0.18.0",
           "bundled": true,
           "requires": {
-            "follow-redirects": "1.4.1",
+            "follow-redirects": "1.5.0",
             "is-buffer": "1.1.6"
           }
         },
@@ -2415,9 +2486,9 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "espower-location-detector": "1.0.0",
-            "espurify": "1.7.0",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0"
           }
         },
@@ -2532,7 +2603,7 @@
           "requires": {
             "babel-core": "6.26.3",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.10",
             "mkdirp": "0.5.1",
@@ -2552,7 +2623,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2654,10 +2725,6 @@
             }
           }
         },
-        "base64url": {
-          "version": "2.0.0",
-          "bundled": true
-        },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "bundled": true,
@@ -2673,13 +2740,6 @@
         "bluebird": {
           "version": "3.5.1",
           "bundled": true
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
         },
         "boxen": {
           "version": "1.3.0",
@@ -2875,9 +2935,9 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "deep-equal": "1.0.1",
-            "espurify": "1.7.0",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0"
           }
         },
@@ -2955,7 +3015,7 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
-            "fsevents": "1.2.3",
+            "fsevents": "1.2.4",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -3109,6 +3169,15 @@
           "version": "1.1.0",
           "bundled": true
         },
+        "codecov": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "argv": "0.0.2",
+            "request": "2.87.0",
+            "urlgrey": "0.4.4"
+          }
+        },
         "collection-visit": {
           "version": "1.0.0",
           "bundled": true,
@@ -3144,7 +3213,7 @@
           }
         },
         "commander": {
-          "version": "2.11.0",
+          "version": "2.15.1",
           "bundled": true
         },
         "common-path-prefix": {
@@ -3205,7 +3274,7 @@
           "requires": {
             "dot-prop": "4.2.0",
             "graceful-fs": "4.1.11",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "unique-string": "1.0.0",
             "write-file-atomic": "2.3.0",
             "xdg-basedir": "3.0.0"
@@ -3236,7 +3305,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.5",
+          "version": "2.5.6",
           "bundled": true
         },
         "core-util-is": {
@@ -3254,25 +3323,9 @@
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "shebang-command": "1.2.0",
             "which": "1.3.0"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            }
           }
         },
         "crypto-random-string": {
@@ -3437,7 +3490,7 @@
           "bundled": true
         },
         "diff-match-patch": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "dir-glob": {
@@ -3474,7 +3527,7 @@
           "bundled": true
         },
         "domhandler": {
-          "version": "2.4.1",
+          "version": "2.4.2",
           "bundled": true,
           "requires": {
             "domelementtype": "1.3.0"
@@ -3500,7 +3553,7 @@
           "bundled": true
         },
         "duplexify": {
-          "version": "3.5.4",
+          "version": "3.6.0",
           "bundled": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -3522,10 +3575,9 @@
           }
         },
         "ecdsa-sig-formatter": {
-          "version": "1.0.9",
+          "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "base64url": "2.0.0",
             "safe-buffer": "5.1.2"
           }
         },
@@ -3533,7 +3585,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "empower-core": "0.6.2"
           }
         },
@@ -3549,7 +3601,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "end-of-stream": {
@@ -3805,7 +3857,7 @@
           "bundled": true
         },
         "espower": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "requires": {
             "array-find": "1.0.0",
@@ -3813,7 +3865,7 @@
             "escodegen": "1.9.1",
             "escope": "3.6.0",
             "espower-location-detector": "1.0.0",
-            "espurify": "1.7.0",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0",
             "source-map": "0.5.7",
             "type-name": "2.0.2",
@@ -3859,7 +3911,7 @@
             "convert-source-map": "1.5.1",
             "empower-assert": "1.1.0",
             "escodegen": "1.9.1",
-            "espower": "2.1.0",
+            "espower": "2.1.1",
             "estraverse": "4.2.0",
             "merge-estraverse-visitors": "1.0.0",
             "multi-stage-sourcemap": "0.2.1",
@@ -3892,10 +3944,10 @@
           "bundled": true
         },
         "espurify": {
-          "version": "1.7.0",
+          "version": "1.8.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5"
+            "core-js": "2.5.6"
           }
         },
         "esquery": {
@@ -3981,16 +4033,16 @@
           "version": "1.8.2",
           "bundled": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "2.2.4"
           },
           "dependencies": {
             "fill-range": {
-              "version": "2.2.3",
+              "version": "2.2.4",
               "bundled": true,
               "requires": {
                 "is-number": "2.1.0",
                 "isobject": "2.1.0",
-                "randomatic": "1.1.7",
+                "randomatic": "3.0.0",
                 "repeat-element": "1.1.2",
                 "repeat-string": "1.6.1"
               }
@@ -4044,7 +4096,7 @@
           "bundled": true,
           "requires": {
             "chardet": "0.4.2",
-            "iconv-lite": "0.4.21",
+            "iconv-lite": "0.4.23",
             "tmp": "0.0.33"
           }
         },
@@ -4114,13 +4166,14 @@
           "bundled": true
         },
         "fast-glob": {
-          "version": "2.2.1",
+          "version": "2.2.2",
           "bundled": true,
           "requires": {
             "@mrmlnc/readdir-enhanced": "2.2.1",
+            "@nodelib/fs.stat": "1.0.2",
             "glob-parent": "3.1.0",
             "is-glob": "4.0.0",
-            "merge2": "1.2.1",
+            "merge2": "1.2.2",
             "micromatch": "3.1.10"
           }
         },
@@ -4183,7 +4236,7 @@
           "bundled": true,
           "requires": {
             "commondir": "1.0.1",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "pkg-dir": "2.0.0"
           }
         },
@@ -4209,7 +4262,7 @@
           "bundled": true
         },
         "follow-redirects": {
-          "version": "1.4.1",
+          "version": "1.5.0",
           "bundled": true,
           "requires": {
             "debug": "3.1.0"
@@ -4397,7 +4450,7 @@
           "requires": {
             "array-union": "1.0.2",
             "dir-glob": "2.0.0",
-            "fast-glob": "2.2.1",
+            "fast-glob": "2.2.2",
             "glob": "7.1.2",
             "ignore": "3.3.8",
             "pify": "3.0.0",
@@ -4405,15 +4458,15 @@
           }
         },
         "google-auth-library": {
-          "version": "1.4.0",
+          "version": "1.5.0",
           "bundled": true,
           "requires": {
             "axios": "0.18.0",
             "gcp-metadata": "0.6.3",
             "gtoken": "2.3.0",
-            "jws": "3.1.4",
+            "jws": "3.1.5",
             "lodash.isstring": "4.0.1",
-            "lru-cache": "4.1.2",
+            "lru-cache": "4.1.3",
             "retry-axios": "0.3.2"
           }
         },
@@ -4421,22 +4474,22 @@
           "version": "0.10.1",
           "bundled": true,
           "requires": {
-            "async": "2.6.0",
+            "async": "2.6.1",
             "gcp-metadata": "0.6.3",
-            "google-auth-library": "1.4.0",
-            "request": "2.85.0"
+            "google-auth-library": "1.5.0",
+            "request": "2.87.0"
           }
         },
         "google-gax": {
           "version": "0.16.1",
           "bundled": true,
           "requires": {
-            "duplexify": "3.5.4",
+            "duplexify": "3.6.0",
             "extend": "3.0.1",
             "globby": "8.0.1",
             "google-auto-auth": "0.10.1",
             "google-proto-files": "0.15.1",
-            "grpc": "1.11.0",
+            "grpc": "1.11.3",
             "is-stream-ended": "0.1.4",
             "lodash": "4.17.10",
             "protobufjs": "6.8.6",
@@ -4515,32 +4568,22 @@
           "bundled": true
         },
         "growl": {
-          "version": "1.10.3",
+          "version": "1.10.5",
           "bundled": true
         },
         "grpc": {
-          "version": "1.11.0",
+          "version": "1.11.3",
           "bundled": true,
           "requires": {
             "lodash": "4.17.10",
             "nan": "2.10.0",
-            "node-pre-gyp": "0.7.0",
-            "protobufjs": "5.0.2"
+            "node-pre-gyp": "0.10.0",
+            "protobufjs": "5.0.3"
           },
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
               "bundled": true
-            },
-            "ajv": {
-              "version": "5.5.2",
-              "bundled": true,
-              "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
-              }
             },
             "ansi-regex": {
               "version": "2.1.1",
@@ -4558,51 +4601,9 @@
                 "readable-stream": "2.3.6"
               }
             },
-            "asn1": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "asynckit": {
-              "version": "0.4.0",
-              "bundled": true
-            },
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.7.0",
-              "bundled": true
-            },
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "bcrypt-pbkdf": {
-              "version": "1.0.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "tweetnacl": "0.14.5"
-              }
-            },
-            "block-stream": {
-              "version": "0.0.9",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3"
-              }
-            },
-            "boom": {
-              "version": "4.3.1",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -4612,24 +4613,13 @@
                 "concat-map": "0.0.1"
               }
             },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "co": {
-              "version": "4.6.0",
+            "chownr": {
+              "version": "1.0.1",
               "bundled": true
             },
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              }
             },
             "concat-map": {
               "version": "0.0.1",
@@ -4643,29 +4633,6 @@
               "version": "1.0.2",
               "bundled": true
             },
-            "cryptiles": {
-              "version": "3.1.2",
-              "bundled": true,
-              "requires": {
-                "boom": "5.2.0"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "5.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.1"
-                  }
-                }
-              }
-            },
-            "dashdash": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
             "debug": {
               "version": "2.6.9",
               "bundled": true,
@@ -4674,11 +4641,7 @@
               }
             },
             "deep-extend": {
-              "version": "0.4.2",
-              "bundled": true
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
+              "version": "0.5.1",
               "bundled": true
             },
             "delegates": {
@@ -4689,65 +4652,16 @@
               "version": "1.0.3",
               "bundled": true
             },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "jsbn": "0.1.1"
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "extsprintf": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "fast-deep-equal": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "fast-json-stable-stringify": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.2",
+            "fs-minipass": {
+              "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "minipass": "2.2.4"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
-              }
             },
             "gauge": {
               "version": "2.7.4",
@@ -4763,13 +4677,6 @@
                 "wide-align": "1.1.2"
               }
             },
-            "getpass": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0"
-              }
-            },
             "glob": {
               "version": "7.1.2",
               "bundled": true,
@@ -4782,47 +4689,19 @@
                 "path-is-absolute": "1.0.1"
               }
             },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "har-schema": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
-              }
-            },
             "has-unicode": {
               "version": "2.0.1",
               "bundled": true
             },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
-              }
-            },
-            "hoek": {
-              "version": "4.2.1",
+            "iconv-lite": {
+              "version": "0.4.19",
               "bundled": true
             },
-            "http-signature": {
-              "version": "1.2.0",
+            "ignore-walk": {
+              "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "minimatch": "3.0.4"
               }
             },
             "inflight": {
@@ -4848,55 +4727,9 @@
                 "number-is-nan": "1.0.1"
               }
             },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
             "isarray": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "jsbn": {
-              "version": "0.1.1",
-              "bundled": true,
-              "optional": true
-            },
-            "json-schema": {
-              "version": "0.2.3",
-              "bundled": true
-            },
-            "json-schema-traverse": {
-              "version": "0.3.1",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "jsprim": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-              }
-            },
-            "mime-db": {
-              "version": "1.33.0",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.18",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.33.0"
-              }
             },
             "minimatch": {
               "version": "3.0.4",
@@ -4908,6 +4741,21 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "2.2.4"
+              }
             },
             "mkdirp": {
               "version": "0.5.1",
@@ -4926,20 +4774,29 @@
               "version": "2.0.0",
               "bundled": true
             },
+            "needle": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "iconv-lite": "0.4.19",
+                "sax": "1.2.4"
+              }
+            },
             "node-pre-gyp": {
-              "version": "0.7.0",
+              "version": "0.10.0",
               "bundled": true,
               "requires": {
                 "detect-libc": "1.0.3",
                 "mkdirp": "0.5.1",
+                "needle": "2.2.1",
                 "nopt": "4.0.1",
+                "npm-packlist": "1.1.10",
                 "npmlog": "4.1.2",
-                "rc": "1.2.6",
-                "request": "2.83.0",
+                "rc": "1.2.7",
                 "rimraf": "2.6.2",
                 "semver": "5.5.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.1"
+                "tar": "4.4.2"
               }
             },
             "nopt": {
@@ -4948,6 +4805,18 @@
               "requires": {
                 "abbrev": "1.1.1",
                 "osenv": "0.1.5"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "requires": {
+                "ignore-walk": "3.0.1",
+                "npm-bundled": "1.0.3"
               }
             },
             "npmlog": {
@@ -4962,10 +4831,6 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
               "bundled": true
             },
             "object-assign": {
@@ -4999,16 +4864,12 @@
               "version": "1.0.1",
               "bundled": true
             },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
             "process-nextick-args": {
               "version": "2.0.0",
               "bundled": true
             },
             "protobufjs": {
-              "version": "5.0.2",
+              "version": "5.0.3",
               "bundled": true,
               "requires": {
                 "ascli": "1.0.1",
@@ -5017,19 +4878,11 @@
                 "yargs": "3.32.0"
               }
             },
-            "punycode": {
-              "version": "1.4.1",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
             "rc": {
-              "version": "1.2.6",
+              "version": "1.2.7",
               "bundled": true,
               "requires": {
-                "deep-extend": "0.4.2",
+                "deep-extend": "0.5.1",
                 "ini": "1.3.5",
                 "minimist": "1.2.0",
                 "strip-json-comments": "2.0.1"
@@ -5048,34 +4901,6 @@
                 "util-deprecate": "1.0.2"
               }
             },
-            "request": {
-              "version": "2.83.0",
-              "bundled": true,
-              "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
-              }
-            },
             "rimraf": {
               "version": "2.6.2",
               "bundled": true,
@@ -5085,6 +4910,10 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
               "bundled": true
             },
             "semver": {
@@ -5098,27 +4927,6 @@
             "signal-exit": {
               "version": "3.0.2",
               "bundled": true
-            },
-            "sntp": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
-            },
-            "sshpk": {
-              "version": "1.14.1",
-              "bundled": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-              }
             },
             "string-width": {
               "version": "1.0.2",
@@ -5136,10 +4944,6 @@
                 "safe-buffer": "5.1.1"
               }
             },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
@@ -5152,67 +4956,27 @@
               "bundled": true
             },
             "tar": {
-              "version": "2.2.1",
+              "version": "4.4.2",
               "bundled": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.2",
+                "yallist": "3.0.2"
+              },
+              "dependencies": {
+                "safe-buffer": {
+                  "version": "5.1.2",
+                  "bundled": true
+                }
               }
-            },
-            "tar-pack": {
-              "version": "3.4.1",
-              "bundled": true,
-              "requires": {
-                "debug": "2.6.9",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.3.6",
-                "rimraf": "2.6.2",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.3.4",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "tweetnacl": {
-              "version": "0.14.5",
-              "bundled": true,
-              "optional": true
-            },
-            "uid-number": {
-              "version": "0.0.6",
-              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "uuid": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "verror": {
-              "version": "1.10.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-              }
             },
             "wide-align": {
               "version": "1.1.2",
@@ -5224,6 +4988,10 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
             }
           }
         },
@@ -5233,7 +5001,7 @@
           "requires": {
             "axios": "0.18.0",
             "google-p12-pem": "1.0.2",
-            "jws": "3.1.4",
+            "jws": "3.1.5",
             "mime": "2.3.1",
             "pify": "3.0.0"
           }
@@ -5329,22 +5097,8 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
-        },
         "he": {
           "version": "1.1.1",
-          "bundled": true
-        },
-        "hoek": {
-          "version": "4.2.1",
           "bundled": true
         },
         "home-or-tmp": {
@@ -5364,7 +5118,7 @@
           "bundled": true,
           "requires": {
             "domelementtype": "1.3.0",
-            "domhandler": "2.4.1",
+            "domhandler": "2.4.2",
             "domutils": "1.7.0",
             "entities": "1.1.1",
             "inherits": "2.0.3",
@@ -5405,7 +5159,7 @@
           }
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.23",
           "bundled": true,
           "requires": {
             "safer-buffer": "2.1.2"
@@ -5460,7 +5214,7 @@
           "bundled": true
         },
         "ink-docstrap": {
-          "version": "git+https://github.com/docstrap/docstrap.git#0fff6c83ab7f9154b27c0996b775f1639037df9b",
+          "version": "git+https://github.com/docstrap/docstrap.git#1e56828b819bcbc9855543bd20809a0aed415a80",
           "bundled": true,
           "requires": {
             "moment": "2.22.1",
@@ -5937,21 +5691,19 @@
           "bundled": true
         },
         "jwa": {
-          "version": "1.1.5",
+          "version": "1.1.6",
           "bundled": true,
           "requires": {
-            "base64url": "2.0.0",
             "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.9",
+            "ecdsa-sig-formatter": "1.0.10",
             "safe-buffer": "5.1.2"
           }
         },
         "jws": {
-          "version": "3.1.4",
+          "version": "3.1.5",
           "bundled": true,
           "requires": {
-            "base64url": "2.0.0",
-            "jwa": "1.1.5",
+            "jwa": "1.1.6",
             "safe-buffer": "5.1.2"
           }
         },
@@ -6092,7 +5844,7 @@
           "bundled": true
         },
         "lolex": {
-          "version": "2.3.2",
+          "version": "2.6.0",
           "bundled": true
         },
         "long": {
@@ -6123,7 +5875,7 @@
           "bundled": true
         },
         "lru-cache": {
-          "version": "4.1.2",
+          "version": "4.1.3",
           "bundled": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -6131,7 +5883,7 @@
           }
         },
         "make-dir": {
-          "version": "1.2.0",
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
             "pify": "3.0.0"
@@ -6162,6 +5914,10 @@
           "requires": {
             "escape-string-regexp": "1.0.5"
           }
+        },
+        "math-random": {
+          "version": "1.0.1",
+          "bundled": true
         },
         "md5-hex": {
           "version": "2.0.0",
@@ -6289,7 +6045,7 @@
           }
         },
         "merge2": {
-          "version": "1.2.1",
+          "version": "1.2.2",
           "bundled": true
         },
         "methmeth": {
@@ -6378,29 +6134,20 @@
           }
         },
         "mocha": {
-          "version": "5.1.1",
+          "version": "5.2.0",
           "bundled": true,
           "requires": {
             "browser-stdout": "1.3.1",
-            "commander": "2.11.0",
+            "commander": "2.15.1",
             "debug": "3.1.0",
             "diff": "3.5.0",
             "escape-string-regexp": "1.0.5",
             "glob": "7.1.2",
-            "growl": "1.10.3",
+            "growl": "1.10.5",
             "he": "1.1.1",
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
-            "supports-color": "4.4.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "4.4.0",
-              "bundled": true,
-              "requires": {
-                "has-flag": "2.0.0"
-              }
-            }
+            "supports-color": "5.4.0"
           }
         },
         "modelo": {
@@ -6485,7 +6232,7 @@
           "requires": {
             "@sinonjs/formatio": "2.0.0",
             "just-extend": "1.1.27",
-            "lolex": "2.3.2",
+            "lolex": "2.6.0",
             "path-to-regexp": "1.7.0",
             "text-encoding": "0.6.4"
           }
@@ -6538,7 +6285,7 @@
           "bundled": true
         },
         "nyc": {
-          "version": "11.7.1",
+          "version": "11.8.0",
           "bundled": true,
           "requires": {
             "archy": "1.0.0",
@@ -6559,7 +6306,7 @@
             "istanbul-reports": "1.4.0",
             "md5-hex": "1.3.0",
             "merge-source-map": "1.1.0",
-            "micromatch": "2.3.11",
+            "micromatch": "3.1.10",
             "mkdirp": "0.5.1",
             "resolve-from": "2.0.0",
             "rimraf": "2.6.2",
@@ -6603,11 +6350,8 @@
               "bundled": true
             },
             "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "arr-flatten": "1.1.0"
-              }
+              "version": "4.0.0",
+              "bundled": true
             },
             "arr-flatten": {
               "version": "1.1.0",
@@ -6618,7 +6362,7 @@
               "bundled": true
             },
             "array-unique": {
-              "version": "0.2.1",
+              "version": "0.3.2",
               "bundled": true
             },
             "arrify": {
@@ -6634,7 +6378,7 @@
               "bundled": true
             },
             "atob": {
-              "version": "2.1.0",
+              "version": "2.1.1",
               "bundled": true
             },
             "babel-code-frame": {
@@ -6655,7 +6399,7 @@
                 "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
               }
@@ -6671,7 +6415,7 @@
               "version": "6.26.0",
               "bundled": true,
               "requires": {
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "regenerator-runtime": "0.11.1"
               }
             },
@@ -6683,7 +6427,7 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
               }
             },
             "babel-traverse": {
@@ -6698,7 +6442,7 @@
                 "debug": "2.6.9",
                 "globals": "9.18.0",
                 "invariant": "2.2.4",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
               }
             },
             "babel-types": {
@@ -6707,7 +6451,7 @@
               "requires": {
                 "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "to-fast-properties": "1.0.3"
               }
             },
@@ -6781,12 +6525,28 @@
               }
             },
             "braces": {
-              "version": "1.8.5",
+              "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
               }
             },
             "builtin-modules": {
@@ -6921,14 +6681,14 @@
               "bundled": true
             },
             "core-js": {
-              "version": "2.5.5",
+              "version": "2.5.6",
               "bundled": true
             },
             "cross-spawn": {
               "version": "4.0.2",
               "bundled": true,
               "requires": {
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "which": "1.3.0"
               }
             },
@@ -7038,7 +6798,7 @@
                   "version": "5.1.0",
                   "bundled": true,
                   "requires": {
-                    "lru-cache": "4.1.2",
+                    "lru-cache": "4.1.3",
                     "shebang-command": "1.2.0",
                     "which": "1.3.0"
                   }
@@ -7046,17 +6806,32 @@
               }
             },
             "expand-brackets": {
-              "version": "0.1.5",
+              "version": "2.1.4",
               "bundled": true,
               "requires": {
-                "is-posix-bracket": "0.1.1"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "requires": {
-                "fill-range": "2.2.3"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
               }
             },
             "extend-shallow": {
@@ -7077,25 +6852,79 @@
               }
             },
             "extglob": {
-              "version": "0.3.2",
+              "version": "2.0.4",
               "bundled": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "1.0.0",
+                    "is-data-descriptor": "1.0.0",
+                    "kind-of": "6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
               }
             },
-            "filename-regex": {
-              "version": "2.0.1",
-              "bundled": true
-            },
             "fill-range": {
-              "version": "2.2.3",
+              "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
               }
             },
             "find-cache-dir": {
@@ -7117,13 +6946,6 @@
             "for-in": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "for-own": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "for-in": "1.0.2"
-              }
             },
             "foreground-child": {
               "version": "1.5.6",
@@ -7166,21 +6988,6 @@
                 "minimatch": "3.0.4",
                 "once": "1.4.0",
                 "path-is-absolute": "1.0.1"
-              }
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-glob": "2.0.1"
               }
             },
             "globals": {
@@ -7344,23 +7151,8 @@
                 }
               }
             },
-            "is-dotfile": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "bundled": true,
-              "requires": {
-                "is-primitive": "2.0.0"
-              }
-            },
             "is-extendable": {
               "version": "0.1.1",
-              "bundled": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
               "bundled": true
             },
             "is-finite": {
@@ -7374,15 +7166,8 @@
               "version": "2.0.0",
               "bundled": true
             },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
             "is-number": {
-              "version": "2.1.0",
+              "version": "3.0.0",
               "bundled": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -7414,14 +7199,6 @@
                 }
               }
             },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "bundled": true
-            },
             "is-stream": {
               "version": "1.1.0",
               "bundled": true
@@ -7443,11 +7220,8 @@
               "bundled": true
             },
             "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
+              "version": "3.0.1",
+              "bundled": true
             },
             "istanbul-lib-coverage": {
               "version": "1.2.0",
@@ -7572,7 +7346,7 @@
               }
             },
             "lodash": {
-              "version": "4.17.5",
+              "version": "4.17.10",
               "bundled": true
             },
             "longest": {
@@ -7587,7 +7361,7 @@
               }
             },
             "lru-cache": {
-              "version": "4.1.2",
+              "version": "4.1.3",
               "bundled": true,
               "requires": {
                 "pseudomap": "1.0.2",
@@ -7637,22 +7411,28 @@
               }
             },
             "micromatch": {
-              "version": "2.3.11",
+              "version": "3.1.10",
               "bundled": true,
               "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
               }
             },
             "mimic-fn": {
@@ -7740,13 +7520,6 @@
                 "validate-npm-package-license": "3.0.3"
               }
             },
-            "normalize-path": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "remove-trailing-separator": "1.1.0"
-              }
-            },
             "npm-run-path": {
               "version": "2.0.2",
               "bundled": true,
@@ -7791,14 +7564,6 @@
                   "version": "3.0.1",
                   "bundled": true
                 }
-              }
-            },
-            "object.omit": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
               }
             },
             "object.pick": {
@@ -7863,16 +7628,6 @@
             "p-try": {
               "version": "1.0.0",
               "bundled": true
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-              }
             },
             "parse-json": {
               "version": "2.2.0",
@@ -7949,46 +7704,9 @@
               "version": "0.1.1",
               "bundled": true
             },
-            "preserve": {
-              "version": "0.2.0",
-              "bundled": true
-            },
             "pseudomap": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "randomatic": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
-              },
-              "dependencies": {
-                "is-number": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "is-buffer": "1.1.6"
-                      }
-                    }
-                  }
-                },
-                "kind-of": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
             },
             "read-pkg": {
               "version": "1.1.0",
@@ -8021,13 +7739,6 @@
               "version": "0.11.1",
               "bundled": true
             },
-            "regex-cache": {
-              "version": "0.4.4",
-              "bundled": true,
-              "requires": {
-                "is-equal-shallow": "0.1.3"
-              }
-            },
             "regex-not": {
               "version": "1.0.2",
               "bundled": true,
@@ -8035,10 +7746,6 @@
                 "extend-shallow": "3.0.2",
                 "safe-regex": "1.1.0"
               }
-            },
-            "remove-trailing-separator": {
-              "version": "1.1.0",
-              "bundled": true
             },
             "repeat-element": {
               "version": "1.1.2",
@@ -8237,7 +7944,7 @@
               "version": "0.5.1",
               "bundled": true,
               "requires": {
-                "atob": "2.1.0",
+                "atob": "2.1.1",
                 "decode-uri-component": "0.2.0",
                 "resolve-url": "0.2.1",
                 "source-map-url": "0.4.0",
@@ -8817,7 +8524,7 @@
               "version": "11.1.0",
               "bundled": true,
               "requires": {
-                "cliui": "4.0.0",
+                "cliui": "4.1.0",
                 "decamelize": "1.2.0",
                 "find-up": "2.1.0",
                 "get-caller-file": "1.0.2",
@@ -8840,7 +8547,7 @@
                   "bundled": true
                 },
                 "cliui": {
-                  "version": "4.0.0",
+                  "version": "4.1.0",
                   "bundled": true,
                   "requires": {
                     "string-width": "2.1.1",
@@ -9281,7 +8988,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -9291,8 +8998,8 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.5",
-            "espurify": "1.7.0",
+            "core-js": "2.5.6",
+            "espurify": "1.8.0",
             "estraverse": "4.2.0"
           }
         },
@@ -9300,7 +9007,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "estraverse": "4.2.0"
           }
         },
@@ -9308,7 +9015,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -9333,8 +9040,8 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
-            "diff-match-patch": "1.0.0",
+            "core-js": "2.5.6",
+            "diff-match-patch": "1.0.1",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
             "type-name": "2.0.2"
@@ -9344,7 +9051,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -9421,12 +9128,12 @@
             "@protobufjs/pool": "1.1.0",
             "@protobufjs/utf8": "1.1.0",
             "@types/long": "3.0.32",
-            "@types/node": "8.10.11",
+            "@types/node": "8.10.17",
             "long": "4.0.0"
           },
           "dependencies": {
             "@types/node": {
-              "version": "8.10.11",
+              "version": "8.10.17",
               "bundled": true
             },
             "long": {
@@ -9462,7 +9169,7 @@
           "bundled": true
         },
         "qs": {
-          "version": "6.5.1",
+          "version": "6.5.2",
           "bundled": true
         },
         "query-string": {
@@ -9475,19 +9182,17 @@
           }
         },
         "randomatic": {
-          "version": "1.1.7",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "4.0.0",
+            "kind-of": "6.0.2",
+            "math-random": "1.0.1"
           },
           "dependencies": {
-            "kind-of": {
+            "is-number": {
               "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "bundled": true
             }
           }
         },
@@ -9578,7 +9283,7 @@
           }
         },
         "regenerate": {
-          "version": "1.3.3",
+          "version": "1.4.0",
           "bundled": true
         },
         "regenerator-runtime": {
@@ -9608,7 +9313,7 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "regenerate": "1.3.3",
+            "regenerate": "1.4.0",
             "regjsgen": "0.2.0",
             "regjsparser": "0.1.5"
           }
@@ -9666,7 +9371,7 @@
           }
         },
         "request": {
-          "version": "2.85.0",
+          "version": "2.87.0",
           "bundled": true,
           "requires": {
             "aws-sign2": "0.7.0",
@@ -9677,7 +9382,6 @@
             "forever-agent": "0.6.1",
             "form-data": "2.3.2",
             "har-validator": "5.0.3",
-            "hawk": "6.0.2",
             "http-signature": "1.2.0",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
@@ -9685,12 +9389,21 @@
             "mime-types": "2.1.18",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "safe-buffer": "5.1.2",
-            "stringstream": "0.0.5",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.2.1"
+          },
+          "dependencies": {
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            }
           }
         },
         "require-directory": {
@@ -9778,7 +9491,7 @@
           "version": "3.3.1",
           "bundled": true,
           "requires": {
-            "request": "2.85.0",
+            "request": "2.87.0",
             "through2": "2.0.3"
           }
         },
@@ -9914,7 +9627,7 @@
             "@sinonjs/formatio": "2.0.0",
             "diff": "3.5.0",
             "lodash.get": "4.4.2",
-            "lolex": "2.3.2",
+            "lolex": "2.6.0",
             "nise": "1.3.3",
             "supports-color": "5.4.0",
             "type-detect": "4.0.8"
@@ -9951,7 +9664,7 @@
             "extend-shallow": "2.0.1",
             "map-cache": "0.2.2",
             "source-map": "0.5.7",
-            "source-map-resolve": "0.5.1",
+            "source-map-resolve": "0.5.2",
             "use": "3.1.0"
           },
           "dependencies": {
@@ -10035,13 +9748,6 @@
             }
           }
         },
-        "sntp": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        },
         "sort-keys": {
           "version": "2.0.0",
           "bundled": true,
@@ -10054,7 +9760,7 @@
           "bundled": true
         },
         "source-map-resolve": {
-          "version": "0.5.1",
+          "version": "0.5.2",
           "bundled": true,
           "requires": {
             "atob": "2.1.1",
@@ -10065,7 +9771,7 @@
           }
         },
         "source-map-support": {
-          "version": "0.5.5",
+          "version": "0.5.6",
           "bundled": true,
           "requires": {
             "buffer-from": "1.0.0",
@@ -10107,10 +9813,9 @@
           "bundled": true
         },
         "split-array-stream": {
-          "version": "1.0.3",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "async": "2.6.0",
             "is-stream-ended": "0.1.4"
           }
         },
@@ -10211,14 +9916,10 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.5",
+            "core-js": "2.5.6",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -10269,7 +9970,7 @@
             "formidable": "1.2.1",
             "methods": "1.1.2",
             "mime": "1.6.0",
-            "qs": "6.5.1",
+            "qs": "6.5.2",
             "readable-stream": "2.3.6"
           },
           "dependencies": {
@@ -10477,6 +10178,12 @@
           "bundled": true,
           "requires": {
             "safe-buffer": "5.1.2"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            }
           }
         },
         "tweetnacl": {
@@ -10706,6 +10413,10 @@
           "version": "1.0.1",
           "bundled": true
         },
+        "urlgrey": {
+          "version": "0.4.4",
+          "bundled": true
+        },
         "use": {
           "version": "3.1.0",
           "bundled": true,
@@ -10827,7 +10538,7 @@
           "requires": {
             "detect-indent": "5.0.0",
             "graceful-fs": "4.1.11",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "pify": "3.0.0",
             "sort-keys": "2.0.0",
             "write-file-atomic": "2.3.0"
@@ -10979,7 +10690,7 @@
             "lodash.difference": "4.5.0",
             "lodash.flatten": "4.4.0",
             "loud-rejection": "1.6.0",
-            "make-dir": "1.2.0",
+            "make-dir": "1.3.0",
             "matcher": "1.1.0",
             "md5-hex": "2.0.0",
             "meow": "3.7.0",
@@ -10996,7 +10707,7 @@
             "safe-buffer": "5.1.2",
             "semver": "5.5.0",
             "slash": "1.0.0",
-            "source-map-support": "0.5.5",
+            "source-map-support": "0.5.6",
             "stack-utils": "1.0.1",
             "strip-ansi": "4.0.0",
             "strip-bom-buf": "1.0.0",
@@ -11016,7 +10727,7 @@
             "@sinonjs/formatio": "2.0.0",
             "diff": "3.5.0",
             "lodash.get": "4.4.2",
-            "lolex": "2.3.2",
+            "lolex": "2.6.0",
             "nise": "1.3.3",
             "supports-color": "5.4.0",
             "type-detect": "4.0.8"
@@ -11078,7 +10789,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -11296,7 +11007,7 @@
         "lodash.difference": "4.5.0",
         "lodash.flatten": "4.4.0",
         "loud-rejection": "1.6.0",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "matcher": "1.1.0",
         "md5-hex": "2.0.0",
         "meow": "3.7.0",
@@ -11620,9 +11331,9 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "espower-location-detector": "1.0.0",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -11767,7 +11478,7 @@
       "requires": {
         "babel-core": "6.26.3",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -11791,7 +11502,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -12002,9 +11713,9 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.6",
         "deep-equal": "1.0.1",
-        "espurify": "1.7.0",
+        "espurify": "1.8.0",
         "estraverse": "4.2.0"
       }
     },
@@ -12066,7 +11777,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -12270,7 +11981,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -12305,9 +12016,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
       "dev": true
     },
     "core-util-is": {
@@ -12331,7 +12042,7 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -12450,7 +12161,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "equal-length": {
@@ -12499,12 +12210,12 @@
       "dev": true
     },
     "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
+      "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5"
+        "core-js": "2.5.6"
       }
     },
     "estraverse": {
@@ -12549,7 +12260,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "2.2.4"
       }
     },
     "extend": {
@@ -12599,14 +12310,14 @@
       }
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
-        "randomatic": "1.1.7",
+        "randomatic": "3.0.0",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
       }
@@ -12618,7 +12329,7 @@
       "dev": true,
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -12706,13 +12417,13 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -12781,7 +12492,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "optional": true
         },
@@ -12937,7 +12648,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.10.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -12947,7 +12658,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -13033,11 +12744,11 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -13963,9 +13674,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
+      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
       "dev": true
     },
     "longest": {
@@ -14000,9 +13711,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -14010,9 +13721,9 @@
       }
     },
     "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
         "pify": "3.0.0"
@@ -14040,6 +13751,12 @@
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "md5-hex": {
       "version": "2.0.0",
@@ -14307,7 +14024,7 @@
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.3.2",
+        "lolex": "2.6.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -16375,9 +16092,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "query-string": {
@@ -16392,43 +16109,27 @@
       }
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -16522,9 +16223,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -16548,7 +16249,7 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
+        "regenerate": "1.4.0",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -16766,7 +16467,7 @@
         "diff": "3.5.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
+        "lolex": "2.6.0",
         "nise": "1.3.3",
         "supports-color": "4.5.0",
         "type-detect": "4.0.8"
@@ -16820,9 +16521,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-      "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
         "buffer-from": "1.0.0",
@@ -16979,7 +16680,7 @@
         "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.6.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "readable-stream": "2.3.6"
       }
     },
@@ -17385,7 +17086,7 @@
       "requires": {
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pify": "3.0.0",
         "sort-keys": "2.0.0",
         "write-file-atomic": "2.3.0"


### PR DESCRIPTION
For some reason in this library we install `codecov` in the CI step. In all other libraries it's just a dev dependency. I want to make CI configuration files look as much similar as possible across the packages, hence this change.