### PR TITLE
Adding explicit dependency on ProtobufJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "is": "^3.2.1",
     "lodash.merge": "^4.6.1",
     "pkg-up": "^2.0.0",
+    "protobufjs": "^6.8.6",
     "through2": "^2.0.3"
   },
   "devDependencies": {
@@ -81,7 +82,6 @@
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
     "power-assert": "^1.6.0",
-    "protobufjs": "^6.8.6",
     "proxyquire": "^2.0.1",
     "ts-node": "^7.0.0",
     "source-map-support": "^0.5.6",


### PR DESCRIPTION
The generated code from Protobuf JS has a dependency on "protobufjs", so we should have one too.

Fixes: https://github.com/firebase/firebase-admin-node/issues/338