### PR TITLE
Remove 'use strict' from TS files

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'power-assert';
 import path from 'path';
 import is from 'is';

--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-import assert from 'power-assert';
-import path from 'path';
-import is from 'is';
-import through2 from 'through2';
-import googleProtoFiles from 'google-proto-files';
-import protobufjs from 'protobufjs';
 import duplexify from 'duplexify';
+import googleProtoFiles from 'google-proto-files';
+import is from 'is';
+import path from 'path';
+import assert from 'power-assert';
+import protobufjs from 'protobufjs';
+import through2 from 'through2';
 
 import {google} from '../protos/firestore_proto_api';
+
 import api = google.firestore.v1beta1;
 
 const {Firestore} = require('../src/index');

--- a/dev/src/backoff.ts
+++ b/dev/src/backoff.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import {logger} from './logger';
 
 /*

--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import is from 'is';
 
 import {createValidator} from './validate';

--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -16,8 +16,9 @@
 
 import is from 'is';
 
-import {createValidator} from './validate';
 import * as fspb from '../protos/firestore_proto_api';
+
+import {createValidator} from './validate';
 
 const validate = createValidator();
 

--- a/dev/src/document-change.ts
+++ b/dev/src/document-change.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import * as is from 'is';
 import {QueryDocumentSnapshot} from './document';
 export type DocumentChangeType = 'added'|'removed'|'modified';

--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'assert';
 import deepEqual from 'deep-equal';
 import is from 'is';

--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -18,11 +18,11 @@ import assert from 'assert';
 import deepEqual from 'deep-equal';
 import is from 'is';
 
-import {FieldPath} from './path';
 import {FieldTransform} from './field-value';
-import {Timestamp} from './timestamp';
-import {isPlainObject} from './serializer';
+import {FieldPath} from './path';
 import {DocumentReference} from './reference';
+import {isPlainObject} from './serializer';
+import {Timestamp} from './timestamp';
 import {ApiMapValue, UpdateData} from './types';
 
 /**

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -16,9 +16,11 @@
 
 import deepEqual from 'deep-equal';
 
+import {google} from '../protos/firestore_proto_api';
+
 import {AnyDuringMigration, AnyJs} from './types';
 import {createValidator} from './validate';
-import {google} from '../protos/firestore_proto_api';
+
 import api = google.firestore.v1beta1;
 import {Serializer} from './serializer';
 import {FieldPath} from './path';

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import deepEqual from 'deep-equal';
 
 import {AnyDuringMigration, AnyJs} from './types';

--- a/dev/src/geo-point.ts
+++ b/dev/src/geo-point.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import {google} from '../protos/firestore_proto_api';
 import api = google.firestore.v1beta1;
 

--- a/dev/src/logger.ts
+++ b/dev/src/logger.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import util from 'util';
 
 import {createValidator} from './validate';

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import * as is from 'is';
 
 import {google} from '../protos/firestore_proto_api';

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import is from 'is';
 import {google} from '../protos/firestore_proto_api';
 import api = google.firestore.v1beta1;

--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'assert';
 
 /**

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import bun from 'bun';
 import deepEqual from 'deep-equal';
 import extend from 'extend';

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import is from 'is';
 
 import {google} from '../protos/firestore_proto_api';

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import is from 'is';
 import {google} from '../protos/firestore_proto_api';
 import {createValidator} from './validate';

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import is from 'is';
 
 import {DocumentReference, Query} from './reference';

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 /**
  * A union of all of the standard JS types, useful for cases where the type is
  * unknown. Unlike "any" this doesn't lose all type-safety, since the consuming

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 /**
  * Generate a unique client-side identifier.
  *

--- a/dev/src/validate.ts
+++ b/dev/src/validate.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import * as is from 'is';
 import {AnyDuringMigration} from './types';
 

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'assert';
 import rbtree from 'functional-red-black-tree';
 import through2 from 'through2';

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -16,16 +16,16 @@
 
 import assert from 'assert';
 import rbtree from 'functional-red-black-tree';
+import {PassThrough} from 'stream';
 import through2 from 'through2';
 
-import {logger} from './logger';
 import {ExponentialBackoff} from './backoff';
-import {Timestamp} from './timestamp';
-import {ResourcePath} from './path';
-import {requestTag} from './util';
 import {DocumentSnapshot} from './document';
 import {DocumentChange, DocumentChangeType} from './document-change';
-import {PassThrough} from 'stream';
+import {logger} from './logger';
+import {ResourcePath} from './path';
+import {Timestamp} from './timestamp';
+import {requestTag} from './util';
 
 export class ErrorWithCode extends Error {
   code?: number;

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import * as assert from 'power-assert';
 import {expect} from 'chai';
 import is from 'is';

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -15,8 +15,6 @@
  */
 
 
-'use strict';
-
 import {expect} from 'chai';
 
 // TODO: This should be a TypeScript import after the full migration.

--- a/dev/test/field-value.ts
+++ b/dev/test/field-value.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-
-'use strict';
-
 import {use, expect} from 'chai';
 
 import {ApiOverride, arrayTransform, commitRequest, createInstance, document, serverTimestamp, set, writeResult} from './util/helpers';

--- a/dev/test/field-value.ts
+++ b/dev/test/field-value.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {use, expect} from 'chai';
+import {expect, use} from 'chai';
 
 import {ApiOverride, arrayTransform, commitRequest, createInstance, document, serverTimestamp, set, writeResult} from './util/helpers';
 

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import {use, expect} from 'chai';
+import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
 import {ClientPool} from '../src/pool';
+
 import {Deferred} from './util/helpers';
 
 use(chaiAsPromised.default);

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import {use, expect} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import {GrpcClient} from 'google-gax';
 
 import {google} from '../../protos/firestore_proto_api';


### PR DESCRIPTION
As per PR feedback from https://github.com/googleapis/nodejs-firestore/pull/361

For reasons unbeknownst to me, this also leads to some import reordering courtesy of clang-format.