### PR TITLE
Using the package root to find the package.json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const pkgUp = require('pkg-up');
 const through = require('through2');
 const util = require('util');
 
-const libVersion = require(pkgUp.sync()).version;
+const libVersion = require(pkgUp.sync(__dirname)).version;
 
 const path = require('./path');
 const convert = require('./convert');

--- a/src/v1beta1/firestore_client.js
+++ b/src/v1beta1/firestore_client.js
@@ -20,7 +20,7 @@ const merge = require('lodash.merge');
 const path = require('path');
 const pkgUp = require('pkg-up');
 
-const VERSION = require(pkgUp.sync()).version;
+const VERSION = require(pkgUp.sync(__dirname)).version;
 
 /**
  * The Cloud Firestore service.

--- a/system-test/firestore.js
+++ b/system-test/firestore.js
@@ -24,7 +24,7 @@ let DocumentReference = require('../src/reference').DocumentReference;
 let DocumentSnapshot =
     require('../src/document')(DocumentReference).DocumentSnapshot;
 
-let version = require(pkgUp.sync()).version;
+let version = require(pkgUp.sync(__dirname)).version;
 let Firestore = require('../src');
 
 if (process.env.NODE_ENV === 'DEBUG') {


### PR DESCRIPTION
If we don't pass __dirname, `pkg-up` will use the users source folder instead of ours to extract the package.json.

Fixes https://github.com/googleapis/nodejs-firestore/issues/278