### PR TITLE
Removing assert that fails the system-tests on CI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -455,11 +455,7 @@ class Firestore {
    * for existing documents, otherwise a DocumentSnapshot.
    */
   snapshot_(documentOrName, readTime, encoding) {
-    if (!this._initalizationSettings.projectId) {
-      throw new Error(
-          'Cannot use `snapshot_()` without a Project ID. Please provide a ' +
-          'Project ID via `Firestore.settings()`.');
-    }
+    // TODO: Assert that Firestore Project ID is valid.
 
     let convertTimestamp;
     let convertDocument;

--- a/test/index.js
+++ b/test/index.js
@@ -540,17 +540,6 @@ describe('snapshot_() method', function() {
     });
   });
 
-  it('validates Project ID provided', function() {
-    firestore = new Firestore({
-      sslCreds: grpc.credentials.createInsecure(),
-      keyFilename: './test/fake-certificate.json'
-    });
-
-    assert.throws(
-        () => firestore.snapshot_(),
-        /Cannot use `snapshot_\(\)` without a Project ID. Please provide a Project ID via `Firestore.settings\(\)`./);
-  });
-
   it('handles ProtobufJS', function() {
     let doc = firestore.snapshot_(
         document('doc', {


### PR DESCRIPTION
Removing an assert that fails the system-tests in the release validation. This assert was just added in https://github.com/googleapis/nodejs-firestore/pull/257

We eventually want to re-work our Project ID detection and can address the TODO at that point.