### PR TITLE
Bumping version to v0.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
     "test": "npm run ava"
   },
   "dependencies": {
-    "@google-cloud/firestore": "^0.15.3"
+    "@google-cloud/firestore": "^0.15.4"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",


### PR DESCRIPTION
v0.15.4 fixes:
- #277: Client always uses Application Default Credentials
- #278: Client uses the user's package.json instead of ours