### PR TITLE
Configuring test credentials for CI environments

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,6 @@
 environment:
+  GOOGLE_APPLICATION_CREDENTIALS: build/test/fake-certificate.json
+
   matrix:
   - nodejs_version: 8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,11 @@ jobs:
             npm install
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
-      - run: npm run test-only
+      - run:
+          name: Run unit tests
+          command: npm run test-only
+          environment:
+            GOOGLE_APPLICATION_CREDENTIALS: build/test/fake-certificate.json
       - run: npm run codecov
   node8:
     docker:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "generate-scaffolding": "repo-tools generate all",
     "system-test": "mocha build/system-test --timeout 600000",
     "conformance": "mocha build/conformance",
-    "test-only": "GOOGLE_APPLICATION_CREDENTIALS=build/test/fake-certificate.json nyc mocha build/test",
+    "test-only": "nyc mocha build/test",
     "test": "npm run test-only",
     "check": "gts check",
     "clean": "gts clean",


### PR DESCRIPTION
Moving the GCLOUD_APPLICATION_DEFAULT_CREDENTIALS to environment variables in CicleCI and AppVeyor, which should fix the AppVeyor build.