### PR TITLE
Support empty write batches

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -34,8 +34,8 @@ let logFunction = (msg: string) => {};
  * @private
  */
 export function logger(
-    methodName: string, requestTag: string|null,
-    logMessage: string, ...additionalArgs: Array<string|object>): void {
+    methodName: string, requestTag: string|null, logMessage: string,
+    ...additionalArgs: Array<string|object>): void {
   requestTag = requestTag || '#####';
 
   const formattedMessage = util.format(logMessage, ...additionalArgs);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -34,11 +34,11 @@ let logFunction = (msg: string) => {};
  * @private
  */
 export function logger(
-    libVersion: string, methodName: string, requestTag: string|null,
+    methodName: string, requestTag: string|null,
     logMessage: string, ...additionalArgs: Array<string|object>): void {
   requestTag = requestTag || '#####';
 
-  const formattedMessage = util.format.apply(null, additionalArgs);
+  const formattedMessage = util.format(logMessage, ...additionalArgs);
   const time = new Date().toISOString();
   logFunction(
       `Firestore (${libVersion}) ${time} ${requestTag} [${methodName}]: ` +

--- a/src/write-batch.js
+++ b/src/write-batch.js
@@ -541,15 +541,17 @@ class WriteBatch {
     this._committed = true;
 
     return this._firestore.request('commit', request, requestTag).then(resp => {
-      const commitTime = Timestamp.fromProto(resp.commitTime);
       const writeResults = [];
 
-      if (resp.writeResults) {
+      if (request.writes.length > 0) {
         assert(
-            request.writes.length === resp.writeResults.length,
+            resp.writeResults instanceof Array &&
+                request.writes.length === resp.writeResults.length,
             `Expected one write result per operation, but got ${
                 resp.writeResults.length} results for ${
                 request.writes.length} operations.`);
+
+        const commitTime = Timestamp.fromProto(resp.commitTime);
 
         let offset = 0;
 

--- a/system-test/firestore.js
+++ b/system-test/firestore.js
@@ -1438,6 +1438,10 @@ describe('WriteBatch class', function() {
     randomCol = getTestRoot(firestore);
   });
 
+  it('supports empty batches', function() {
+    return firestore.batch().commit();
+  });
+
   it('has create() method', function() {
     let ref = randomCol.doc();
     let batch = firestore.batch();


### PR DESCRIPTION
The backend doesn't return a commitTime anymore (or has never?) if a CommitRequest doesn't contain any commits.

Fixes: https://github.com/firebase/firebase-admin-node/issues/312#issuecomment-408043928