### PR TITLE
Deprecate getCollections in favor of listCollections

### DIFF
--- a/dev/src/index.js
+++ b/dev/src/index.js
@@ -591,6 +591,27 @@ class Firestore {
    * with an array of CollectionReferences.
    *
    * @example
+   * firestore.listCollections().then(collections => {
+   *   for (let collection of collections) {
+   *     console.log(`Found collection with id: ${collection.id}`);
+   *   }
+   * });
+   */
+  listCollections() {
+    let rootDocument = new DocumentReference(this, this._referencePath);
+    return rootDocument.listCollections();
+  }
+
+  /**
+   * Fetches the root collections that are associated with this Firestore
+   * database.
+   *
+   * @deprecated Use `listCollections()`.
+   *
+   * @returns {Promise.<Array.<CollectionReference>>} A Promise that resolves
+   * with an array of CollectionReferences.
+   *
+   * @example
    * firestore.getCollections().then(collections => {
    *   for (let collection of collections) {
    *     console.log(`Found collection with id: ${collection.id}`);
@@ -598,8 +619,7 @@ class Firestore {
    * });
    */
   getCollections() {
-    let rootDocument = new DocumentReference(this, this._referencePath);
-    return rootDocument.getCollections();
+    return this.listCollections();
   }
 
   /**

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -256,13 +256,13 @@ export class DocumentReference {
    * @example
    * let documentRef = firestore.doc('col/doc');
    *
-   * documentRef.getCollections().then(collections => {
+   * documentRef.listCollections().then(collections => {
    *   for (let collection of collections) {
    *     console.log(`Found subcollection with id: ${collection.id}`);
    *   }
    * });
    */
-  getCollections(): Promise<CollectionReference[]> {
+  listCollections(): Promise<CollectionReference[]> {
     const request = {parent: this._path.formattedName};
 
     return this._firestore.request('listCollectionIds', request, requestTag())
@@ -279,6 +279,27 @@ export class DocumentReference {
 
           return collections;
         });
+  }
+
+  /**
+   * Fetches the subcollections that are direct children of this document.
+   *
+   * @deprecated Use `listCollections()`.
+   *
+   * @returns {Promise.<Array.<CollectionReference>>} A Promise that resolves
+   * with an array of CollectionReferences.
+   *
+   * @example
+   * let documentRef = firestore.doc('col/doc');
+   *
+   * documentRef.getCollections().then(collections => {
+   *   for (let collection of collections) {
+   *     console.log(`Found subcollection with id: ${collection.id}`);
+   *   }
+   * });
+   */
+  getCollections(): Promise<CollectionReference[]> {
+    return this.listCollections();
   }
 
   /**

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -426,7 +426,7 @@ describe('DocumentReference class', function() {
         });
   });
 
-  it('has getCollections() method', function() {
+  it('has listCollections() method', function() {
     let collections = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
     let promises : Promise<{}>[] = [];
 
@@ -436,7 +436,7 @@ describe('DocumentReference class', function() {
 
     return Promise.all(promises)
         .then(() => {
-          return randomCol.doc('doc').getCollections();
+          return randomCol.doc('doc').listCollections();
         })
         .then(response => {
           assert.equal(response.length, collections.length);

--- a/dev/test/document.js
+++ b/dev/test/document.js
@@ -1762,7 +1762,7 @@ describe('update document', function() {
   });
 });
 
-describe('getCollections() method', function() {
+describe('listCollections() method', function() {
   it('sorts results', function() {
     const overrides = {
       listCollectionIds: (request, options, callback) => {
@@ -1776,6 +1776,7 @@ describe('getCollections() method', function() {
     };
 
     return createInstance(overrides).then(firestore => {
+      // We are using `getCollections()` to ensure 100% code coverage
       return firestore.doc('coll/doc').getCollections().then(collections => {
         assert.equal(collections[0].path, 'coll/doc/first');
         assert.equal(collections[1].path, 'coll/doc/second');

--- a/dev/test/index.js
+++ b/dev/test/index.js
@@ -703,7 +703,7 @@ describe('collection() method', function() {
   });
 });
 
-describe('getCollections() method', function() {
+describe('listCollections() method', function() {
   it('returns collections', function() {
     const overrides = {
       listCollectionIds: (request, options, callback) => {
@@ -716,6 +716,7 @@ describe('getCollections() method', function() {
     };
 
     return createInstance(overrides).then(firestore => {
+      // We are using `getCollections()` to ensure 100% code coverage
       return firestore.getCollections().then(collections => {
         assert.equal(collections[0].path, 'first');
         assert.equal(collections[1].path, 'second');

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -67,6 +67,8 @@ xdescribe('firestore.d.ts', function() {
         });
     firestore.getCollections().then((collections:CollectionReference[]) => {
     });
+    firestore.listCollections().then((collections:CollectionReference[]) => {
+    });
     const transactionResult: Promise<string> = firestore.runTransaction(
         (updateFunction: Transaction) => {
           return Promise.resolve("string")
@@ -143,6 +145,8 @@ xdescribe('firestore.d.ts', function() {
     const path: string = docRef.path;
     const subcollection: CollectionReference = docRef.collection('coll');
     docRef.getCollections().then((collections:CollectionReference[]) => {
+    });
+    docRef.listCollections().then((collections:CollectionReference[]) => {
     });
     docRef.get().then((snapshot: DocumentSnapshot) => {
     });

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -135,9 +135,19 @@ declare namespace FirebaseFirestore {
      * Fetches the root collections that are associated with this Firestore
      * database.
      *
+     * @deprecated Use `listCollections()`.
+     *
      * @returns A Promise that resolves with an array of CollectionReferences.
      */
     getCollections() : Promise<CollectionReference[]>;
+
+    /**
+     * Fetches the root collections that are associated with this Firestore
+     * database.
+     *
+     * @returns A Promise that resolves with an array of CollectionReferences.
+     */
+    listCollections() : Promise<CollectionReference[]>;
 
     /**
      * Executes the given updateFunction and commits the changes applied within
@@ -501,9 +511,18 @@ declare namespace FirebaseFirestore {
     /**
      * Fetches the subcollections that are direct children of this document.
      *
+     * @deprecated Use `listCollections()`.
+     *
      * @returns A Promise that resolves with an array of CollectionReferences.
      */
     getCollections() : Promise<CollectionReference[]>;
+
+    /**
+     * Fetches the subcollections that are direct children of this document.
+     *
+     * @returns A Promise that resolves with an array of CollectionReferences.
+     */
+    listCollections() : Promise<CollectionReference[]>;
 
     /**
      * Creates a document referred to by this `DocumentReference` with the


### PR DESCRIPTION
Deprecate getCollections in favor of listCollections

To prepare for `listDocuments()`.