### PR TITLE
Manually editing .d.ts files to use 'string' for large numbers

### DIFF
--- a/protos/README.md
+++ b/protos/README.md
@@ -23,4 +23,11 @@ sed -i '' 's/import \"google\/firestore\/v1beta1\//import \"/g' *.proto
 mkdir -p out && pbjs --proto_path node_modules/google-proto-files -t static-module -w commonjs -o out/firestore_proto_api.js firestore.proto && pbts -o out/firestore_proto_api.d.ts out/firestore_proto_api.js
 ```
 
+- Edit the type used for integers greater than 2^53. The GRPC settings we use represent them as 
+Strings, but pbjs uses the "Long" type.
+
+```
+sed -i '' 's/number\|Long/number\|string \"/g' firestore_proto_api.d.ts firestore_proto_api.js
+```
+
 TODO: Find a way to properly specify the proto paths for the Firestore imports so this can be automated.

--- a/protos/firestore_proto_api.d.ts
+++ b/protos/firestore_proto_api.d.ts
@@ -1,5 +1,8 @@
 import * as $protobuf from "protobufjs";
 
+// Note: This file was manually edited to use "string" instead of "Long" for
+// types that can potentially hold large integer values (> 2^53).
+
 /** Namespace google. */
 export namespace google {
 
@@ -3598,7 +3601,7 @@ export namespace google {
         booleanValue?: (boolean|null);
 
         /** Value integerValue */
-        integerValue?: (number|Long|null);
+        integerValue?: (number|string|null);
 
         /** Value doubleValue */
         doubleValue?: (number|null);
@@ -3641,7 +3644,7 @@ export namespace google {
         public booleanValue: boolean;
 
         /** Value integerValue. */
-        public integerValue: (number|Long);
+        public integerValue: (number|string);
 
         /** Value doubleValue. */
         public doubleValue: number;
@@ -8353,10 +8356,10 @@ export namespace google {
       identifierValue?: (string|null);
 
       /** UninterpretedOption positiveIntValue */
-      positiveIntValue?: (number|Long|null);
+      positiveIntValue?: (number|string|null);
 
       /** UninterpretedOption negativeIntValue */
-      negativeIntValue?: (number|Long|null);
+      negativeIntValue?: (number|string|null);
 
       /** UninterpretedOption doubleValue */
       doubleValue?: (number|null);
@@ -8384,10 +8387,10 @@ export namespace google {
       public identifierValue: string;
 
       /** UninterpretedOption positiveIntValue. */
-      public positiveIntValue: (number|Long);
+      public positiveIntValue: (number|string);
 
       /** UninterpretedOption negativeIntValue. */
-      public negativeIntValue: (number|Long);
+      public negativeIntValue: (number|string);
 
       /** UninterpretedOption doubleValue. */
       public doubleValue: number;
@@ -8980,7 +8983,7 @@ export namespace google {
     interface ITimestamp {
 
       /** Timestamp seconds */
-      seconds?: (number|Long|null);
+      seconds?: (number|string|null);
 
       /** Timestamp nanos */
       nanos?: (number|null);
@@ -8996,7 +8999,7 @@ export namespace google {
       constructor(properties?: google.protobuf.ITimestamp);
 
       /** Timestamp seconds. */
-      public seconds: (number|Long);
+      public seconds: (number|string);
 
       /** Timestamp nanos. */
       public nanos: number;
@@ -9564,7 +9567,7 @@ export namespace google {
     interface IInt64Value {
 
       /** Int64Value value */
-      value?: (number|Long|null);
+      value?: (number|string|null);
     }
 
     /** Represents an Int64Value. */
@@ -9577,7 +9580,7 @@ export namespace google {
       constructor(properties?: google.protobuf.IInt64Value);
 
       /** Int64Value value. */
-      public value: (number|Long);
+      public value: (number|string);
 
       /**
        * Creates a new Int64Value instance using the specified properties.
@@ -9654,7 +9657,7 @@ export namespace google {
     interface IUInt64Value {
 
       /** UInt64Value value */
-      value?: (number|Long|null);
+      value?: (number|string|null);
     }
 
     /** Represents a UInt64Value. */
@@ -9667,7 +9670,7 @@ export namespace google {
       constructor(properties?: google.protobuf.IUInt64Value);
 
       /** UInt64Value value. */
-      public value: (number|Long);
+      public value: (number|string);
 
       /**
        * Creates a new UInt64Value instance using the specified properties.

--- a/protos/firestore_proto_api.js
+++ b/protos/firestore_proto_api.js
@@ -1,6 +1,9 @@
 /*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins*/
 "use strict";
 
+// Note: This file was manually edited to use "string" instead of "Long" for
+// types that can potentially hold large integer values (> 2^53).
+
 var $protobuf = require("protobufjs/minimal");
 
 // Common aliases
@@ -8852,7 +8855,7 @@ $root.google = (function() {
          * @interface IValue
          * @property {google.protobuf.NullValue|null} [nullValue] Value nullValue
          * @property {boolean|null} [booleanValue] Value booleanValue
-         * @property {number|Long|null} [integerValue] Value integerValue
+         * @property {number|string|null} [integerValue] Value integerValue
          * @property {number|null} [doubleValue] Value doubleValue
          * @property {google.protobuf.ITimestamp|null} [timestampValue] Value timestampValue
          * @property {string|null} [stringValue] Value stringValue
@@ -8896,7 +8899,7 @@ $root.google = (function() {
 
         /**
          * Value integerValue.
-         * @member {number|Long} integerValue
+         * @member {number|string} integerValue
          * @memberof google.firestore.v1beta1.Value
          * @instance
          */
@@ -21483,8 +21486,8 @@ $root.google = (function() {
        * @interface IUninterpretedOption
        * @property {Array.<google.protobuf.UninterpretedOption.INamePart>|null} [name] UninterpretedOption name
        * @property {string|null} [identifierValue] UninterpretedOption identifierValue
-       * @property {number|Long|null} [positiveIntValue] UninterpretedOption positiveIntValue
-       * @property {number|Long|null} [negativeIntValue] UninterpretedOption negativeIntValue
+       * @property {number|string|null} [positiveIntValue] UninterpretedOption positiveIntValue
+       * @property {number|string|null} [negativeIntValue] UninterpretedOption negativeIntValue
        * @property {number|null} [doubleValue] UninterpretedOption doubleValue
        * @property {Uint8Array|null} [stringValue] UninterpretedOption stringValue
        * @property {string|null} [aggregateValue] UninterpretedOption aggregateValue
@@ -21524,7 +21527,7 @@ $root.google = (function() {
 
       /**
        * UninterpretedOption positiveIntValue.
-       * @member {number|Long} positiveIntValue
+       * @member {number|string} positiveIntValue
        * @memberof google.protobuf.UninterpretedOption
        * @instance
        */
@@ -21532,7 +21535,7 @@ $root.google = (function() {
 
       /**
        * UninterpretedOption negativeIntValue.
-       * @member {number|Long} negativeIntValue
+       * @member {number|string} negativeIntValue
        * @memberof google.protobuf.UninterpretedOption
        * @instance
        */
@@ -23101,7 +23104,7 @@ $root.google = (function() {
        * Properties of a Timestamp.
        * @memberof google.protobuf
        * @interface ITimestamp
-       * @property {number|Long|null} [seconds] Timestamp seconds
+       * @property {number|string|null} [seconds] Timestamp seconds
        * @property {number|null} [nanos] Timestamp nanos
        */
 
@@ -23122,7 +23125,7 @@ $root.google = (function() {
 
       /**
        * Timestamp seconds.
-       * @member {number|Long} seconds
+       * @member {number|string} seconds
        * @memberof google.protobuf.Timestamp
        * @instance
        */
@@ -24499,7 +24502,7 @@ $root.google = (function() {
        * Properties of an Int64Value.
        * @memberof google.protobuf
        * @interface IInt64Value
-       * @property {number|Long|null} [value] Int64Value value
+       * @property {number|string|null} [value] Int64Value value
        */
 
       /**
@@ -24519,7 +24522,7 @@ $root.google = (function() {
 
       /**
        * Int64Value value.
-       * @member {number|Long} value
+       * @member {number|string} value
        * @memberof google.protobuf.Int64Value
        * @instance
        */
@@ -24700,7 +24703,7 @@ $root.google = (function() {
        * Properties of a UInt64Value.
        * @memberof google.protobuf
        * @interface IUInt64Value
-       * @property {number|Long|null} [value] UInt64Value value
+       * @property {number|string|null} [value] UInt64Value value
        */
 
       /**
@@ -24720,7 +24723,7 @@ $root.google = (function() {
 
       /**
        * UInt64Value value.
-       * @member {number|Long} value
+       * @member {number|string} value
        * @memberof google.protobuf.UInt64Value
        * @instance
        */


### PR DESCRIPTION
This changes the Proto type for large numbers to the type we use in code. `pbjs` uses `number|Long`, but we use `number|string`.

I wasn't able to find the right setting in `pbjs` to make it generate the right settings. There is `--force-long ` but no `--force-string`, and I much rather deal with strings in the API than with the Long type (we also use strings in the Web Firestore SDK)