### PR TITLE
Allow `npm publish` to use `tsc`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,4 +127,5 @@ jobs:
     steps:
       - checkout
       - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run: *npm_install_and_link
       - run: npm publish


### PR DESCRIPTION
NPM publish needs to install the typescript dependency to be able to publish.

See https://circleci.com/gh/googleapis/nodejs-firestore/7128
