### PR TITLE
Using import instead of require

### DIFF
--- a/src/backoff.js
+++ b/src/backoff.js
@@ -221,10 +221,10 @@ class ExponentialBackoff {
   }
 }
 
-module.exports = FirestoreType => {
+export function backoffPkg(FirestoreType) {
   Firestore = FirestoreType;
   return {
     ExponentialBackoff,
     setTimeoutHandler,
   };
-};
+}

--- a/src/convert.js
+++ b/src/convert.js
@@ -16,8 +16,11 @@
 
 'use strict';
 
-const is = require('is');
-const validate = require('./validate')();
+import is from 'is';
+
+import {validatePkg} from './validate';
+
+const validate = validatePkg();
 
 /*!
  * @module firestore/convert

--- a/src/document.js
+++ b/src/document.js
@@ -16,43 +16,14 @@
 
 'use strict';
 
-const assert = require('assert');
-const deepEqual = require('deep-equal');
-const is = require('is');
+import assert from 'assert';
+import deepEqual from 'deep-equal';
+import is from 'is';
 
-const fieldValue = require('./field-value');
-const path = require('./path');
-
-/*!
- * @see {ResourcePath}
- */
-const ResourcePath = path.ResourcePath;
-
-/*!
- * @see {FieldPath}
- */
-const FieldPath = path.FieldPath;
-
-/*!
- * @see {FieldTransform}
- */
-
-const FieldTransform = fieldValue.FieldTransform;
-
-/*!
- * @see {DeleteTransform}
- */
-const DeleteTransform = fieldValue.DeleteTransform;
-
-/*!
- * @see {ServerTimestampTransform}
- */
-const ServerTimestampTransform = fieldValue.ServerTimestampTransform;
-
-/*!
- * @see {Timestamp}
- */
-const Timestamp = require('./timestamp');
+import {FieldTransform, DeleteTransform, ServerTimestampTransform} from './field-value';
+import {FieldPath, ResourcePath} from './path';
+import {Timestamp} from './timestamp';
+import {validatePkg} from './validate';
 
 /*!
  * Injected.
@@ -1594,9 +1565,9 @@ function isPlainObject(input) {
        Object.getPrototypeOf(input) === null));
 }
 
-module.exports = DocumentRefType => {
+export function documentPkg(DocumentRefType) {
   DocumentReference = DocumentRefType;
-  validate = require('./validate')({
+  validate = validatePkg({
     FieldPath: FieldPath.validateFieldPath,
     PlainObject: isPlainObject,
   });

--- a/src/index.js
+++ b/src/index.js
@@ -16,18 +16,27 @@
 
 'use strict';
 
-const assert = require('assert');
-const bun = require('bun');
-const extend = require('extend');
-const is = require('is');
-const pkgUp = require('pkg-up');
-const through = require('through2');
-const util = require('util');
+import assert from 'assert';
+import bun from 'bun';
+import extend from 'extend';
+import is from 'is';
+import pkgUp from 'pkg-up';
+import through2 from 'through2';
+import util from 'util';
+
+import {referencePkg} from './reference';
+import {documentPkg} from './document';
+import {FieldValue} from './field-value';
+import {validatePkg} from './validate';
+import {writeBatchPkg} from './write-batch';
+import {transactionPkg} from './transaction';
+import {Timestamp} from './timestamp';
+import {FieldPath, ResourcePath} from './path';
+import {ClientPool} from './pool';
+
+import * as convert from './convert';
 
 const libVersion = require(pkgUp.sync(__dirname)).version;
-
-const path = require('./path');
-const convert = require('./convert');
 
 /*!
  * DO NOT REMOVE THE FOLLOWING NAMESPACE DEFINITIONS
@@ -45,30 +54,6 @@ const convert = require('./convert');
  * @namespace google.firestore.v1beta1
  */
 
-/*!
- * @see ResourcePath
- */
-const ResourcePath = path.ResourcePath;
-
-/*!
- * @see ResourcePath
- */
-const FieldPath = path.FieldPath;
-
-/*!
- * @see FieldValue
- */
-const FieldValue = require('./field-value').FieldValue;
-
-/*!
- * @see Timestamp
- */
-const Timestamp = require('./timestamp');
-
-/*!
- * @see ClientPool
- */
-const ClientPool = require('./pool').ClientPool;
 
 /*!
  * @see CollectionReference
@@ -1130,7 +1115,7 @@ follow these steps, YOUR APP MAY BREAK.`);
                        'Sending request: %j', decorated.request);
                    let stream = gapicClient[methodName](
                        decorated.request, decorated.gax);
-                   let logger = through.obj(function(chunk, enc, callback) {
+                   let logger = through2.obj(function(chunk, enc, callback) {
                      Firestore.log(
                          'Firestore.readStream', requestTag,
                          'Received response: %j', chunk);
@@ -1183,7 +1168,7 @@ follow these steps, YOUR APP MAY BREAK.`);
           let requestStream = gapicClient[methodName]({}, decorated.gax);
 
           // The transform stream to assign the project ID.
-          let transform = through.obj(function(chunk, encoding, callback) {
+          let transform = through2.obj(function(chunk, encoding, callback) {
             let decoratedChunk = extend(true, {}, chunk);
             common.util.replaceProjectIdToken(
                 decoratedChunk, self._referencePath.projectId);
@@ -1193,7 +1178,7 @@ follow these steps, YOUR APP MAY BREAK.`);
             requestStream.write(decoratedChunk, encoding, callback);
           });
 
-          let logger = through.obj(function(chunk, enc, callback) {
+          let logger = through2.obj(function(chunk, enc, callback) {
             Firestore.log(
                 'Firestore.readWriteStream', requestTag,
                 'Received response: %j', chunk);
@@ -1248,19 +1233,19 @@ Firestore.setLogFunction = function(logger) {
 };
 
 // Initializing dependencies that require that Firestore class type.
-const reference = require('./reference')(Firestore);
+const reference = referencePkg(Firestore);
 CollectionReference = reference.CollectionReference;
 DocumentReference = reference.DocumentReference;
-const document = require('./document')(DocumentReference);
+const document = documentPkg(DocumentReference);
 DocumentSnapshot = document.DocumentSnapshot;
 GeoPoint = document.GeoPoint;
-validate = require('./validate')({
+validate = validatePkg({
   DocumentReference: reference.validateDocumentReference,
   ResourcePath: ResourcePath.validateResourcePath,
 });
-const batch = require('./write-batch')(Firestore, DocumentReference);
+const batch = writeBatchPkg(Firestore, DocumentReference);
 WriteBatch = batch.WriteBatch;
-Transaction = require('./transaction')(Firestore);
+Transaction = transactionPkg(Firestore);
 
 /**
  * The default export of the `@google-cloud/firestore` package is the

--- a/src/order.js
+++ b/src/order.js
@@ -16,13 +16,12 @@
 
 'use strict';
 
-const is = require('is');
-const validate = require('./validate')();
+import is from 'is';
 
-/*!
- * @see ResourcePath
- */
-const ResourcePath = require('./path').ResourcePath;
+import {ResourcePath} from './path';
+import {validatePkg} from './validate';
+
+const validate = validatePkg({});
 
 /*!
  * The type order as defined by the backend.

--- a/src/path.ts
+++ b/src/path.ts
@@ -16,9 +16,11 @@
 
 'use strict';
 
-const is = require('is');
+import is from 'is';
 
-const validate = require('./validate')();
+import {validatePkg} from './validate';
+
+const validate = validatePkg({});
 
 /*!
  * A regular expression to verify an absolute Resource Path in Firestore. It

--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -16,8 +16,11 @@
 
 'use strict';
 
-const is = require('is');
-const validate = require('./validate')();
+import is from 'is';
+
+import {validatePkg} from './validate';
+
+const validate = validatePkg({});
 
 /*!
  * Number of nanoseconds in a millisecond.
@@ -37,7 +40,7 @@ const MS_TO_NANOS = 1000000;
  *
  * @see https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto
  */
-class Timestamp {
+export class Timestamp {
   /**
    * Creates a new timestamp with the current date, with millisecond precision.
    *
@@ -238,5 +241,3 @@ class Timestamp {
     return timestamp;
   }
 }
-
-module.exports = Timestamp;

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -16,7 +16,10 @@
 
 'use strict';
 
-const is = require('is');
+import is from 'is';
+
+import {referencePkg} from './reference';
+import {validatePkg} from './validate';
 
 /*! Injected. */
 let validate;
@@ -356,13 +359,13 @@ class Transaction {
   }
 }
 
-module.exports = FirestoreType => {
-  let reference = require('./reference')(FirestoreType);
+export function transactionPkg(FirestoreType) {
+  let reference = referencePkg(FirestoreType);
   DocumentReference = reference.DocumentReference;
   Query = reference.Query;
   Firestore = FirestoreType;
-  validate = require('./validate')({
+  validate = validatePkg({
     DocumentReference: reference.validateDocumentReference,
   });
   return Transaction;
-};
+}

--- a/src/validate.js
+++ b/src/validate.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-const is = require('is');
+import is from 'is';
 
 /**
  * Formats the given word as plural conditionally given the preceding number.
@@ -45,7 +45,7 @@ function formatPlural(num, str) {
  * @returns {Object.<string, function>} Map with validators following the naming
  * convention is{Type} and isOptional{Type}.
  */
-module.exports = validators => {
+export function validatePkg(validators) {
   validators = Object.assign(
       {
         function: is.function,

--- a/src/watch.js
+++ b/src/watch.js
@@ -16,9 +16,13 @@
 
 'use strict';
 
-const assert = require('assert');
-const rbtree = require('functional-red-black-tree');
-const through = require('through2');
+import assert from 'assert';
+import rbtree from 'functional-red-black-tree';
+import through2 from 'through2';
+
+import {backoffPkg} from './backoff';
+import {Timestamp} from './timestamp';
+import {ResourcePath} from './path';
 
 /*!
  * Injected.
@@ -54,16 +58,6 @@ let DocumentSnapshot;
  * @see Firestore
  */
 let Firestore;
-
-/*!
- * @see ResourcePath
- */
-let ResourcePath = require('./path').ResourcePath;
-
-/*!
- * @see Timestamp
- */
-const Timestamp = require('./timestamp');
 
 /*!
  * Target ID used by watch. Watch uses a fixed target id since we only support
@@ -386,7 +380,7 @@ class Watch {
 
     // We may need to replace the underlying stream on reset events.
     // This is the one that will be returned and proxy the current one.
-    const stream = through.obj();
+    const stream = through2.obj();
     // The current stream to the backend.
     let currentStream = null;
 
@@ -809,16 +803,16 @@ class Watch {
   }
 }
 
-module.exports =
-    (FirestoreType, DocumentChangeType, DocumentReferenceType,
-     DocumentSnapshotType) => {
-      Firestore = FirestoreType;
-      DocumentChange = DocumentChangeType;
-      DocumentReference = DocumentReferenceType;
-      DocumentSnapshot = DocumentSnapshotType;
+export function watchPkg(
+    FirestoreType, DocumentChangeType, DocumentReferenceType,
+    DocumentSnapshotType) {
+  Firestore = FirestoreType;
+  DocumentChange = DocumentChangeType;
+  DocumentReference = DocumentReferenceType;
+  DocumentSnapshot = DocumentSnapshotType;
 
-      const backoff = require('./backoff')(FirestoreType);
-      ExponentialBackoff = backoff.ExponentialBackoff;
+  const backoff = backoffPkg(FirestoreType);
+  ExponentialBackoff = backoff.ExponentialBackoff;
 
-      return Watch;
-    };
+  return Watch;
+}

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -16,8 +16,13 @@
 
 'use strict';
 
-const assert = require('assert');
-const is = require('is');
+import assert from 'assert';
+import is from 'is';
+
+import {documentPkg} from './document';
+import {validatePkg} from './validate';
+import {FieldPath} from './path';
+import {Timestamp} from './timestamp';
 
 /*!
  * Injected.
@@ -43,12 +48,6 @@ let DocumentTransform;
 /*!
  * @see FieldPath
  */
-const FieldPath = require('./path').FieldPath;
-
-/*!
- * @see Timestamp
- */
-const Timestamp = require('./timestamp');
 
 /*!
  * Injected.
@@ -625,28 +624,28 @@ function validateUpdateMap(data) {
   return true;
 }
 
-module.exports =
-    (FirestoreType, DocumentReferenceType, validateDocumentReference) => {
-      let document = require('./document')(DocumentReferenceType);
-      Firestore = FirestoreType;
-      DocumentMask = document.DocumentMask;
-      DocumentSnapshot = document.DocumentSnapshot;
-      DocumentTransform = document.DocumentTransform;
-      Precondition = document.Precondition;
-      validate = require('./validate')({
-        Document: document.validateDocumentData,
-        DocumentReference: validateDocumentReference,
-        FieldValue: document.validateFieldValue,
-        FieldPath: FieldPath.validateFieldPath,
-        UpdatePrecondition: precondition => document.validatePrecondition(
-            precondition, /* allowExists= */ false),
-        DeletePrecondition: precondition => document.validatePrecondition(
-            precondition, /* allowExists= */ true),
-        SetOptions: document.validateSetOptions,
-        UpdateMap: validateUpdateMap,
-      });
-      return {
-        WriteBatch,
-        WriteResult,
-      };
-    };
+export function writeBatchPkg(
+    FirestoreType, DocumentReferenceType, validateDocumentReference) {
+  let document = documentPkg(DocumentReferenceType);
+  Firestore = FirestoreType;
+  DocumentMask = document.DocumentMask;
+  DocumentSnapshot = document.DocumentSnapshot;
+  DocumentTransform = document.DocumentTransform;
+  Precondition = document.Precondition;
+  validate = validatePkg({
+    Document: document.validateDocumentData,
+    DocumentReference: validateDocumentReference,
+    FieldValue: document.validateFieldValue,
+    FieldPath: FieldPath.validateFieldPath,
+    UpdatePrecondition: precondition =>
+        document.validatePrecondition(precondition, /* allowExists= */ false),
+    DeletePrecondition: precondition =>
+        document.validatePrecondition(precondition, /* allowExists= */ true),
+    SetOptions: document.validateSetOptions,
+    UpdateMap: validateUpdateMap,
+  });
+  return {
+    WriteBatch,
+    WriteResult,
+  };
+}

--- a/system-test/firestore.js
+++ b/system-test/firestore.js
@@ -16,16 +16,15 @@
 
 'use strict';
 
-let assert = require('power-assert');
-let is = require('is');
-let pkgUp = require('pkg-up');
+import * as assert from 'power-assert';
+import is from 'is';
+import pkgUp from 'pkg-up';
 
-let DocumentReference = require('../src/reference').DocumentReference;
-let DocumentSnapshot =
-    require('../src/document')(DocumentReference).DocumentSnapshot;
+import Firestore from '../src';
+
+const DocumentSnapshot = Firestore.DocumentSnapshot;
 
 let version = require(pkgUp.sync(__dirname)).version;
-let Firestore = require('../src');
 
 if (process.env.NODE_ENV === 'DEBUG') {
   Firestore.setLogFunction(console.log);

--- a/test/backoff.js
+++ b/test/backoff.js
@@ -16,11 +16,12 @@
 
 'use strict';
 
-const assert = require('power-assert');
+import assert from 'power-assert';
 
-const Firestore = require('../src');
-const backoff = require('../src/backoff')(Firestore);
+import {Firestore} from '../src/index';
+import {backoffPkg} from '../src/backoff';
 
+const backoff = backoffPkg(Firestore);
 const ExponentialBackoff = backoff.ExponentialBackoff;
 const setTimeoutHandler = backoff.setTimeoutHandler;
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -16,15 +16,15 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
-const is = require('is');
+import assert from 'power-assert';
+import is from 'is';
 
-const Firestore = require('../src');
-const DocumentReference =
-    require('../src/reference')(Firestore).DocumentReference;
-const createInstance = require('../test/util/helpers').createInstance;
+import {Firestore} from '../src/index';
+import {referencePkg} from '../src/reference';
+import {createInstance} from '../test/util/helpers';
+
+const reference = referencePkg(Firestore);
+const DocumentReference = reference.DocumentReference;
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});

--- a/test/document.js
+++ b/test/document.js
@@ -16,15 +16,13 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const extend = require('extend');
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
-const is = require('is');
-const through = require('through2');
+import assert from 'power-assert';
+import extend from 'extend';
+import is from 'is';
+import through2 from 'through2';
 
-const Firestore = require('../src');
-const createInstance = require('../test/util/helpers').createInstance;
+import {Firestore} from '../src/index';
+import {createInstance} from '../test/util/helpers';
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
@@ -174,7 +172,7 @@ function requestEquals(actual, protoOperation) {
 }
 
 function stream() {
-  let stream = through.obj();
+  let stream = through2.obj();
   let args = arguments;
 
   setImmediate(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -16,19 +16,22 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const extend = require('extend');
+import assert from 'power-assert';
+import extend from 'extend';
+import is from 'is';
+import through2 from 'through2';
+
+import {Firestore} from '../src/index';
+import {referencePkg} from '../src/reference';
+import {ResourcePath} from '../src/path';
+import {createInstance} from '../test/util/helpers';
+
 const gax = require('google-gax');
 const grpc = new gax.GrpcClient().grpc;
-const is = require('is');
-const through = require('through2');
 
-const Firestore = require('../src');
-const reference = require('../src/reference')(Firestore);
+const reference = referencePkg(Firestore);
 const DocumentReference = reference.DocumentReference;
 const CollectionReference = reference.CollectionReference;
-const ResourcePath = require('../src/path').ResourcePath;
-const createInstance = require('../test/util/helpers').createInstance;
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
@@ -292,7 +295,7 @@ function missing(name) {
 }
 
 function stream() {
-  let stream = through.obj();
+  let stream = through2.obj();
   let args = arguments;
 
   setImmediate(function() {

--- a/test/order.js
+++ b/test/order.js
@@ -16,19 +16,20 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
+import assert from 'power-assert';
 
-const Firestore = require('../src');
-const DocumentReference =
-    require('../src/reference')(Firestore).DocumentReference;
-const document = require('../src/document')(DocumentReference);
+import {Firestore} from '../src/index';
+import {referencePkg} from '../src/reference';
+import {documentPkg} from '../src/document';
+import {createInstance} from '../test/util/helpers';
+import {ResourcePath} from '../src/path';
+import * as order from '../src/order'
+
+const reference = referencePkg(Firestore);
+const DocumentReference = reference.DocumentReference;
+const document = documentPkg(DocumentReference);
 const DocumentSnapshot = document.DocumentSnapshot;
 const GeoPoint = document.GeoPoint;
-const order = require('../src/order');
-const ResourcePath = require('../src/path').ResourcePath;
-const createInstance = require('../test/util/helpers').createInstance;
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});

--- a/test/path.js
+++ b/test/path.js
@@ -16,11 +16,9 @@
 
 'use strict';
 
-const assert = require('power-assert');
+import assert from 'power-assert';
 
-const path = require('../src/path');
-const ResourcePath = path.ResourcePath;
-const FieldPath = path.FieldPath;
+import {FieldPath, ResourcePath} from '../src/path';
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;

--- a/test/query.js
+++ b/test/query.js
@@ -16,20 +16,20 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const extend = require('extend');
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
-const is = require('is');
-const through = require('through2');
+import assert from 'power-assert';
+import extend from 'extend';
+import is from 'is';
+import through2 from 'through2';
 
-const Firestore = require('../src');
-const reference = require('../src/reference')(Firestore);
+import {Firestore} from '../src/index';
+import {referencePkg} from '../src/reference';
+import {documentPkg} from '../src/document';
+import {createInstance} from '../test/util/helpers';
+import {ResourcePath} from '../src/path';
+
+const reference = referencePkg(Firestore);
 const DocumentReference = reference.DocumentReference;
-const DocumentSnapshot =
-    require('../src/document')(DocumentReference).DocumentSnapshot;
-const ResourcePath = require('../src/path').ResourcePath;
-const createInstance = require('../test/util/helpers').createInstance;
+const DocumentSnapshot = documentPkg(Firestore).DocumentSnapshot;
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
@@ -268,7 +268,7 @@ function document(name) {
 }
 
 function stream() {
-  let stream = through.obj();
+  let stream = through2.obj();
   let args = arguments;
 
   setImmediate(function() {

--- a/test/timestamp.js
+++ b/test/timestamp.js
@@ -16,19 +16,18 @@
 
 'use strict';
 
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
-const Firestore = require('../src');
-const is = require('is');
-const through = require('through2');
-const assert = require('assert');
 
-const createInstanceHelper = require('../test/util/helpers').createInstance;
+import {Firestore} from '../src/index';
+import is from 'is';
+import through2 from 'through2';
+import assert from 'assert';
+
+import {createInstance as createInstanceHelper} from '../test/util/helpers';
 
 function createInstance(opts, document) {
   const overrides = {
     batchGetDocuments: () => {
-      const stream = through.obj();
+      const stream = through2.obj();
       setImmediate(function() {
         stream.push({found: document, readTime: {seconds: 5, nanos: 6}});
         stream.push(null);

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -16,13 +16,11 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
-const through = require('through2');
+import assert from 'power-assert';
+import through2 from 'through2';
 
-const Firestore = require('../src');
-const createInstance = require('../test/util/helpers').createInstance;
+import {Firestore} from '../src/index';
+import {createInstance} from '../test/util/helpers';
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
@@ -109,7 +107,7 @@ function getDocument(transaction) {
     transaction: transaction || 'foo',
   };
 
-  let stream = through.obj();
+  let stream = through2.obj();
 
   setImmediate(function() {
     stream.push({
@@ -137,7 +135,7 @@ function getAll(docs) {
     transaction: 'foo',
   };
 
-  let stream = through.obj();
+  let stream = through2.obj();
 
   for (const doc of docs) {
     const name = `${COLLECTION_ROOT}/${doc}`;
@@ -191,7 +189,7 @@ function query(transaction) {
     transaction: transaction || 'foo',
   };
 
-  let stream = through.obj();
+  let stream = through2.obj();
 
   setImmediate(function() {
     stream.push({

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -305,15 +305,16 @@ xdescribe('firestore.d.ts', function() {
 
   it('has typings for FieldValue', () => {
     const documentData: UpdateData = {
-      'foo': FieldValue.serverTimestamp(),
-      'bar': FieldValue.delete()
+      'a': FieldValue.serverTimestamp(),
+      'b': FieldValue.delete(),
+      'c': FieldValue.arrayUnion('foo'),
+      'd': FieldValue.arrayRemove('bar'),
     };
+    const serverTimestamp : FieldValue = FieldValue.serverTimestamp();
+    const deleteField : FieldValue = FieldValue.delete();
+    const arrayUnion : FieldValue = FieldValue.arrayUnion('foo', 'bar');
+    const arrayRemove : FieldValue = FieldValue.arrayRemove('foo', 'bar');
     const equals: boolean = FieldValue.serverTimestamp().isEqual(FieldValue.serverTimestamp());
-  });
-
-  it('has typings for FieldPath', () => {
-    const fieldPath = new FieldPath('foo');
-    const equals: boolean = FieldPath.documentId().isEqual(fieldPath);
   });
 
   it('has typings for SetOptions', () => {

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -18,9 +18,10 @@
 
 import {GrpcClient} from 'google-gax';
 
-import Firestore from '../../src';
-import {ClientPool} from '../../src/pool';
 import v1beta1 from '../../src/v1beta1';
+
+import {Firestore} from '../../src';
+import {ClientPool} from '../../src/pool';
 
 /* tslint:disable:no-any */
 type GapicClient = any;

--- a/test/watch.js
+++ b/test/watch.js
@@ -16,20 +16,22 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const duplexify = require('duplexify');
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
-const is = require('is');
-const through = require('through2');
+import assert from 'power-assert';
+import duplexify from 'duplexify';
+import is from 'is';
+import through2 from 'through2';
 
-const Firestore = require('../src');
-const reference = require('../src/reference')(Firestore);
+import {Firestore} from '../src/index';
+import {referencePkg} from '../src/reference';
+import {documentPkg} from '../src/document';
+import {backoffPkg} from '../src/backoff';
+import {createInstance} from '../test/util/helpers';
+
+const reference = referencePkg(Firestore);
 const DocumentReference = reference.DocumentReference;
-const DocumentSnapshot =
-    require('../src/document')(DocumentReference).DocumentSnapshot;
-const Backoff = require('../src/backoff')(Firestore);
-const createInstance = require('../test/util/helpers').createInstance;
+const document = documentPkg(DocumentReference);
+const DocumentSnapshot = document.DocumentSnapshot;
+const Backoff = backoffPkg(Firestore);
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});
@@ -192,8 +194,8 @@ class StreamHelper {
       // Create a mock backend whose stream we can return.
       ++this.streamCount;
 
-      this.readStream = through.obj();
-      this.writeStream = through.obj();
+      this.readStream = through2.obj();
+      this.writeStream = through2.obj();
 
       this.readStream.once(
           'data', result => this.deferredListener.on('data', result));
@@ -1024,7 +1026,7 @@ describe('Query watch', function() {
                     listenCallback = () => {
                       // Return a stream that always errors on write
                       ++streamHelper.streamCount;
-                      return through.obj((chunk, enc, callback) => {
+                      return through2.obj((chunk, enc, callback) => {
                         callback(new Error(
                             `Stream Error (${streamHelper.streamCount})`));
                       });

--- a/test/write-batch.js
+++ b/test/write-batch.js
@@ -16,12 +16,10 @@
 
 'use strict';
 
-const assert = require('power-assert');
-const gax = require('google-gax');
-const grpc = new gax.GrpcClient().grpc;
+import assert from 'power-assert';
 
-const Firestore = require('../src');
-const createInstance = require('../test/util/helpers').createInstance;
+import {Firestore} from '../src/index';
+import {createInstance} from '../test/util/helpers';
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": ".",
     "outDir": "build",
     "target": "es6",
-    "noImplicitAny": false // TODO: Remove when all source are migrated to TS
+    "noImplicitAny": false, // TODO: Remove when all source are migrated to TS
+    "allowSyntheticDefaultImports": true // TODO: Remove when all source are migrated to TS
   },
   "include": [
     "src/*.js",


### PR DESCRIPTION
For arrayUnion()/arrayRemove() I need to import DocumentSnapshot. I was hoping that I could get around the circular import hell with this PR. It turns out that doesn't quite help, but the PR is already written, so I propose we do the `require` to `import` migration either way.

This PR also removes the default exports from our internal modules. We only default export Firestore now.