### PR TITLE
Bumping version to 0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
This will be the v0.14.1 release.

Contains:

- [Changed] Reduced the module load time by lazy-loading the network stack.
- [Fixed] Fixed the export type of the `Query` class (#200)
- [Fixed] Firestore now allows storing of objects created with`Object.create(null)` (#193)

I didn't change the package.info in samples/package.json since I can't update the package-lock until after the release is published. Follow up PR coming.
