### PR TITLE
Bumping Firestore to v0.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
     "test": "npm run ava"
   },
   "dependencies": {
-    "@google-cloud/firestore": "^0.15.2"
+    "@google-cloud/firestore": "^0.15.3"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",


### PR DESCRIPTION
Release fix for #271 to allow `noImplicitAny: true`.