### PR TITLE
Drop Node 4/9 support and Lint pre-submit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,37 +3,22 @@ workflows:
   version: 2
   tests:
     jobs: &workflow_jobs
-      - node4:
+      - node6:
           filters: &all_commits
             tags:
               only: /.*/
-      - node6:
-          filters: *all_commits
       - node8:
-          filters: *all_commits
-      - node9:
           filters: *all_commits
       - node10:
           filters: *all_commits
-      - lint:
-          requires:
-            - node4
-            - node6
-            - node8
-            - node9
-            - node10
-          filters: *all_commits
       - docs:
           requires:
-            - node4
             - node6
             - node8
-            - node9
             - node10
           filters: *all_commits
       - system_tests:
           requires:
-            - lint
             - docs
           filters:
             branches:
@@ -56,9 +41,9 @@ workflows:
               only: master
     jobs: *workflow_jobs
 jobs:
-  node4:
+  node6:
     docker:
-      - image: 'node:4'
+      - image: 'node:6'
         user: node
     steps: &unit_tests_steps
       - checkout
@@ -87,19 +72,9 @@ jobs:
           name: Submit coverage data to codecov.
           command: node_modules/.bin/codecov
           when: always
-  node6:
-    docker:
-      - image: 'node:6'
-        user: node
-    steps: *unit_tests_steps
   node8:
     docker:
       - image: 'node:8'
-        user: node
-    steps: *unit_tests_steps
-  node9:
-    docker:
-      - image: 'node:9'
         user: node
     steps: *unit_tests_steps
   node10:
@@ -107,20 +82,9 @@ jobs:
       - image: 'node:10'
         user: node
     steps: *unit_tests_steps
-  lint:
-    docker:
-      - image: 'node:8'
-        user: node
-    steps:
-      - checkout
-      - run: *remove_package_lock
-      - run: *npm_install_and_link
-      - run:
-          name: Run linting.
-          command: npm run lint
   docs:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout
@@ -131,7 +95,7 @@ jobs:
           command: npm run docs
   system_tests:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout
@@ -157,7 +121,7 @@ jobs:
           when: always
   publish_npm:
     docker:
-      - image: 'node:8'
+      - image: 'node:10'
         user: node
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "repository": "googleapis/nodejs-firestore",
   "main": "./build/src/index.js",


### PR DESCRIPTION
Drop Node 4/9 support and disable the linting step (since it uses eslint).