### PR TITLE
Support empty GeoPoint

### DIFF
--- a/src/geo-point.ts
+++ b/src/geo-point.ts
@@ -50,7 +50,7 @@ export class GeoPoint implements Serializable {
    *     `${data.google.longitude}`);
    * });
    */
-  constructor(latitude, longitude) {
+  constructor(latitude: number, longitude: number) {
     validate.isNumber('latitude', latitude, -90, 90);
     validate.isNumber('longitude', longitude, -180, 180);
 
@@ -65,7 +65,7 @@ export class GeoPoint implements Serializable {
    * @name GeoPoint#latitude
    * @readonly
    */
-  get latitude() {
+  get latitude(): number {
     return this._latitude;
   }
 
@@ -76,7 +76,7 @@ export class GeoPoint implements Serializable {
    * @name GeoPoint#longitude
    * @readonly
    */
-  get longitude() {
+  get longitude(): number {
     return this._longitude;
   }
 
@@ -121,6 +121,6 @@ export class GeoPoint implements Serializable {
    * @private
    */
   static fromProto(proto: google.type.ILatLng): GeoPoint {
-    return new GeoPoint(proto.latitude, proto.longitude);
+    return new GeoPoint(proto.latitude || 0, proto.longitude || 0);
   }
 }

--- a/system-test/firestore.js
+++ b/system-test/firestore.js
@@ -170,11 +170,13 @@ describe('DocumentReference class', function() {
       objectValue: {foo: 'bar', '😀': '😜'},
       emptyObject: {},
       dateValue: new Firestore.Timestamp(479978400, 123000000),
+      zeroDateValue: new Firestore.Timestamp(0, 0),
       pathValue: firestore.doc('col1/ref1'),
       arrayValue: ['foo', 42, 'bar'],
       emptyArray: [],
       nilValue: null,
       geoPointValue: new Firestore.GeoPoint(50.1430847, -122.947778),
+      zeroGeoPointValue: new Firestore.GeoPoint(0, 0),
       bytesValue: Buffer.from([0x01, 0x02]),
     };
     let ref = randomCol.doc('doc');


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-admin-node/issues/337

Note that the original issue doesn't reproduce for me, but the 'latitude' and 'longitude' itself is defined as optional and can therefore be omitted. We would have caught this with stricter types (as added in this PR).
