### PR TITLE
Adding Array Transforms

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import util from 'util';
 
 import {referencePkg} from './reference';
 import {documentPkg} from './document';
-import {FieldValue} from './field-value';
+import {fieldValuePkg} from './field-value';
 import {validatePkg} from './validate';
 import {writeBatchPkg} from './write-batch';
 import {transactionPkg} from './transaction';
@@ -74,6 +74,11 @@ let DocumentSnapshot;
  * @see GeoPoint
  */
 let GeoPoint;
+
+/*!
+ * @see FieldValue
+ */
+let FieldValue;
 
 /*! Injected. */
 let validate;
@@ -1246,6 +1251,7 @@ validate = validatePkg({
 const batch = writeBatchPkg(Firestore, DocumentReference);
 WriteBatch = batch.WriteBatch;
 Transaction = transactionPkg(Firestore);
+FieldValue = fieldValuePkg(DocumentSnapshot).FieldValue;
 
 /**
  * The default export of the `@google-cloud/firestore` package is the

--- a/src/reference.js
+++ b/src/reference.js
@@ -1174,10 +1174,10 @@ class Query {
    */
   where(fieldPath, opStr, value) {
     validate.isFieldPath('fieldPath', fieldPath);
-    validate.isFieldComparison('opStr', opStr, value);
-    validate.isFieldValue('value', value, {
+    validate.isQueryComparison('opStr', opStr, value);
+    validate.isQueryValue('value', value, {
       allowDeletes: 'none',
-      allowServerTimestamps: false,
+      allowTransforms: false,
     });
 
     if (this._queryOptions.startAt || this._queryOptions.endAt) {
@@ -1453,9 +1453,9 @@ class Query {
         fieldValue = this._convertReference(fieldValue);
       }
 
-      validate.isFieldValue(i, fieldValue, {
+      validate.isQueryValue(i, fieldValue, {
         allowDeletes: 'none',
-        allowServerTimestamps: false,
+        allowTransforms: false,
       });
 
       options.values.push(DocumentSnapshot.encodeValue(fieldValue));
@@ -2045,7 +2045,7 @@ class CollectionReference extends Query {
     validate.isDocument('data', data, {
       allowEmpty: true,
       allowDeletes: 'none',
-      allowServerTimestamps: true,
+      allowTransforms: true,
     });
 
     let documentRef = this.doc();
@@ -2166,9 +2166,9 @@ export function referencePkg(FirestoreType) {
   validate = validatePkg({
     Document: document.validateDocumentData,
     FieldPath: FieldPath.validateFieldPath,
-    FieldComparison: validateComparisonOperator,
+    QueryComparison: validateComparisonOperator,
     FieldOrder: validateFieldOrder,
-    FieldValue: document.validateFieldValue,
+    QueryValue: document.validateFieldValue,
     Precondition: document.validatePrecondition,
     ResourcePath: ResourcePath.validateResourcePath,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * A union of all of the standard JS types, useful for cases where the type is
+ * unknown. Unlike "any" this doesn't lose all type-safety, since the consuming
+ * code must still cast to a particular type before using it.
+ */
+export type AnyJs = null|undefined|boolean|number|string|object;
+
+// tslint:disable-next-line:no-any
+export type AnyDuringMigration = any;

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -190,7 +190,7 @@ class WriteBatch {
     validate.isDocument('data', data, {
       allowEmpty: true,
       allowDeletes: 'none',
-      allowServerTimestamps: true,
+      allowTransforms: true,
     });
 
     this.verifyNotCommitted();
@@ -288,7 +288,7 @@ class WriteBatch {
     validate.isDocument('data', data, {
       allowEmpty: true,
       allowDeletes: mergePaths || mergeLeaves ? 'all' : 'none',
-      allowServerTimestamps: true,
+      allowTransforms: true,
     });
 
     this.verifyNotCommitted();
@@ -391,7 +391,7 @@ class WriteBatch {
             validate.minNumberOfArguments('update', arguments, i + 1);
             validate.isFieldValue(i, arguments[i + 1], {
               allowDeletes: 'root',
-              allowServerTimestamps: true,
+              allowTransforms: true,
             });
             updateMap.set(
                 FieldPath.fromArgument(arguments[i]), arguments[i + 1]);
@@ -409,7 +409,7 @@ class WriteBatch {
         validate.isDocument('dataOrField', dataOrField, {
           allowEmpty: false,
           allowDeletes: 'root',
-          allowServerTimestamps: true,
+          allowTransforms: true,
         });
         validate.maxNumberOfArguments('update', arguments, 3);
 

--- a/system-test/firestore.js
+++ b/system-test/firestore.js
@@ -255,6 +255,60 @@ describe('DocumentReference class', function() {
         });
   });
 
+  it('supports arrayUnion()', function() {
+    const baseObject = {
+      a: [],
+      b: ['foo'],
+      c: {d: ['foo']},
+    };
+    const updateObject = {
+      a: Firestore.FieldValue.arrayUnion('foo', 'bar'),
+      b: Firestore.FieldValue.arrayUnion('foo', 'bar'),
+      'c.d': Firestore.FieldValue.arrayUnion('foo', 'bar')
+    };
+    const expectedObject = {
+      a: ['foo', 'bar'],
+      b: ['foo', 'bar'],
+      c: {d: ['foo', 'bar']},
+    };
+
+    let ref = randomCol.doc('doc');
+
+    return ref.set(baseObject)
+        .then(() => ref.update(updateObject))
+        .then(() => ref.get())
+        .then(doc => {
+          assert.deepEqual(doc.data(), expectedObject);
+        });
+  });
+
+  it('supports arrayRemove()', function() {
+    const baseObject = {
+      a: [],
+      b: ['foo', 'foo', 'baz'],
+      c: {d: ['foo', 'bar', 'baz']},
+    };
+    const updateObject = {
+      a: Firestore.FieldValue.arrayRemove('foo'),
+      b: Firestore.FieldValue.arrayRemove('foo'),
+      'c.d': Firestore.FieldValue.arrayRemove('foo', 'bar')
+    };
+    const expectedObject = {
+      a: [],
+      b: ['baz'],
+      c: {d: ['baz']},
+    };
+
+    let ref = randomCol.doc('doc');
+
+    return ref.set(baseObject)
+        .then(() => ref.update(updateObject))
+        .then(() => ref.get())
+        .then(doc => {
+          assert.deepEqual(doc.data(), expectedObject);
+        });
+  });
+
   it('supports set() with merge', function() {
     let ref = randomCol.doc('doc');
     return ref.set({'a.1': 'foo', nested: {'b.1': 'bar'}})

--- a/test/document.js
+++ b/test/document.js
@@ -388,64 +388,6 @@ describe('serialize document', function() {
     });
   });
 
-  it('supports server timestamps', function() {
-    const overrides = {
-      commit: (request, options, callback) => {
-        requestEquals(
-            request,
-            set(document('foo', 'bar'),
-                /* updateMask= */ null,
-                fieldTransform(
-                    'field', 'REQUEST_TIME', 'map.field', 'REQUEST_TIME')));
-
-        callback(null, writeResult(2));
-      }
-    };
-
-    return createInstance(overrides).then(firestore => {
-      return firestore.doc('collectionId/documentId').set({
-        foo: 'bar',
-        field: Firestore.FieldValue.serverTimestamp(),
-        map: {field: Firestore.FieldValue.serverTimestamp()},
-      });
-    });
-  });
-
-  it('doesn\'t support server timestamp in array', function() {
-    const expectedErr =
-        /FieldValue transformations are not supported inside of array values./;
-
-    assert.throws(() => {
-      return firestore.doc('collectionId/documentId').set({
-        array: [Firestore.FieldValue.serverTimestamp()],
-      });
-    }, expectedErr);
-
-    assert.throws(() => {
-      return firestore.doc('collectionId/documentId').set({
-        map: {
-          array: [Firestore.FieldValue.serverTimestamp()],
-        },
-      });
-    }, expectedErr);
-
-    assert.throws(() => {
-      return firestore.doc('collectionId/documentId').set({
-        array: [{map: Firestore.FieldValue.serverTimestamp()}],
-      });
-    }, expectedErr);
-
-    assert.throws(() => {
-      return firestore.doc('collectionId/documentId').set({
-        array: {
-          map: {
-            array: [Firestore.FieldValue.serverTimestamp()],
-          },
-        },
-      });
-    }, expectedErr);
-  });
-
   it('with invalid geopoint', function() {
     assert.throws(() => {
       new Firestore.GeoPoint(57.2999988, 'INVALID');
@@ -921,7 +863,7 @@ describe('set document', function() {
     });
   });
 
-  it('skips merges with just server timestamps', function() {
+  it('skips merges with just field transform', function() {
     const overrides = {
       commit: (request, options, callback) => {
         requestEquals(
@@ -943,7 +885,7 @@ describe('set document', function() {
     });
   });
 
-  it('sends empty non-merge write even with just server timestamps', () => {
+  it('sends empty non-merge write even with just field transform', () => {
     const overrides = {
       commit: (request, options, callback) => {
         requestEquals(
@@ -1100,7 +1042,7 @@ describe('set document', function() {
     });
   });
 
-  it('supports document merges with field mask and server timestamps', () => {
+  it('supports document merges with field mask and field transform', () => {
     const overrides = {
       commit: (request, options, callback) => {
         requestEquals(
@@ -1285,7 +1227,7 @@ describe('create document', function() {
     });
   });
 
-  it('supports server timestamps', function() {
+  it('supports field transform', function() {
     const overrides = {
       commit: (request, options, callback) => {
         requestEquals(
@@ -1366,7 +1308,7 @@ describe('update document', function() {
     });
   });
 
-  it('supports nested server timestamps', function() {
+  it('supports nested field transform', function() {
     const overrides = {
       commit: (request, options, callback) => {
         requestEquals(
@@ -1391,7 +1333,7 @@ describe('update document', function() {
     });
   });
 
-  it('skips write for single server timestamp', function() {
+  it('skips write for single field transform', function() {
     const overrides = {
       commit: (request, options, callback) => {
         requestEquals(

--- a/test/field-value.ts
+++ b/test/field-value.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+'use strict';
+
+import {use, expect} from 'chai';
+
+import {ApiOverride, arrayTransform, commitRequest, createInstance, document, serverTimestamp, set, writeResult} from './util/helpers';
+import {Firestore} from '../src';
+import {referencePkg} from '../src/reference';
+import {fieldValuePkg} from '../src/field-value';
+import {documentPkg} from '../src/document';
+import {AnyDuringMigration} from '../src/types';
+
+const reference = referencePkg(Firestore);
+const fieldValue =
+    fieldValuePkg(documentPkg(reference.DocumentReference).DocumentSnapshot);
+const FieldValue = fieldValue.FieldValue;
+
+// tslint:disable:no-unused-expression
+
+function genericFieldValueTests(
+    methodName: string, sentinel: AnyDuringMigration) {
+  it('can\'t be used inside arrays', () => {
+    return createInstance().then((firestore: AnyDuringMigration) => {
+      const docRef = firestore.doc('coll/doc');
+      const expectedErr =
+          `${methodName}() is not supported inside of array values.`;
+      expect(() => docRef.set({a: [sentinel]})).to.throw(expectedErr);
+      expect(() => docRef.set({a: {b: [sentinel]}})).to.throw(expectedErr);
+      expect(() => docRef.set({
+        a: [{b: sentinel}],
+      })).to.throw(expectedErr);
+      expect(() => docRef.set({a: {b: {c: [sentinel]}}})).to.throw(expectedErr);
+    });
+  });
+
+  it('can\'t be used with queries', () => {
+    return createInstance().then((firestore: AnyDuringMigration) => {
+      const collRef = firestore.collection('coll');
+      expect(() => collRef.where('a', '==', sentinel))
+          .to.throw(`Argument "value" is not a valid QueryValue. ${
+              methodName}() can only be used in set(), create() or update().`);
+      expect(() => collRef.orderBy('a').startAt(sentinel))
+          .to.throw(`Argument at index 0 is not a valid QueryValue. ${
+              methodName}() can only be used in set(), create() or update().`);
+    });
+  });
+}
+
+describe('FieldValue.arrayUnion()', () => {
+  it('requires one argument', () => {
+    expect(() => FieldValue.arrayUnion())
+        .to.throw(
+            'Function \'FieldValue.arrayUnion()\' requires at least 1 argument.');
+  });
+
+  it('supports isEqual()', () => {
+    const arrayUnionFoo1 = FieldValue.arrayUnion('foo');
+    const arrayUnionFoo2 = FieldValue.arrayUnion('foo');
+    const arrayUnionBar = FieldValue.arrayUnion('bar');
+    expect(arrayUnionFoo1.isEqual(arrayUnionFoo2)).to.be.true;
+    expect(arrayUnionFoo1.isEqual(arrayUnionBar)).to.be.false;
+  });
+
+  it('can be used with set()', () => {
+    const overrides: ApiOverride = {
+      commit: (request, options, callback) => {
+        const expectedRequest = commitRequest(set(document('foo', 'bar'), [
+          arrayTransform('field', 'appendMissingElements', 'foo', 'bar'),
+          arrayTransform('map.field', 'appendMissingElements', 'foo', 'bar')
+        ]));
+
+        expect(request).to.deep.equal(expectedRequest);
+
+        callback(null, writeResult(2));
+      }
+    };
+
+    return createInstance(overrides).then((firestore: AnyDuringMigration) => {
+      return firestore.doc('collectionId/documentId').set({
+        foo: 'bar',
+        field: Firestore.FieldValue.arrayUnion('foo', 'bar'),
+        map: {field: Firestore.FieldValue.arrayUnion('foo', 'bar')},
+      });
+    });
+  });
+
+  genericFieldValueTests('FieldValue.arrayUnion', FieldValue.arrayUnion('foo'));
+});
+
+describe('FieldValue.arrayRemove()', () => {
+  it('requires one argument', () => {
+    expect(() => FieldValue.arrayRemove())
+        .to.throw(
+            'Function \'FieldValue.arrayRemove()\' requires at least 1 argument.');
+  });
+
+  it('supports isEqual()', () => {
+    const arrayRemoveFoo1 = FieldValue.arrayUnion('foo');
+    const arrayRemoveFoo2 = FieldValue.arrayUnion('foo');
+    const arrayRemoveBar = FieldValue.arrayUnion('bar');
+    expect(arrayRemoveFoo1.isEqual(arrayRemoveFoo2)).to.be.true;
+    expect(arrayRemoveFoo1.isEqual(arrayRemoveBar)).to.be.false;
+  });
+
+  it('can be used with set()', () => {
+    const overrides: ApiOverride = {
+      commit: (request, options, callback) => {
+        const expectedRequest = commitRequest(set(document('foo', 'bar'), [
+          arrayTransform('field', 'removeAllFromArray', 'foo', 'bar'),
+          arrayTransform('map.field', 'removeAllFromArray', 'foo', 'bar')
+        ]));
+        expect(request).to.deep.equal(expectedRequest);
+
+        callback(null, writeResult(2));
+      }
+    };
+
+    return createInstance(overrides).then((firestore: AnyDuringMigration) => {
+      return firestore.doc('collectionId/documentId').set({
+        foo: 'bar',
+        field: Firestore.FieldValue.arrayRemove('foo', 'bar'),
+        map: {field: Firestore.FieldValue.arrayRemove('foo', 'bar')},
+      });
+    });
+  });
+
+  genericFieldValueTests(
+      'FieldValue.arrayRemove', FieldValue.arrayRemove('foo'));
+});
+
+describe('FieldValue.serverTimestamp()', () => {
+  it('supports isEqual()', () => {
+    const firstTimestamp = FieldValue.serverTimestamp();
+    const secondTimestamp = FieldValue.serverTimestamp();
+    expect(firstTimestamp.isEqual(secondTimestamp)).to.be.true;
+  });
+
+  it('can be used with set()', () => {
+    const overrides: ApiOverride = {
+      commit: (request, options, callback) => {
+        const expectedRequest = commitRequest(
+            set(document('foo', 'bar'),
+                [serverTimestamp('field'), serverTimestamp('map.field')]));
+        expect(request).to.deep.equal(expectedRequest);
+
+        callback(null, writeResult(2));
+      }
+    };
+
+    return createInstance(overrides).then((firestore: AnyDuringMigration) => {
+      return firestore.doc('collectionId/documentId').set({
+        foo: 'bar',
+        field: Firestore.FieldValue.serverTimestamp(),
+        map: {field: Firestore.FieldValue.serverTimestamp()},
+      });
+    });
+  });
+
+  genericFieldValueTests(
+      'FieldValue.serverTimestamp', FieldValue.serverTimestamp());
+});

--- a/test/query.js
+++ b/test/query.js
@@ -738,21 +738,15 @@ describe('where() interface', function() {
       let query = firestore.collection('collectionId');
       query = query.where('foo', '=', new Firestore.FieldPath('bar'));
       return query.get();
-    }, /Argument "value" is not a valid FieldValue. Cannot use object of type "FieldPath" as a Firestore value./);
+    }, /Argument "value" is not a valid QueryValue. Cannot use object of type "FieldPath" as a Firestore value./);
   });
 
-  it('rejects field transforms as value', function() {
+  it('rejects field delete as value', function() {
     assert.throws(() => {
       let query = firestore.collection('collectionId');
       query = query.where('foo', '=', Firestore.FieldValue.delete());
       return query.get();
     }, /FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
-
-    assert.throws(() => {
-      let query = firestore.collection('collectionId');
-      query = query.where('foo', '=', Firestore.FieldValue.serverTimestamp());
-      return query.get();
-    }, /FieldValue.serverTimestamp\(\) can only be used in update\(\), set\(\) and create\(\)./);
   });
 
   it('rejects custom classes as value', function() {
@@ -766,7 +760,7 @@ describe('where() interface', function() {
 
     assert.throws(() => {
       query.where('foo', '=', new Foo()).get();
-    }, /Argument "value" is not a valid FieldValue. Couldn't serialize object of type "Foo". Firestore doesn't support JavaScript objects with custom prototypes \(i.e. objects that were created via the 'new' operator\)./);
+    }, /Argument "value" is not a valid QueryValue. Couldn't serialize object of type "Foo". Firestore doesn't support JavaScript objects with custom prototypes \(i.e. objects that were created via the 'new' operator\)./);
 
     assert.throws(() => {
       query.where('foo', '=', new FieldPath()).get();
@@ -1358,18 +1352,12 @@ describe('startAt() interface', function() {
     }, /Field 'foo' is missing in the provided DocumentSnapshot. Please provide a document that contains values for all specified orderBy\(\) and where\(\) constraints./);
   });
 
-  it('does not accept field transforms', function() {
-    let query = firestore.collection('collectionId')
-                    .orderBy('foo', 'desc')
-                    .orderBy('bar', 'asc');
+  it('does not accept field deletes', function() {
+    let query = firestore.collection('collectionId').orderBy('foo');
 
     assert.throws(() => {
-      query.startAt(Firestore.FieldValue.serverTimestamp());
-    }, /Argument at index 0 is not a valid FieldValue. FieldValue.serverTimestamp\(\) can only be used in update\(\), set\(\) and create\(\)./);
-
-    assert.throws(() => {
-      query.startAt('foo', Firestore.FieldValue.delete());
-    }, /Argument at index 1 is not a valid FieldValue. FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
+      query.orderBy('foo').startAt('foo', Firestore.FieldValue.delete());
+    }, /Argument at index 1 is not a valid QueryValue. FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
   });
 
   it('requires order by', function() {

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -54,15 +54,15 @@ export class Deferred<R> {
 /**
  * Interface that defines the request handlers used by Firestore.
  */
-export interface ApiOverride {
-  beginTransaction(request, options, callback): void;
-  commit(request, options, callback): void;
-  rollback(request, options, callback): void;
-  listCollectionIds(request, options, callback): void;
-  batchGetDocuments(request): NodeJS.ReadableStream;
-  runQuery(request): NodeJS.ReadableStream;
-  listen(): NodeJS.ReadWriteStream;
-}
+export type ApiOverride = {
+  beginTransaction?: (request, options, callback) => void;
+  commit?: (request, options, callback) => void;
+  rollback?: (request, options, callback) => void;
+  listCollectionIds?: (request, options, callback) => void;
+  batchGetDocuments?: (request) => NodeJS.ReadableStream;
+  runQuery?: (request) => NodeJS.ReadableStream;
+  listen?: () => NodeJS.ReadWriteStream;
+};
 
 /**
  * Creates a new Firestore instance for testing. Request handlers can be

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -1065,22 +1065,55 @@ declare namespace FirebaseFirestore {
   }
 
   /**
-   * Sentinel values that can be used when writing document fields with set()
-   * or update().
+   * Sentinel values that can be used when writing document fields with set(),
+   * create() or update().
    */
   export class FieldValue {
     private constructor();
 
     /**
-     * Returns a sentinel used with set() or update() to include a
+     * Returns a sentinel used with set(), create() or update() to include a
      * server-generated timestamp in the written data.
+     *
+     * @return The FieldValue sentinel for use in a call to set(), create() or
+     * update().
      */
     static serverTimestamp(): FieldValue;
 
     /**
-     * Returns a sentinel for use with update() to mark a field for deletion.
+     * Returns a sentinel for use with update() or set() with {merge:true} to
+     * mark a field for deletion.
+     *
+     * @return The FieldValue sentinel for use in a call to set() or update().
      */
     static delete(): FieldValue;
+
+    /**
+     * Returns a special value that can be used with set(), create() or update()
+     * that tells the server to union the given elements with any array value
+     * that already exists on the server. Each specified element that doesn't
+     * already exist in the array will be added to the end. If the field being
+     * modified is not already an array it will be overwritten with an array
+     * containing exactly the specified elements.
+     *
+     * @param elements The elements to union into the array.
+     * @return The FieldValue sentinel for use in a call to set(), create() or
+     * update().
+     */
+    static arrayUnion(...elements: any[]): FieldValue;
+
+    /**
+     * Returns a special value that can be used with set(), create() or update()
+     * that tells the server to remove the given elements from any array value
+     * that already exists on the server. All instances of each element
+     * specified will be removed from the array. If the field being modified is
+     * not already an array it will be overwritten with an empty array.
+     *
+     * @param elements The elements to remove from the array.
+     * @return The FieldValue sentinel for use in a call to set(), create() or
+     * update().
+     */
+    static arrayRemove(...elements: any[]): FieldValue;
 
     /**
      * Returns true if this `FieldValue` is equal to the provided one.


### PR DESCRIPTION
This PR adds arrayUnion() and arrayRemove() support to the Node client.

It also fixes the error message that is used in query evaluation. We now return: 

`Argument "value" is not a valid QueryValue. FieldValue.method() can only be used in set(), create() or update().`

since `Argument "value" is not a valid FieldValue. FieldValue.method()...` is a little bit non-sensical.

Unfortunately, this PR still uses the old-style dependency injection.