### PR TITLE
Convert tests to TypeScript

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'assert';
 import bun from 'bun';
 import extend from 'extend';

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -14,36 +14,36 @@
  * limitations under the License.
  */
 
+import {replaceProjectIdToken} from '@google-cloud/projectify';
 import assert from 'assert';
 import bun from 'bun';
 import extend from 'extend';
 import is from 'is';
 import through2 from 'through2';
-import {replaceProjectIdToken} from '@google-cloud/projectify';
 
-import {CollectionReference, validateDocumentReference, validateComparisonOperator, validateFieldOrder} from './reference';
+import {google} from '../protos/firestore_proto_api';
+
+import * as convert from './convert';
 import {DocumentSnapshot, QueryDocumentSnapshot, validatePrecondition, validateSetOptions} from './document';
 import {FieldValue} from './field-value';
-import {FieldTransform, DeleteTransform} from './field-value';
-import {Validator, customObjectError} from './validate';
-import {WriteBatch, WriteResult} from './write-batch';
-import {validateUpdateMap} from './write-batch';
-import {Transaction} from './transaction';
-import {Timestamp} from './timestamp';
+import {DeleteTransform, FieldTransform} from './field-value';
+import {GeoPoint} from './geo-point';
+import {logger, setLibVersion, setLogFunction} from './logger';
 import {FieldPath} from './path';
 import {ResourcePath} from './path';
 import {ClientPool} from './pool';
-import {isPlainObject, Serializer} from './serializer';
-import {GeoPoint} from './geo-point';
-import {logger, setLibVersion, setLogFunction} from './logger';
-import {requestTag} from './util';
-import {DocumentData, GapicClient, Settings, ValidationOptions} from './types';
+import {CollectionReference, validateComparisonOperator, validateDocumentReference, validateFieldOrder} from './reference';
 import {DocumentReference} from './reference';
-
-import * as convert from './convert';
+import {isPlainObject, Serializer} from './serializer';
+import {Timestamp} from './timestamp';
+import {Transaction} from './transaction';
+import {DocumentData, GapicClient, Settings, ValidationOptions} from './types';
 import {AnyDuringMigration, AnyJs} from './types';
+import {requestTag} from './util';
+import {customObjectError, Validator} from './validate';
+import {WriteBatch, WriteResult} from './write-batch';
+import {validateUpdateMap} from './write-batch';
 
-import {google} from '../protos/firestore_proto_api';
 import api = google.firestore.v1beta1;
 
 export {CollectionReference, DocumentReference, QuerySnapshot, Query} from './reference';

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -224,16 +224,12 @@ export class ResourcePath extends Path<ResourcePath> {
    * @private
    * @hideconstructor
    *
-   * @param {string} projectId - The Firestore project id.
-   * @param {string} databaseId - The Firestore database id.
-   * @param {string[]?} segments - Sequence of names of the parts of
-   * the path.
+   * @param projectId The Firestore project id.
+   * @param databaseId The Firestore database id.
+   * @param segments Sequence of names of the parts of the path.
    */
-  constructor(projectId: string, databaseId: string, segments?: string[]) {
-    const elements = segments instanceof Array ?
-        segments :
-        Array.prototype.slice.call(arguments, 2);
-    super(elements);
+  constructor(projectId: string, databaseId: string, ...segments: string[]) {
+    super(segments);
 
     this.projectId = projectId;
     this.databaseId = databaseId;
@@ -369,7 +365,7 @@ export class ResourcePath extends Path<ResourcePath> {
    * @returns {ResourcePath} The newly created ResourcePath.
    */
   construct(segments: string[]): ResourcePath {
-    return new ResourcePath(this.projectId, this.databaseId, segments);
+    return new ResourcePath(this.projectId, this.databaseId, ...segments);
   }
 
   /**

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -17,17 +17,18 @@
 import assert from 'assert';
 import is from 'is';
 
-import {logger} from './logger';
-import {DocumentSnapshot, DocumentMask, DocumentTransform, Precondition} from './document';
-import {FieldPath} from './path';
-import {Timestamp} from './timestamp';
-import {requestTag} from './util';
-import {AnyDuringMigration, AnyJs, SetOptions, UpdateData, UserInput, Precondition as PublicPrecondition} from './types';
-import {Serializer} from './serializer';
-import {DocumentData} from './types';
-import {DocumentReference} from './reference';
-
 import {google} from '../protos/firestore_proto_api';
+
+import {DocumentMask, DocumentSnapshot, DocumentTransform, Precondition} from './document';
+import {logger} from './logger';
+import {FieldPath} from './path';
+import {DocumentReference} from './reference';
+import {Serializer} from './serializer';
+import {Timestamp} from './timestamp';
+import {AnyDuringMigration, AnyJs, Precondition as PublicPrecondition, SetOptions, UpdateData, UserInput} from './types';
+import {DocumentData} from './types';
+import {requestTag} from './util';
+
 import api = google.firestore.v1beta1;
 
 /*!

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'assert';
 import is from 'is';
 

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-import assert from 'power-assert';
 import extend from 'extend';
 import is from 'is';
+import assert from 'power-assert';
 import through2 from 'through2';
 
 import {google} from '../protos/firestore_proto_api';
 import * as Firestore from '../src';
-import {createInstance, InvalidApiUsage} from './util/helpers';
-import {AnyDuringMigration, AnyJs} from '../src/types';
 import {DocumentSnapshot, QueryDocumentSnapshot} from '../src';
+import {AnyDuringMigration, AnyJs} from '../src/types';
+
+import {createInstance, InvalidApiUsage} from './util/helpers';
 
 const REQUEST_TIME = google.firestore.v1beta1.DocumentTransform.FieldTransform
                          .ServerValue.REQUEST_TIME;
@@ -648,13 +649,11 @@ describe('get document', () => {
     };
 
     return createInstance(overrides).then(firestore => {
-      return firestore.doc('collectionId/documentId')
-          .get()
-          .then((result) => {
-            assert.ok(result.createTime!.isEqual(new Firestore.Timestamp(1, 2)));
-            assert.ok(result.updateTime!.isEqual(new Firestore.Timestamp(3, 4)));
-            assert.ok(result.readTime.isEqual(new Firestore.Timestamp(5, 6)));
-          });
+      return firestore.doc('collectionId/documentId').get().then((result) => {
+        assert.ok(result.createTime!.isEqual(new Firestore.Timestamp(1, 2)));
+        assert.ok(result.updateTime!.isEqual(new Firestore.Timestamp(3, 4)));
+        assert.ok(result.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+      });
     });
   });
 

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'power-assert';
 import extend from 'extend';
 import is from 'is';
 import through2 from 'through2';
 
 import {ResourcePath} from '../src/path';
-import {createInstance} from '../test/util/helpers';
+import {createInstance, InvalidApiUsage} from '../test/util/helpers';
 import * as gax from 'google-gax';
 
-import * as Firestore from '../src'
-const {grpc} = new gax.GrpcClient();
+import * as Firestore from '../src';
+
+import {AnyDuringMigration} from '../src/types';
+const {grpc} = new gax.GrpcClient({} as AnyDuringMigration);
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
@@ -245,10 +245,10 @@ const allSupportedTypesOutput = {
   bytesValue: Buffer.from([0x1, 0x2]),
 };
 
-function document(name, fields) {
+function document(name, fields?) {
   return {
     name: `${DATABASE_ROOT}/documents/collectionId/${name}`,
-    fields: fields,
+    fields,
     createTime: {seconds: 1, nanos: 2},
     updateTime: {seconds: 3, nanos: 4},
   };
@@ -268,12 +268,12 @@ function missing(name) {
   };
 }
 
-function stream() {
-  let stream = through2.obj();
-  let args = arguments;
+function stream(...elements) {
+  const stream = through2.obj();
+  const args = arguments;
 
-  setImmediate(function() {
-    for (let arg of args) {
+  setImmediate(() => {
+    for (const arg of args) {
       if (is.instance(arg, Error)) {
         stream.destroy(arg);
         return;
@@ -286,22 +286,22 @@ function stream() {
   return stream;
 }
 
-describe('instantiation', function() {
-  it('creates instance', function() {
-    let firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
+describe('instantiation', () => {
+  it('creates instance', () => {
+    const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
     assert(firestore instanceof Firestore.Firestore);
   });
 
-  it('merges settings', function() {
-    let firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
+  it('merges settings', () => {
+    const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
     firestore.settings({foo: 'bar'});
 
-    assert.equal(firestore._initializationSettings.projectId, PROJECT_ID);
-    assert.equal(firestore._initializationSettings.foo, 'bar');
+    assert.equal(firestore['_initializationSettings'].projectId, PROJECT_ID);
+    assert.equal(firestore['_initializationSettings'].foo, 'bar');
   });
 
-  it('can only call settings() once', function() {
-    let firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
+  it('can only call settings() once', () => {
+    const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
     firestore.settings({timestampsInSnapshots: true});
 
     assert.throws(
@@ -309,16 +309,16 @@ describe('instantiation', function() {
         /Firestore.settings\(\) has already be called. You can only call settings\(\) once, and only before calling any other methods on a Firestore object./);
   });
 
-  it('cannot change settings after client initialized', function() {
-    let firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
-    firestore._runRequest(() => Promise.resolve());
+  it('cannot change settings after client initialized', () => {
+    const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
+    firestore['_runRequest'](() => Promise.resolve());
 
     assert.throws(
         () => firestore.settings({}),
         /Firestore has already been started and its settings can no longer be changed. You can only call settings\(\) before calling any other methods on a Firestore object./);
   });
 
-  it('validates project ID is string', function() {
+  it('validates project ID is string', () => {
     assert.throws(() => {
       const settings = Object.assign({}, DEFAULT_SETTINGS, {
         projectId: 1337,
@@ -327,11 +327,13 @@ describe('instantiation', function() {
     }, /Argument "settings.projectId" is not a valid string/);
 
     assert.throws(() => {
-      new Firestore.Firestore(DEFAULT_SETTINGS).settings({projectId: 1337});
+      new Firestore.Firestore(DEFAULT_SETTINGS).settings({
+        projectId: 1337
+      } as InvalidApiUsage);
     }, /Argument "settings.projectId" is not a valid string/);
   });
 
-  it('validates timestampsInSnapshots is boolean', function() {
+  it('validates timestampsInSnapshots is boolean', () => {
     assert.throws(() => {
       const settings = Object.assign({}, DEFAULT_SETTINGS, {
         timestampsInSnapshots: 1337,
@@ -342,14 +344,14 @@ describe('instantiation', function() {
     assert.throws(() => {
       new Firestore.Firestore(DEFAULT_SETTINGS).settings({
         timestampsInSnapshots: 1337
-      });
+      } as AnyDuringMigration);
     }, /Argument "settings.timestampsInSnapshots" is not a valid boolean/);
   });
 
   it('uses project id from constructor', () => {
-    let firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
+    const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
 
-    return firestore._runRequest(() => {
+    return firestore['_runRequest'](() => {
       assert.equal(
           firestore.formattedName,
           `projects/${PROJECT_ID}/databases/(default)`);
@@ -357,8 +359,8 @@ describe('instantiation', function() {
     });
   });
 
-  it('detects project id', function() {
-    let firestore = new Firestore.Firestore({
+  it('detects project id', () => {
+    const firestore = new Firestore.Firestore({
       sslCreds: grpc.credentials.createInsecure(),
       timestampsInSnapshots: true,
       keyFilename: __dirname + '/fake-certificate.json',
@@ -367,9 +369,9 @@ describe('instantiation', function() {
     assert.equal(
         firestore.formattedName, 'projects/{{projectId}}/databases/(default)');
 
-    firestore._detectProjectId = () => Promise.resolve(PROJECT_ID);
+    firestore['_detectProjectId'] = () => Promise.resolve(PROJECT_ID);
 
-    return firestore._runRequest(() => {
+    return firestore['_runRequest'](() => {
       assert.equal(
           firestore.formattedName,
           `projects/${PROJECT_ID}/databases/(default)`);
@@ -377,8 +379,8 @@ describe('instantiation', function() {
     });
   });
 
-  it('uses project id from gapic client', function() {
-    let firestore = new Firestore.Firestore({
+  it('uses project id from gapic client', () => {
+    const firestore = new Firestore.Firestore({
       sslCreds: grpc.credentials.createInsecure(),
       timestampsInSnapshots: true,
       keyFilename: './test/fake-certificate.json',
@@ -387,15 +389,15 @@ describe('instantiation', function() {
     assert.equal(
         firestore.formattedName, 'projects/{{projectId}}/databases/(default)');
 
-    let gapicClient = {getProjectId: callback => callback(null, PROJECT_ID)};
+    const gapicClient = {getProjectId: callback => callback(null, PROJECT_ID)};
 
-    return firestore._detectProjectId(gapicClient).then(projectId => {
+    return  firestore['_detectProjectId'] (gapicClient).then(projectId => {
       assert.equal(projectId, PROJECT_ID);
     });
   });
 
-  it('uses project ID from settings()', function() {
-    let firestore = new Firestore.Firestore({
+  it('uses project ID from settings()', () => {
+    const firestore = new Firestore.Firestore({
       sslCreds: grpc.credentials.createInsecure(),
       timestampsInSnapshots: true,
       keyFilename: './test/fake-certificate.json',
@@ -407,23 +409,23 @@ describe('instantiation', function() {
         firestore.formattedName, `projects/${PROJECT_ID}/databases/(default)`);
   });
 
-  it('handles error from project ID detection', function() {
-    let firestore = new Firestore.Firestore({
+  it('handles error from project ID detection', () => {
+    const firestore = new Firestore.Firestore({
       sslCreds: grpc.credentials.createInsecure(),
       timestampsInSnapshots: true,
       keyFilename: './test/fake-certificate.json',
     });
 
-    let gapicClient = {
+    const gapicClient = {
       getProjectId: callback => callback(new Error('Injected Error'))
     };
 
-    return firestore._detectProjectId(gapicClient)
+    return  firestore['_detectProjectId'] (gapicClient)
         .then(() => assert.fail('Error ignored'))
-        .catch(err => assert.equal('Injected Error', err.message))
+        .catch(err => assert.equal('Injected Error', err.message));
   });
 
-  it('exports all types', function() {
+  it('exports all types', () => {
     // Ordering as per firestore.d.ts
     assert.ok(is.defined(Firestore.Firestore));
     assert.equal(Firestore.Firestore.name, 'Firestore');
@@ -458,8 +460,8 @@ describe('instantiation', function() {
   });
 });
 
-describe('serializer', function() {
-  it('supports all types', function() {
+describe('serializer', () => {
+  it('supports all types', () => {
     const overrides = {
       commit: (request, options, callback) => {
         assert.deepStrictEqual(
@@ -482,17 +484,17 @@ describe('serializer', function() {
   });
 });
 
-describe('snapshot_() method', function() {
+describe('snapshot_() method', () => {
   let firestore;
 
   function verifyAllSupportedTypes(actualObject) {
-    let expected = extend(true, {}, allSupportedTypesOutput);
+    const expected = extend(true, {}, allSupportedTypesOutput);
     // Deep Equal doesn't support matching instances of DocumentRefs, so we
     // compare them manually and remove them from the resulting object.
     assert.equal(
         actualObject.get('pathValue').formattedName,
         expected.pathValue.formattedName);
-    let data = actualObject.data();
+    const data = actualObject.data();
     delete data.pathValue;
     delete expected.pathValue;
     assert.deepStrictEqual(data, expected);
@@ -519,8 +521,8 @@ describe('snapshot_() method', function() {
     });
   });
 
-  it('handles ProtobufJS', function() {
-    let doc = firestore.snapshot_(
+  it('handles ProtobufJS', () => {
+    const doc = firestore.snapshot_(
         document('doc', {
           foo: {valueType: 'bytesValue', bytesValue: bytesData},
         }),
@@ -533,10 +535,10 @@ describe('snapshot_() method', function() {
     assert.ok(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)));
   });
 
-  it('handles Proto3 JSON together with existing types', function() {
+  it('handles Proto3 JSON together with existing types', () => {
     // Google Cloud Functions must be able to call snapshot_() with Proto3 JSON
     // data.
-    let doc = firestore.snapshot_(
+    const doc = firestore.snapshot_(
         {
           name: `${DATABASE_ROOT}/documents/collectionId/doc`,
           fields: {
@@ -563,8 +565,8 @@ describe('snapshot_() method', function() {
     assert.ok(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)));
   });
 
-  it('deserializes all supported types from Protobuf JS', function() {
-    let doc = firestore.snapshot_(allSupportedTypesProtobufJs, {
+  it('deserializes all supported types from Protobuf JS', () => {
+    const doc = firestore.snapshot_(allSupportedTypesProtobufJs, {
       seconds: 5,
       nanos: 6,
     });
@@ -572,13 +574,13 @@ describe('snapshot_() method', function() {
     verifyAllSupportedTypes(doc);
   });
 
-  it('deserializes all supported types from Proto3 JSON', function() {
-    let doc = firestore.snapshot_(
+  it('deserializes all supported types from Proto3 JSON', () => {
+    const doc = firestore.snapshot_(
         allSupportedTypesJson, '1970-01-01T00:00:05.000000006Z', 'json');
     verifyAllSupportedTypes(doc);
   });
 
-  it('handles invalid Proto3 JSON', function() {
+  it('handles invalid Proto3 JSON', () => {
     assert.throws(() => {
       firestore.snapshot_(
           {
@@ -613,8 +615,8 @@ describe('snapshot_() method', function() {
     }, /Specify a valid ISO 8601 timestamp for "documentOrName.createTime"./);
   });
 
-  it('handles missing document ', function() {
-    let doc = firestore.snapshot_(
+  it('handles missing document ', () => {
+    const doc = firestore.snapshot_(
         `${DATABASE_ROOT}/documents/collectionId/doc`,
         '1970-01-01T00:00:05.000000006Z', 'json');
 
@@ -622,7 +624,7 @@ describe('snapshot_() method', function() {
     assert.ok(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)));
   });
 
-  it('handles invalid encoding format ', function() {
+  it('handles invalid encoding format ', () => {
     assert.throws(() => {
       firestore.snapshot_(
           `${DATABASE_ROOT}/documents/collectionId/doc`,
@@ -631,7 +633,7 @@ describe('snapshot_() method', function() {
   });
 });
 
-describe('doc() method', function() {
+describe('doc() method', () => {
   let firestore;
 
   beforeEach(() => {
@@ -640,37 +642,37 @@ describe('doc() method', function() {
     });
   });
 
-  it('returns DocumentReference', function() {
-    let documentRef = firestore.doc('collectionId/documentId');
+  it('returns DocumentReference', () => {
+    const documentRef = firestore.doc('collectionId/documentId');
     assert.ok(documentRef instanceof Firestore.DocumentReference);
   });
 
-  it('requires document path', function() {
-    assert.throws(function() {
-      firestore.doc();
-    }, /Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string./);
+  it('requires document path', () => {
+    assert.throws(
+        () => firestore.doc(),
+        /Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string./);
   });
 
-  it('doesn\'t accept empty components', function() {
-    assert.throws(function() {
-      firestore.doc('coll//doc');
-    }, /Argument "documentPath" is not a valid ResourcePath. Paths must not contain \/\/./);
+  it('doesn\'t accept empty components', () => {
+    assert.throws(
+        () => firestore.doc('coll//doc'),
+        /Argument "documentPath" is not a valid ResourcePath. Paths must not contain \/\/./);
   });
 
-  it('must point to document', function() {
-    assert.throws(function() {
-      firestore.doc('collectionId');
-    }, /Argument "documentPath" must point to a document, but was "collectionId". Your path does not contain an even number of components\./);
+  it('must point to document', () => {
+    assert.throws(
+        () => firestore.doc('collectionId'),
+        /Argument "documentPath" must point to a document, but was "collectionId". Your path does not contain an even number of components\./);
   });
 
-  it('exposes properties', function() {
-    let documentRef = firestore.doc('collectionId/documentId');
+  it('exposes properties', () => {
+    const documentRef = firestore.doc('collectionId/documentId');
     assert.equal(documentRef.id, 'documentId');
     assert.equal(documentRef.firestore, firestore);
   });
 });
 
-describe('collection() method', function() {
+describe('collection() method', () => {
   let firestore;
 
   beforeEach(() => {
@@ -679,33 +681,34 @@ describe('collection() method', function() {
     });
   });
 
-  it('returns collection', function() {
-    let collection = firestore.collection('col1/doc1/col2');
+  it('returns collection', () => {
+    const collection = firestore.collection('col1/doc1/col2');
     assert.ok(is.instance(collection, Firestore.CollectionReference));
   });
 
-  it('requires collection id', function() {
-    assert.throws(function() {
-      firestore.collection();
-    }, /Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string./);
+  it('requires collection id', () => {
+    assert.throws(
+        () => firestore.collection(),
+        /Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string./);
   });
 
-  it('must point to a collection', function() {
-    assert.throws(function() {
-      firestore.collection('collectionId/documentId');
-    }, /Argument "collectionPath" must point to a collection, but was "collectionId\/documentId". Your path does not contain an odd number of components\./);
+
+  it('must point to a collection', () => {
+    assert.throws(
+        () => firestore.collection('collectionId/documentId'),
+        /Argument "collectionPath" must point to a collection, but was "collectionId\/documentId". Your path does not contain an odd number of components\./);
   });
 
-  it('exposes properties', function() {
-    let collection = firestore.collection('collectionId');
+  it('exposes properties', () => {
+    const collection = firestore.collection('collectionId');
     assert.ok(collection.id);
     assert.ok(collection.doc);
     assert.equal(collection.id, 'collectionId');
   });
 });
 
-describe('listCollections() method', function() {
-  it('returns collections', function() {
+describe('listCollections() method', () => {
+  it('returns collections', () => {
     const overrides = {
       listCollectionIds: (request, options, callback) => {
         assert.deepStrictEqual(request, {
@@ -726,12 +729,12 @@ describe('listCollections() method', function() {
   });
 });
 
-describe('getAll() method', function() {
-  function resultEquals(result, doc) {
+describe('getAll() method', () => {
+  function resultEquals(result, ...docs) {
     assert.equal(result.length, arguments.length - 1);
 
     for (let i = 0; i < result.length; ++i) {
-      doc = arguments[i + 1];
+      const doc = arguments[i + 1];
 
       if (doc.found) {
         assert.ok(result[i].exists);
@@ -743,7 +746,7 @@ describe('getAll() method', function() {
     }
   }
 
-  it('accepts empty list', function() {
+  it('accepts empty list', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream();
@@ -757,7 +760,7 @@ describe('getAll() method', function() {
     });
   });
 
-  it('accepts single document', function() {
+  it('accepts single document', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream(found('documentId'));
@@ -772,7 +775,7 @@ describe('getAll() method', function() {
     });
   });
 
-  it('verifies response', function() {
+  it('verifies response', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream(found('documentId2'));
@@ -792,7 +795,7 @@ describe('getAll() method', function() {
     });
   });
 
-  it('handles stream exception during initialization', function() {
+  it('handles stream exception during initialization', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream(new Error('Expected exception'));
@@ -810,7 +813,7 @@ describe('getAll() method', function() {
     });
   });
 
-  it('handles stream exception after initialization', function() {
+  it('handles stream exception after initialization', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream(found('documentId'), new Error('Expected exception'));
@@ -828,7 +831,7 @@ describe('getAll() method', function() {
     });
   });
 
-  it('handles serialization error', function() {
+  it('handles serialization error', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream(found('documentId'));
@@ -836,7 +839,7 @@ describe('getAll() method', function() {
     };
 
     return createInstance(overrides).then(firestore => {
-      firestore.snapshot_ = function() {
+      firestore['snapshot_'] = () => {
         throw new Error('Expected exception');
       };
 
@@ -850,8 +853,8 @@ describe('getAll() method', function() {
     });
   });
 
-  it('only retries on GRPC unavailable', function() {
-    let expectedErrorAttempts = {
+  it('only retries on GRPC unavailable', () => {
+    const expectedErrorAttempts = {
       /* Cancelled */ 1: 1,
       /* Unknown */ 2: 1,
       /* InvalidArgument */ 3: 1,
@@ -870,23 +873,24 @@ describe('getAll() method', function() {
       /* Unauthenticated */ 16: 1,
     };
 
-    let actualErrorAttempts = {};
+    const actualErrorAttempts = {};
 
     const overrides = {
       batchGetDocuments: request => {
-        let errorCode = Number(request.documents[0].split('/').pop());
+        const errorCode = Number(request.documents[0].split('/').pop());
         actualErrorAttempts[errorCode] =
             (actualErrorAttempts[errorCode] || 0) + 1;
-        let error = new Error('Expected exception');
-        error.code = errorCode;
+        const error = new Error('Expected exception');
+        // tslint:disable-next-line:no-any
+        (error as any).code = errorCode;
         return stream(error);
       }
     };
 
     return createInstance(overrides).then(firestore => {
-      let coll = firestore.collection('collectionId');
+      const coll = firestore.collection('collectionId');
 
-      let promises = [];
+      const promises: Array<Promise<void>> = [];
 
       Object.keys(expectedErrorAttempts).forEach(errorCode => {
         promises.push(firestore.getAll(coll.doc(`${errorCode}`))
@@ -904,26 +908,26 @@ describe('getAll() method', function() {
     });
   });
 
-  it('requires document reference', function() {
+  it('requires document reference', () => {
     return createInstance().then(firestore => {
       assert.throws(() => {
-        firestore.getAll({});
+        (firestore as InvalidApiUsage).getAll({});
       }, /Argument at index 0 is not a valid DocumentReference\./);
     });
   });
 
-  it('accepts array', function() {
+  it('accepts array', () => {
     const overrides = {batchGetDocuments: () => stream(found('documentId'))};
 
     return createInstance(overrides).then(firestore => {
-      return firestore.getAll([firestore.doc('collectionId/documentId')])
+      return firestore.getAll(firestore.doc('collectionId/documentId'))
           .then(result => {
             resultEquals(result, found('documentId'));
           });
     });
   });
 
-  it('returns not found for missing documents', function() {
+  it('returns not found for missing documents', () => {
     const overrides = {
       batchGetDocuments: () => stream(found('exists'), missing('missing'))
     };
@@ -939,7 +943,7 @@ describe('getAll() method', function() {
     });
   });
 
-  it('returns results in order', function() {
+  it('returns results in order', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream(
@@ -963,7 +967,7 @@ describe('getAll() method', function() {
     });
   });
 
-  it('accepts same document multiple times', function() {
+  it('accepts same document multiple times', () => {
     const overrides = {
       batchGetDocuments: request => {
         assert.equal(request.documents.length, 2);

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import assert from 'power-assert';
 import extend from 'extend';
+import * as gax from 'google-gax';
 import is from 'is';
+import assert from 'power-assert';
 import through2 from 'through2';
 
-import {ResourcePath} from '../src/path';
-import {createInstance, InvalidApiUsage} from '../test/util/helpers';
-import * as gax from 'google-gax';
-
 import * as Firestore from '../src';
-
+import {ResourcePath} from '../src/path';
 import {AnyDuringMigration} from '../src/types';
+import {createInstance, InvalidApiUsage} from '../test/util/helpers';
+
 const {grpc} = new gax.GrpcClient({} as AnyDuringMigration);
 
 const PROJECT_ID = 'test-project';
@@ -391,7 +390,7 @@ describe('instantiation', () => {
 
     const gapicClient = {getProjectId: callback => callback(null, PROJECT_ID)};
 
-    return  firestore['_detectProjectId'] (gapicClient).then(projectId => {
+    return firestore['_detectProjectId'](gapicClient).then(projectId => {
       assert.equal(projectId, PROJECT_ID);
     });
   });
@@ -420,7 +419,7 @@ describe('instantiation', () => {
       getProjectId: callback => callback(new Error('Injected Error'))
     };
 
-    return  firestore['_detectProjectId'] (gapicClient)
+    return firestore['_detectProjectId'](gapicClient)
         .then(() => assert.fail('Error ignored'))
         .catch(err => assert.equal('Injected Error', err.message));
   });

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'power-assert';
 
 import * as Firestore from '../src';
 import {DocumentReference} from '../src/reference';
 import {DocumentSnapshot} from '../src/document';
-import {createInstance} from '../test/util/helpers';
+import {createInstance, InvalidApiUsage} from '../test/util/helpers';
 import {ResourcePath} from '../src/path';
 import {GeoPoint} from '../src/geo-point';
-import * as order from '../src/order'
+import * as order from '../src/order';
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});
 
-describe('Order', function() {
+describe('Order', () => {
   let firestore;
 
   beforeEach(() => {
@@ -56,38 +54,40 @@ describe('Order', function() {
     return wrap(new GeoPoint(lat, lng));
   }
 
-  function int(number) {
+  function int(n: number) {
     return {
-      integerValue: '' + number,
+      integerValue: '' + n,
     };
   }
 
-  function double(number) {
+  function double(n: number) {
     return {
-      doubleValue: '' + number,
+      doubleValue: '' + n,
     };
   }
 
-  it('throws on invalid value', function() {
+  it('throws on invalid value', () => {
     assert.throws(() => {
-      order.compare({valueType: 'foo'}, {valueType: 'foo'});
+      order.compare(
+          {valueType: 'foo'} as InvalidApiUsage,
+          {valueType: 'foo'} as InvalidApiUsage);
     }, /Invalid use of type "object" as a Firestore argument./);
   });
 
-  it('throws on invalid blob', function() {
+  it('throws on invalid blob', () => {
     assert.throws(() => {
       order.compare(
           {
-            bytesValue: [1, 2, 3],
+            bytesValue: new Uint8Array([1, 2, 3]),
           },
           {
-            bytesValue: [1, 2, 3],
+            bytesValue: new Uint8Array([1, 2, 3]),
           });
     }, /Blobs can only be compared if they are Buffers/);
   });
 
-  it('compares document snapshots by name', function() {
-    let docs = [
+  it('compares document snapshots by name', () => {
+    const docs = [
       new DocumentSnapshot(firestore.doc('col/doc3')),
       new DocumentSnapshot(firestore.doc('col/doc2')),
       new DocumentSnapshot(firestore.doc('col/doc2')),
@@ -100,7 +100,7 @@ describe('Order', function() {
         docs.map(doc => doc.id), ['doc1', 'doc2', 'doc2', 'doc3']);
   });
 
-  it('is correct', function() {
+  it('is correct', () => {
     const groups = [
       // null first
       [wrap(null)],

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -17,12 +17,12 @@
 import assert from 'power-assert';
 
 import * as Firestore from '../src';
-import {DocumentReference} from '../src/reference';
 import {DocumentSnapshot} from '../src/document';
-import {createInstance, InvalidApiUsage} from '../test/util/helpers';
-import {ResourcePath} from '../src/path';
 import {GeoPoint} from '../src/geo-point';
 import * as order from '../src/order';
+import {ResourcePath} from '../src/path';
+import {DocumentReference} from '../src/reference';
+import {createInstance, InvalidApiUsage} from '../test/util/helpers';
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});

--- a/dev/test/path.ts
+++ b/dev/test/path.ts
@@ -14,37 +14,36 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'power-assert';
 
 import {FieldPath, ResourcePath} from '../src/path';
+import {InvalidApiUsage} from './util/helpers';
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
 
-describe('ResourcePath', function() {
-  it('has id property', function() {
+describe('ResourcePath', () => {
+  it('has id property', () => {
     assert.equal(new ResourcePath(PROJECT_ID, '(default)', 'foo').id, 'foo');
     assert.equal(new ResourcePath(PROJECT_ID, '(default)').id, null);
   });
 
-  it('has append() method', function() {
+  it('has append() method', () => {
     let path = new ResourcePath(PROJECT_ID, '(default)');
     assert.equal(path.formattedName, DATABASE_ROOT);
     path = path.append('foo');
     assert.equal(path.formattedName, `${DATABASE_ROOT}/documents/foo`);
   });
 
-  it('has parent() method', function() {
+  it('has parent() method', () => {
     let path = new ResourcePath(PROJECT_ID, '(default)', 'foo');
     assert.equal(path.formattedName, `${DATABASE_ROOT}/documents/foo`);
-    path = path.parent();
+    path = path.parent()!;
     assert.equal(path.formattedName, DATABASE_ROOT);
     assert.equal(path.parent(), null);
   });
 
-  it('parses strings', function() {
+  it('parses strings', () => {
     let path = ResourcePath.fromSlashSeparatedString(DATABASE_ROOT);
     assert.equal(path.formattedName, DATABASE_ROOT);
     path =
@@ -56,63 +55,63 @@ describe('ResourcePath', function() {
     }, /Resource name 'projects\/project\/databases' is not valid\./);
   });
 
-  it('accepts newlines', function() {
+  it('accepts newlines', () => {
     const path = ResourcePath.fromSlashSeparatedString(
         `${DATABASE_ROOT}/documents/foo\nbar`);
     assert.equal(path.formattedName, `${DATABASE_ROOT}/documents/foo\nbar`);
   });
 });
 
-describe('FieldPath', function() {
-  it('encodes field names', function() {
-    let components = [['foo'], ['foo', 'bar'], ['.', '`'], ['\\']];
+describe('FieldPath', () => {
+  it('encodes field names', () => {
+    const components = [['foo'], ['foo', 'bar'], ['.', '`'], ['\\']];
 
-    let results = ['foo', 'foo.bar', '`.`.`\\``', '`\\\\`'];
+    const results = ['foo', 'foo.bar', '`.`.`\\``', '`\\\\`'];
 
     for (let i = 0; i < components.length; ++i) {
-      assert.equal(new FieldPath(components[i]).toString(), results[i]);
+      assert.equal(new FieldPath(...components[i]).toString(), results[i]);
     }
   });
 
-  it('doesn\'t accept empty path', function() {
+  it('doesn\'t accept empty path', () => {
     assert.throws(() => {
       new FieldPath();
     }, /Function 'FieldPath\(\)' requires at least 1 argument\./);
   });
 
-  it('only accepts strings', function() {
+  it('only accepts strings', () => {
     assert.throws(() => {
-      new FieldPath('foo', 'bar', 0);
+      new FieldPath('foo', 'bar', 0 as InvalidApiUsage);
     }, /Argument at index 2 is not a valid string\./);
   });
 
-  it('has append() method', function() {
+  it('has append() method', () => {
     let path = new FieldPath('foo');
     path = path.append('bar');
     assert.equal(path.formattedName, 'foo.bar');
   });
 
-  it('has parent() method', function() {
+  it('has parent() method', () => {
     let path = new FieldPath('foo', 'bar');
-    path = path.parent();
+    path = path.parent()!;
     assert.equal(path.formattedName, 'foo');
   });
 
-  it('escapes special characters', function() {
-    let path = new FieldPath('f.o.o');
+  it('escapes special characters', () => {
+    const path = new FieldPath('f.o.o');
     assert.equal(path.formattedName, '`f.o.o`');
   });
 
-  it('doesn\'t allow empty components', function() {
+  it('doesn\'t allow empty components', () => {
     assert.throws(() => {
       new FieldPath('foo', '');
     }, /Argument at index 1 should not be empty./);
   });
 
-  it('has isEqual() method', function() {
-    let path = new FieldPath('a');
-    let equals = new FieldPath('a');
-    let notEquals = new FieldPath('a', 'b', 'a');
+  it('has isEqual() method', () => {
+    const path = new FieldPath('a');
+    const equals = new FieldPath('a');
+    const notEquals = new FieldPath('a', 'b', 'a');
     assert.ok(path.isEqual(equals));
     assert.ok(!path.isEqual(notEquals));
   });

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-import assert from 'power-assert';
 import extend from 'extend';
 import is from 'is';
+import assert from 'power-assert';
 import through2 from 'through2';
 
 import {google} from '../protos/firestore_proto_api';
-
 import * as Firestore from '../src';
-import {DocumentReference} from '../src/reference';
+import {Query, Timestamp} from '../src';
 import {DocumentSnapshot} from '../src/document';
 import {ResourcePath} from '../src/path';
+import {DocumentReference} from '../src/reference';
 import {AnyDuringMigration} from '../src/types';
-import {Query, Timestamp} from '../src';
-
 import {createInstance, InvalidApiUsage} from '../test/util/helpers';
 
 import api = google.firestore.v1beta1;

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
-
 import * as Firestore from '../src/index';
 import is from 'is';
 import through2 from 'through2';
@@ -28,7 +25,7 @@ function createInstance(opts, document) {
   const overrides = {
     batchGetDocuments: () => {
       const stream = through2.obj();
-      setImmediate(function() {
+      setImmediate(() => {
         stream.push({found: document, readTime: {seconds: 5, nanos: 6}});
         stream.push(null);
       });
@@ -37,11 +34,11 @@ function createInstance(opts, document) {
     }
   };
 
-  return createInstanceHelper(overrides, opts)
+  return createInstanceHelper(overrides, opts);
 }
 
 function document(field, value) {
-  let document = {
+  const document = {
     name: `projects/test-project/databases/(default)/documents/coll/doc`,
     fields: {},
     createTime: {},
@@ -70,20 +67,20 @@ const DOCUMENT_WITH_EMPTY_TIMESTAMP = document('moonLanding', {
   timestampValue: {},
 });
 
-describe('timestamps', function() {
-  it('returned when enabled', function() {
+describe('timestamps', () => {
+  it('returned when enabled', () => {
     return createInstance(
                {timestampsInSnapshots: true}, DOCUMENT_WITH_TIMESTAMP)
         .then(firestore => {
           const expected = new Firestore.Timestamp(-14182920, 123000123);
           return firestore.doc('coll/doc').get().then(res => {
-            assert.ok(res.data()['moonLanding'].isEqual(expected));
-            assert.ok(res.get('moonLanding').isEqual(expected));
+            assert.ok(res.data()!['moonLanding'].isEqual(expected));
+            assert.ok(res.get('moonLanding')!.isEqual(expected));
           });
         });
   });
 
-  it('converted to dates when disabled', function() {
+  it('converted to dates when disabled', () => {
     const oldErrorLog = console.error;
     // Prevent error message that prompts to enable `timestampsInSnapshots`
     // behavior.
@@ -93,14 +90,14 @@ describe('timestamps', function() {
                {timestampsInSnapshots: false}, DOCUMENT_WITH_TIMESTAMP)
         .then(firestore => {
           return firestore.doc('coll/doc').get().then(res => {
-            assert.ok(is.date(res.data()['moonLanding']));
+            assert.ok(is.date(res.data()!['moonLanding']));
             assert.ok(is.date(res.get('moonLanding')));
             console.error = oldErrorLog;
           });
         });
   });
 
-  it('retain seconds and nanoseconds', function() {
+  it('retain seconds and nanoseconds', () => {
     return createInstance(
                {timestampsInSnapshots: true}, DOCUMENT_WITH_TIMESTAMP)
         .then(firestore => {
@@ -112,7 +109,7 @@ describe('timestamps', function() {
         });
   });
 
-  it('convert to date', function() {
+  it('convert to date', () => {
     return createInstance(
                {timestampsInSnapshots: true}, DOCUMENT_WITH_TIMESTAMP)
         .then(firestore => {
@@ -125,7 +122,7 @@ describe('timestamps', function() {
         });
   });
 
-  it('convert to millis', function() {
+  it('convert to millis', () => {
     return createInstance(
                {timestampsInSnapshots: true}, DOCUMENT_WITH_TIMESTAMP)
         .then(firestore => {
@@ -136,7 +133,7 @@ describe('timestamps', function() {
         });
   });
 
-  it('support missing values', function() {
+  it('support missing values', () => {
     return createInstance(
                {timestampsInSnapshots: true}, DOCUMENT_WITH_EMPTY_TIMESTAMP)
         .then(firestore => {
@@ -148,7 +145,7 @@ describe('timestamps', function() {
         });
   });
 
-  it('constructed using helper', function() {
+  it('constructed using helper', () => {
     assert.ok(is.instance(Firestore.Timestamp.now(), Firestore.Timestamp));
 
     let actual = Firestore.Timestamp.fromDate(new Date(123123));
@@ -160,7 +157,7 @@ describe('timestamps', function() {
     assert.ok(actual.isEqual(expected));
   });
 
-  it('validates nanoseconds', function() {
+  it('validates nanoseconds', () => {
     assert.throws(
         () => new Firestore.Timestamp(0.1, 0),
         /Argument "seconds" is not a valid integer./);

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as Firestore from '../src/index';
+import assert from 'assert';
 import is from 'is';
 import through2 from 'through2';
-import assert from 'assert';
 
+import * as Firestore from '../src/index';
 import {createInstance as createInstanceHelper} from '../test/util/helpers';
 
 function createInstance(opts, document) {

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -35,9 +35,10 @@ import Precondition = FirebaseFirestore.Precondition;
 import SetOptions = FirebaseFirestore.SetOptions;
 import Timestamp = FirebaseFirestore.Timestamp;
 import Settings = FirebaseFirestore.Settings;
+import {AnyDuringMigration} from '../src/types';
 
 // This test verifies the Typescript typings and is not meant for execution.
-xdescribe('firestore.d.ts', function() {
+xdescribe('firestore.d.ts', () => {
   const firestore: Firestore = new Firestore({
     keyFilename: 'foo',
     projectId: 'foo',
@@ -254,7 +255,7 @@ xdescribe('firestore.d.ts', function() {
       const empty: boolean = snapshot.empty;
       const readTime: Timestamp = snapshot.readTime;
       snapshot.forEach((result: QueryDocumentSnapshot) => {});
-      snapshot.forEach((result: QueryDocumentSnapshot) => {}, this);
+      snapshot.forEach((result: QueryDocumentSnapshot) => {}, {});
       const equals: boolean = snapshot.isEqual(snapshot);
     });
   });

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -36,6 +36,10 @@ export const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
 export const COLLECTION_ROOT = `${DATABASE_ROOT}/documents/collectionId`;
 export const DOCUMENT_NAME = `${COLLECTION_ROOT}/documentId`;
 
+// Allow invalid API usage to test error handling.
+// tslint:disable-next-line:no-any
+export type InvalidApiUsage = any;
+
 /** A Promise implementation that supports deferred resolution. */
 export class Deferred<R> {
   promise: Promise<R>;

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import assert from 'power-assert';
 import duplexify from 'duplexify';
 import is from 'is';
+import assert from 'power-assert';
 import through2 from 'through2';
 
 import {google} from '../protos/firestore_proto_api';
-
 import * as Firestore from '../src';
-import {DocumentSnapshot} from '../src/document';
 import {setTimeoutHandler} from '../src/backoff';
-import {createInstance} from '../test/util/helpers';
+import {DocumentSnapshot} from '../src/document';
 import {AnyDuringMigration} from '../src/types';
+import {createInstance} from '../test/util/helpers';
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'power-assert';
 import duplexify from 'duplexify';
 import is from 'is';
@@ -27,11 +25,13 @@ import * as Firestore from '../src';
 import {DocumentSnapshot} from '../src/document';
 import {setTimeoutHandler} from '../src/backoff';
 import {createInstance} from '../test/util/helpers';
+import {AnyDuringMigration} from '../src/types';
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});
 
-const api = google.firestore.v1beta1;
+import api = google.firestore.v1beta1;
+import {QueryDocumentSnapshot} from '../src';
 
 let PROJECT_ID = process.env.PROJECT_ID;
 if (!PROJECT_ID) {
@@ -42,7 +42,7 @@ if (!PROJECT_ID) {
  * @param actual The computed docs array.
  * @param expected The expected docs array.
  */
-const docsEqual = function(actual, expected) {
+function docsEqual(actual, expected) {
   assert.equal(actual.length, expected.length);
   for (let i = 0; i < actual.size; i++) {
     assert.equal(actual[i].ref.id, expected[i].ref.id);
@@ -50,7 +50,8 @@ const docsEqual = function(actual, expected) {
     assert.ok(is.string(expected[i].createTime));
     assert.ok(is.string(expected[i].updateTime));
   }
-};
+}
+
 /**
  * Asserts that the given query snapshot matches the expected results.
  * @param lastSnapshot The previous snapshot that this snapshot is based upon.
@@ -58,8 +59,8 @@ const docsEqual = function(actual, expected) {
  * @param actual A QuerySnapshot with results.
  * @param expected Array of DocumentSnapshot.
  */
-const snapshotsEqual = function(lastSnapshot, version, actual, expected) {
-  let localDocs = [].concat(lastSnapshot.docs);
+function snapshotsEqual(lastSnapshot, version, actual, expected) {
+  const localDocs: QueryDocumentSnapshot[] = [].concat(lastSnapshot.docs);
 
   const actualDocChanges = actual.docChanges();
 
@@ -70,7 +71,7 @@ const snapshotsEqual = function(lastSnapshot, version, actual, expected) {
         actualDocChanges[i].doc.ref.id, expected.docChanges[i].doc.ref.id);
     assert.deepStrictEqual(
         actualDocChanges[i].doc.data(), expected.docChanges[i].doc.data());
-    let readVersion =
+    const readVersion =
         actualDocChanges[i].type === 'removed' ? version - 1 : version;
     assert.ok(actualDocChanges[i].doc.readTime.isEqual(
         new Firestore.Timestamp(0, readVersion)));
@@ -91,12 +92,12 @@ const snapshotsEqual = function(lastSnapshot, version, actual, expected) {
   assert.equal(actual.size, expected.docs.length);
 
   return {docs: actual.docs, docChanges: actualDocChanges};
-};
+}
 
 /*
  * Helper for constructing a snapshot.
  */
-const snapshot = function(ref, data) {
+function snapshot(ref, data) {
   const snapshot = new DocumentSnapshot.Builder();
   snapshot.ref = ref;
   snapshot.fieldsProto = ref.firestore._serializer.encodeFields(data);
@@ -104,17 +105,14 @@ const snapshot = function(ref, data) {
   snapshot.createTime = new Firestore.Timestamp(0, 0);
   snapshot.updateTime = new Firestore.Timestamp(0, 0);
   return snapshot.build();
-};
+}
 
 /*
  * Helpers for constructing document changes.
  */
-const docChange = function(type, ref, data) {
-  return {
-    type: type,
-    doc: snapshot(ref, data),
-  };
-};
+function docChange(type, ref, data) {
+  return {type, doc: snapshot(ref, data)};
+}
 
 const added = (ref, data) => docChange('added', ref, data);
 const modified = (ref, data) => docChange('modified', ref, data);
@@ -127,17 +125,15 @@ const EMPTY = {
 
 /** Captures stream data and makes it available via deferred Promises. */
 class DeferredListener {
-  constructor() {
-    this.pendingData = [];
-    this.pendingListeners = [];
-  }
+  private readonly pendingData: AnyDuringMigration[] = [];
+  private readonly pendingListeners: AnyDuringMigration[] = [];
 
   /**
    * Makes stream data available via the Promises set in the 'await' call. If no
    * Promise has been set, the data will be cached.
    */
-  on(type, data) {
-    let listener = this.pendingListeners.shift();
+  on(type, data?) {
+    const listener = this.pendingListeners.shift();
 
     if (listener) {
       assert.equal(
@@ -147,8 +143,8 @@ class DeferredListener {
       listener.resolve(data);
     } else {
       this.pendingData.push({
-        type: type,
-        data: data,
+        type,
+        data,
       });
     }
   }
@@ -159,7 +155,7 @@ class DeferredListener {
    * resolves when the next chunk arrives.
    */
   await(expectedType) {
-    let data = this.pendingData.shift();
+    const data = this.pendingData.shift();
 
     if (data) {
       assert.equal(
@@ -171,7 +167,7 @@ class DeferredListener {
 
     return new Promise(resolve => this.pendingListeners.push({
       type: expectedType,
-      resolve: resolve,
+      resolve,
     }));
   }
 }
@@ -182,10 +178,11 @@ class DeferredListener {
  * sequential invocations of the Listen API.
  */
 class StreamHelper {
-  constructor() {
-    this.streamCount = 0;
-    this.deferredListener = new DeferredListener();
-  }
+  private streamCount = 0;
+  private readonly deferredListener = new DeferredListener();
+  private readStream;
+  private writeStream;
+  private backendStream;
 
   /** Returns the GAPIC callback to use with this stream helper. */
   getListenCallback() {
@@ -263,17 +260,21 @@ class StreamHelper {
  * Encapsulates the stream logic for the Watch API.
  */
 class WatchHelper {
+  private readonly serializer;
+  private readonly streamHelper;
+  private snapshotVersion = 0;
+  private readonly deferredListener = new DeferredListener();
+  private unsubscribe;
+
   /**
    * @param streamHelper The StreamHelper base class for this Watch operation.
    * @param reference The CollectionReference or DocumentReference that is being
    * watched.
    * @param targetId The target ID of the watch stream.
    */
-  constructor(streamHelper, reference, targetId) {
-    this.reference = reference;
+  constructor(streamHelper, private reference, private targetId) {
     this.serializer = reference.firestore._serializer;
     this.streamHelper = streamHelper;
-    this.targetId = targetId;
     this.snapshotVersion = 0;
     this.deferredListener = new DeferredListener();
   }
@@ -333,7 +334,7 @@ class WatchHelper {
    * @param {number} cause The optional code indicating why the target was removed.
    */
   sendRemoveTarget(cause) {
-    const proto = {
+    const proto: AnyDuringMigration = {
       targetChange: {
         targetChangeType: 'REMOVE',
         targetIds: [this.targetId],
@@ -355,7 +356,7 @@ class WatchHelper {
   sendSnapshot(version, resumeToken) {
     this.snapshotVersion = version;
 
-    let proto = {
+    const proto: AnyDuringMigration = {
       targetChange: {
         targetChangeType: 'NO_CHANGE',
         targetIds: [],
@@ -374,7 +375,7 @@ class WatchHelper {
    * Sends a target change from the backend of type 'CURRENT'.
    */
   sendCurrent(resumeToken) {
-    let proto = {
+    const proto: AnyDuringMigration = {
       targetChange: {
         targetChangeType: 'CURRENT',
         targetIds: [this.targetId],
@@ -476,7 +477,7 @@ class WatchHelper {
   }
 }
 
-describe('Query watch', function() {
+describe('Query watch', () => {
   // The collection to query.
   let colRef;
 
@@ -501,7 +502,7 @@ describe('Query watch', function() {
             from: [{collectionId: 'col'}],
           },
         },
-        targetId: targetId,
+        targetId,
       },
     };
   };
@@ -532,7 +533,7 @@ describe('Query watch', function() {
             },
           },
         },
-        targetId: targetId,
+        targetId,
       },
     };
   };
@@ -548,8 +549,8 @@ describe('Query watch', function() {
             from: [{collectionId: 'col'}],
           },
         },
-        targetId: targetId,
-        resumeToken: resumeToken,
+        targetId,
+        resumeToken,
       },
     };
   };
@@ -573,7 +574,7 @@ describe('Query watch', function() {
             }],
           },
         },
-        targetId: targetId,
+        targetId,
       },
     };
   };
@@ -581,7 +582,7 @@ describe('Query watch', function() {
   /** The GAPIC callback that executes the listen. */
   let listenCallback;
 
-  beforeEach(function() {
+  beforeEach(() => {
     // We are intentionally skipping the delays to ensure fast test execution.
     // The retry semantics are uneffected by this, as we maintain their
     // asynchronous behavior.
@@ -610,11 +611,11 @@ describe('Query watch', function() {
         });
   });
 
-  afterEach(function() {
+  afterEach(() => {
     setTimeoutHandler(setTimeout);
   });
 
-  it('with invalid callbacks', function() {
+  it('with invalid callbacks', () => {
     assert.throws(() => {
       colRef.onSnapshot('foo');
     }, /Argument "onNext" is not a valid function./);
@@ -624,8 +625,8 @@ describe('Query watch', function() {
     }, /Argument "onError" is not a valid function./);
   });
 
-  it('without error callback', function(done) {
-    let unsubscribe = colRef.onSnapshot(() => {
+  it('without error callback', (done) => {
+    const unsubscribe = colRef.onSnapshot(() => {
       unsubscribe();
       done();
     });
@@ -637,14 +638,14 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles invalid listen protos', function() {
+  it('handles invalid listen protos', () => {
     return watchHelper.runFailedTest(collQueryJSON(), () => {
       // Mock the server responding to the query with an invalid proto.
       streamHelper.write({invalid: true});
     }, 'Unknown listen response type: {"invalid":true}');
   });
 
-  it('handles invalid target change protos', function() {
+  it('handles invalid target change protos', () => {
     return watchHelper.runFailedTest(
         collQueryJSON(),
         () => {
@@ -660,25 +661,25 @@ describe('Query watch', function() {
             '"targetIds":[65261]}');
   });
 
-  it('handles remove target change protos', function() {
+  it('handles remove target change protos', () => {
     return watchHelper.runFailedTest(collQueryJSON(), () => {
       watchHelper.sendRemoveTarget();
     }, 'Error 13: internal error');
   });
 
-  it('handles remove target change with code', function() {
+  it('handles remove target change with code', () => {
     return watchHelper.runFailedTest(collQueryJSON(), () => {
       watchHelper.sendRemoveTarget(7);
     }, 'Error 7: test remove');
   });
 
-  it('rejects an unknown target', function() {
+  it('rejects an unknown target', () => {
     return watchHelper.runFailedTest(collQueryJSON(), () => {
       watchHelper.sendAddTarget(2);
     }, 'Unexpected target ID sent by server');
   });
 
-  it('re-opens on unexpected stream end', function() {
+  it('re-opens on unexpected stream end', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       watchHelper.sendAddTarget();
       watchHelper.sendCurrent();
@@ -704,7 +705,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('doesn\'t re-open inactive stream', function() {
+  it('doesn\'t re-open inactive stream', () => {
     // This test uses the normal timeout handler since it relies on the actual
     // backoff window during the the stream recovery. We then use this window to
     // unsubscribe from the Watch stream and make sure that we don't
@@ -730,7 +731,7 @@ describe('Query watch', function() {
         });
   });
 
-  it('retries based on error code', function() {
+  it('retries based on error code', () => {
     const expectRetry = {
       /* Cancelled */ 1: true,
       /* Unknown */ 2: true,
@@ -756,7 +757,7 @@ describe('Query watch', function() {
       if (expectRetry.hasOwnProperty(statusCode)) {
         result = result.then(() => {
           const err = new Error('GRPC Error');
-          err.code = Number(statusCode);
+          (err as AnyDuringMigration).code = Number(statusCode);
 
           if (expectRetry[statusCode]) {
             return watchHelper.runTest(collQueryJSON(), () => {
@@ -792,7 +793,7 @@ describe('Query watch', function() {
     return result;
   });
 
-  it('retries with unknown code', function() {
+  it('retries with unknown code', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       watchHelper.sendAddTarget();
       watchHelper.sendCurrent();
@@ -804,7 +805,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles changing a doc', function() {
+  it('handles changing a doc', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -850,7 +851,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('reconnects after error', function() {
+  it('reconnects after error', () => {
     let resumeToken = [0xabcd];
 
     return watchHelper.runTest(collQueryJSON(), () => {
@@ -914,7 +915,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('ignores changes sent after the last snapshot', function() {
+  it('ignores changes sent after the last snapshot', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -955,7 +956,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('ignores non-matching tokens', function() {
+  it('ignores non-matching tokens', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -989,7 +990,7 @@ describe('Query watch', function() {
                 targetChangeType: 'NO_CHANGE',
                 targetIds: [],
                 readTime: {seconds: 0, nanos: 0},
-                resumeToken: resumeToken,
+                resumeToken,
               },
             });
 
@@ -1010,7 +1011,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('reconnects with multiple attempts', function() {
+  it('reconnects with multiple attempts', () => {
     return watchHelper
         .runFailedTest(
             collQueryJSON(),
@@ -1018,7 +1019,7 @@ describe('Query watch', function() {
               // Mock the server responding to the query.
               watchHelper.sendAddTarget();
               watchHelper.sendCurrent();
-              let resumeToken = [0xabcd];
+              const resumeToken = [0xabcd];
               watchHelper.sendSnapshot(1, resumeToken);
               return watchHelper.await('snapshot')
                   .then(results => {
@@ -1052,7 +1053,7 @@ describe('Query watch', function() {
         });
   });
 
-  it('sorts docs', function() {
+  it('sorts docs', () => {
     watchHelper = new WatchHelper(streamHelper, sortedQuery(), targetId);
 
     return watchHelper.runTest(sortedQueryJSON(), () => {
@@ -1094,7 +1095,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('combines multiple change events for the same doc', function() {
+  it('combines multiple change events for the same doc', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1140,9 +1141,9 @@ describe('Query watch', function() {
     });
   });
 
-  it('can sort by FieldPath.documentId()', function() {
+  it('can sort by FieldPath.documentId()', () => {
     let query = sortedQuery();
-    let expectedJson = sortedQueryJSON();
+    const expectedJson = sortedQueryJSON();
 
     // Add FieldPath.documentId() sorting
     query = query.orderBy(Firestore.FieldPath.documentId(), 'desc');
@@ -1173,7 +1174,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('sorts document changes in the right order', function() {
+  it('sorts document changes in the right order', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1219,7 +1220,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles changing a doc so it doesn\'t match', function() {
+  it('handles changing a doc so it doesn\'t match', () => {
     watchHelper = new WatchHelper(streamHelper, includeQuery(), targetId);
 
     return watchHelper.runTest(includeQueryJSON(), () => {
@@ -1270,7 +1271,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles deleting a doc', function() {
+  it('handles deleting a doc', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1316,7 +1317,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles removing a doc', function() {
+  it('handles removing a doc', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1362,7 +1363,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles deleting a non-existent doc', function() {
+  it('handles deleting a non-existent doc', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1390,7 +1391,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles reset', function() {
+  it('handles reset', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1459,7 +1460,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles reset with phantom doc', function() {
+  it('handles reset with phantom doc', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1510,7 +1511,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles sending the snapshot version multiple times', function() {
+  it('handles sending the snapshot version multiple times', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1538,7 +1539,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles filter mismatch', function() {
+  it('handles filter mismatch', () => {
     let oldRequestStream;
 
     return watchHelper.runTest(collQueryJSON(), () => {
@@ -1587,7 +1588,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles filter match', function() {
+  it('handles filter match', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       watchHelper.sendAddTarget();
       // Add a result.
@@ -1623,7 +1624,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles resets with pending updates', function() {
+  it('handles resets with pending updates', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       watchHelper.sendAddTarget();
       // Add a result.
@@ -1661,7 +1662,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles add and delete in same snapshot', function() {
+  it('handles add and delete in same snapshot', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1687,7 +1688,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles non-changing modify', function() {
+  it('handles non-changing modify', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1725,7 +1726,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles update time change', function() {
+  it('handles update time change', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -1770,7 +1771,7 @@ describe('Query watch', function() {
     });
   });
 
-  describe('supports isEqual', function() {
+  describe('supports isEqual', () => {
     let snapshotVersion;
 
     beforeEach(() => {
@@ -1793,7 +1794,7 @@ describe('Query watch', function() {
       return watchHelper.await('snapshot');
     }
 
-    it('for equal snapshots', function() {
+    it('for equal snapshots', () => {
       let firstSnapshot;
       let secondSnapshot;
       let thirdSnapshot;
@@ -1847,7 +1848,7 @@ describe('Query watch', function() {
                 }));
     });
 
-    it('for equal snapshots with materialized changes', function() {
+    it('for equal snapshots with materialized changes', () => {
       let firstSnapshot;
 
       return initialSnapshot(snapshot => {
@@ -1865,14 +1866,14 @@ describe('Query watch', function() {
                            watchHelper.sendDoc(doc2, {foo: 'b'});
                            watchHelper.sendDoc(doc3, {foo: 'c'});
                          }).then(snapshot => {
-                    let materializedDocs = snapshot.docs;
+                    const materializedDocs = snapshot.docs;
                     assert.equal(materializedDocs.length, 3);
                     assert.ok(snapshot.isEqual(firstSnapshot));
                   });
                 }));
     });
 
-    it('for snapshots of different size', function() {
+    it('for snapshots of different size', () => {
       let firstSnapshot;
 
       return initialSnapshot(snapshot => {
@@ -1892,7 +1893,7 @@ describe('Query watch', function() {
                 }));
     });
 
-    it('for snapshots with different kind of changes', function() {
+    it('for snapshots with different kind of changes', () => {
       let firstSnapshot;
 
       return initialSnapshot(snapshot => {
@@ -1915,7 +1916,7 @@ describe('Query watch', function() {
                 }));
     });
 
-    it('for snapshots with different number of changes', function() {
+    it('for snapshots with different number of changes', () => {
       let firstSnapshot;
 
       return initialSnapshot(snapshot => {
@@ -1954,7 +1955,7 @@ describe('Query watch', function() {
                 }));
     });
 
-    it('for snapshots with different data types', function() {
+    it('for snapshots with different data types', () => {
       let originalSnapshot;
 
       return initialSnapshot(snapshot => {
@@ -1973,7 +1974,7 @@ describe('Query watch', function() {
                 }));
     });
 
-    it('for snapshots with different queries', function() {
+    it('for snapshots with different queries', () => {
       let firstSnapshot;
 
       return initialSnapshot(snapshot => {
@@ -2002,7 +2003,7 @@ describe('Query watch', function() {
     });
   });
 
-  it('handles delete and re-add in same snapshot', function() {
+  it('handles delete and re-add in same snapshot', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
@@ -2042,7 +2043,7 @@ describe('Query watch', function() {
   });
 });
 
-describe('DocumentReference watch', function() {
+describe('DocumentReference watch', () => {
   // The document to query.
   let doc;
 
@@ -2059,7 +2060,7 @@ describe('DocumentReference watch', function() {
         documents: {
           documents: [doc.formattedName],
         },
-        targetId: targetId,
+        targetId,
       },
     };
   };
@@ -2072,20 +2073,20 @@ describe('DocumentReference watch', function() {
         documents: {
           documents: [doc.formattedName],
         },
-        targetId: targetId,
-        resumeToken: resumeToken,
+        targetId,
+        resumeToken,
       },
     };
   };
 
-  beforeEach(function() {
+  beforeEach(() => {
     // We are intentionally skipping the delays to ensure fast test execution.
     // The retry semantics are uneffected by this, as we maintain their
     // asynchronous behavior.
     setTimeoutHandler(setImmediate);
 
     targetId = 0x1;
-    streamHelper = new StreamHelper(firestore);
+    streamHelper = new StreamHelper();
 
     const overrides = {listen: streamHelper.getListenCallback()};
     return createInstance(overrides).then(firestoreClient => {
@@ -2095,11 +2096,11 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  afterEach(function() {
+  afterEach(() => {
     setTimeoutHandler(setTimeout);
   });
 
-  it('with invalid callbacks', function() {
+  it('with invalid callbacks', () => {
     assert.throws(() => {
       doc.onSnapshot('foo');
     }, /Argument "onNext" is not a valid function./);
@@ -2109,8 +2110,8 @@ describe('DocumentReference watch', function() {
     }, /Argument "onError" is not a valid function./);
   });
 
-  it('without error callback', function(done) {
-    let unsubscribe = doc.onSnapshot(() => {
+  it('without error callback', done => {
+    const unsubscribe = doc.onSnapshot(() => {
       unsubscribe();
       done();
     });
@@ -2122,14 +2123,14 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  it('handles invalid listen protos', function() {
+  it('handles invalid listen protos', () => {
     return watchHelper.runFailedTest(watchJSON(), () => {
       // Mock the server responding to the watch with an invalid proto.
       streamHelper.write({invalid: true});
     }, 'Unknown listen response type: {"invalid":true}');
   });
 
-  it('handles invalid target change protos', function() {
+  it('handles invalid target change protos', () => {
     return watchHelper.runFailedTest(
         watchJSON(),
         () => {
@@ -2145,19 +2146,19 @@ describe('DocumentReference watch', function() {
             '"targetIds":[65261]}');
   });
 
-  it('handles remove target change protos', function() {
+  it('handles remove target change protos', () => {
     return watchHelper.runFailedTest(watchJSON(), () => {
       watchHelper.sendRemoveTarget();
     }, 'Error 13: internal error');
   });
 
-  it('handles remove target change with code', function() {
+  it('handles remove target change with code', () => {
     return watchHelper.runFailedTest(watchJSON(), () => {
       watchHelper.sendRemoveTarget(7);
     }, 'Error 7: test remove');
   });
 
-  it('handles changing a doc', function() {
+  it('handles changing a doc', () => {
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
       watchHelper.sendAddTarget();
@@ -2192,7 +2193,7 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  it('ignores non-matching doc', function() {
+  it('ignores non-matching doc', () => {
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
       watchHelper.sendAddTarget();
@@ -2223,8 +2224,8 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  it('reconnects after error', function() {
-    let resumeToken = [0xabcd];
+  it('reconnects after error', () => {
+    const resumeToken = [0xabcd];
 
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
@@ -2270,7 +2271,7 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  it('combines multiple change events for the same doc', function() {
+  it('combines multiple change events for the same doc', () => {
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
       watchHelper.sendAddTarget();
@@ -2307,7 +2308,7 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  it('handles deleting a doc', function() {
+  it('handles deleting a doc', () => {
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
       watchHelper.sendAddTarget();
@@ -2336,7 +2337,7 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  it('handles removing a doc', function() {
+  it('handles removing a doc', () => {
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
       watchHelper.sendAddTarget();
@@ -2365,7 +2366,7 @@ describe('DocumentReference watch', function() {
     });
   });
 
-  it('handles reset', function() {
+  it('handles reset', () => {
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
       watchHelper.sendAddTarget();
@@ -2402,12 +2403,12 @@ describe('DocumentReference watch', function() {
   });
 });
 
-describe('Query comparator', function() {
+describe('Query comparator', () => {
   let firestore;
   let colRef;
   let doc1, doc2, doc3, doc4;
 
-  beforeEach(function() {
+  beforeEach(() => {
     return createInstance().then(firestoreClient => {
       firestore = firestoreClient;
 
@@ -2426,7 +2427,7 @@ describe('Query comparator', function() {
     docsEqual(input, expected);
   }
 
-  it('handles basic case', function() {
+  it('handles basic case', () => {
     const query = colRef.orderBy('foo');
 
     const input = [
@@ -2444,7 +2445,7 @@ describe('Query comparator', function() {
     testSort(query, input, expected);
   });
 
-  it('handles descending case', function() {
+  it('handles descending case', () => {
     const query = colRef.orderBy('foo', 'desc');
 
     const input = [
@@ -2462,7 +2463,7 @@ describe('Query comparator', function() {
     testSort(query, input, expected);
   });
 
-  it('handles nested fields', function() {
+  it('handles nested fields', () => {
     const query = colRef.orderBy('foo.bar');
 
     const input = [
@@ -2480,7 +2481,7 @@ describe('Query comparator', function() {
     testSort(query, input, expected);
   });
 
-  it('fails on missing fields', function() {
+  it('fails on missing fields', () => {
     const query = colRef.orderBy('bar');
 
     const input = [

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-'use strict';
-
 import assert from 'power-assert';
 
 import {google} from '../protos/firestore_proto_api';
@@ -30,7 +28,7 @@ Firestore.setLogFunction(() => {});
 
 const PROJECT_ID = 'test-project';
 
-describe('set() method', function() {
+describe('set() method', () => {
   let firestore;
   let writeBatch;
 
@@ -41,24 +39,24 @@ describe('set() method', function() {
     });
   });
 
-  it('requires document name', function() {
-    assert.throws(function() {
-      writeBatch.set();
-    }, /Argument "documentRef" is not a valid DocumentReference\./);
+  it('requires document name', () => {
+    assert.throws(
+        () => writeBatch.set(),
+        /Argument "documentRef" is not a valid DocumentReference\./);
   });
 
-  it('requires object', function() {
-    assert.throws(function() {
-      writeBatch.set(firestore.doc('sub/doc'));
-    }, /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
+  it('requires object', () => {
+    assert.throws(
+        () => writeBatch.set(firestore.doc('sub/doc')),
+        /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
   });
 
-  it('accepts preconditions', function() {
+  it('accepts preconditions', () => {
     writeBatch.set(firestore.doc('sub/doc'), {exists: false});
   });
 });
 
-describe('delete() method', function() {
+describe('delete() method', () => {
   let firestore;
   let writeBatch;
 
@@ -69,20 +67,20 @@ describe('delete() method', function() {
     });
   });
 
-  it('requires document name', function() {
-    assert.throws(function() {
-      writeBatch.delete();
-    }, /Argument "documentRef" is not a valid DocumentReference\./);
+  it('requires document name', () => {
+    assert.throws(
+        () => writeBatch.delete(),
+        /Argument "documentRef" is not a valid DocumentReference\./);
   });
 
-  it('accepts preconditions', function() {
+  it('accepts preconditions', () => {
     writeBatch.delete(firestore.doc('sub/doc'), {
       lastUpdateTime: new Firestore.Timestamp(479978400, 123000000),
     });
   });
 });
 
-describe('update() method', function() {
+describe('update() method', () => {
   let firestore;
   let writeBatch;
 
@@ -93,26 +91,26 @@ describe('update() method', function() {
     });
   });
 
-  it('requires document name', function() {
-    assert.throws(() => {
-      writeBatch.update({}, {});
-    }, /Argument "documentRef" is not a valid DocumentReference\./);
+  it('requires document name', () => {
+    assert.throws(
+        () => writeBatch.update({}, {}),
+        /Argument "documentRef" is not a valid DocumentReference\./);
   });
 
-  it('requires object', function() {
+  it('requires object', () => {
     assert.throws(() => {
       writeBatch.update(firestore.doc('sub/doc'), firestore.doc('sub/doc'));
     }, /Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object./);
   });
 
-  it('accepts preconditions', function() {
+  it('accepts preconditions', () => {
     writeBatch.update(
         firestore.doc('sub/doc'), {foo: 'bar'},
         {lastUpdateTime: new Firestore.Timestamp(479978400, 123000000)});
   });
 });
 
-describe('create() method', function() {
+describe('create() method', () => {
   let firestore;
   let writeBatch;
 
@@ -123,20 +121,20 @@ describe('create() method', function() {
     });
   });
 
-  it('requires document name', function() {
-    assert.throws(function() {
-      writeBatch.create();
-    }, /Argument "documentRef" is not a valid DocumentReference\./);
+  it('requires document name', () => {
+    assert.throws(
+        () => writeBatch.create(),
+        /Argument "documentRef" is not a valid DocumentReference\./);
   });
 
-  it('requires object', function() {
-    assert.throws(function() {
+  it('requires object', () => {
+    assert.throws(() => {
       writeBatch.create(firestore.doc('sub/doc'));
     }, /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
   });
 });
 
-describe('batch support', function() {
+describe('batch support', () => {
   const documentName =
       `projects/${PROJECT_ID}/databases/(default)/documents/col/doc`;
 
@@ -251,8 +249,8 @@ describe('batch support', function() {
     assert.ok(writeResults[3].writeTime.isEqual(new Firestore.Timestamp(3, 3)));
   }
 
-  it('accepts multiple operations', function() {
-    let documentName = firestore.doc('col/doc');
+  it('accepts multiple operations', () => {
+    const documentName = firestore.doc('col/doc');
 
     writeBatch.set(documentName, {foo: Firestore.FieldValue.serverTimestamp()});
     writeBatch.update(documentName, {foo: 'bar'});
@@ -264,8 +262,8 @@ describe('batch support', function() {
     });
   });
 
-  it('chains multiple operations', function() {
-    let documentName = firestore.doc('col/doc');
+  it('chains multiple operations', () => {
+    const documentName = firestore.doc('col/doc');
 
     return writeBatch
         .set(documentName, {foo: Firestore.FieldValue.serverTimestamp()})
@@ -278,8 +276,8 @@ describe('batch support', function() {
         });
   });
 
-  it('handles exception', function() {
-    firestore.request = function() {
+  it('handles exception', () => {
+    firestore.request = () => {
       return Promise.reject(new Error('Expected exception'));
     };
 
@@ -293,15 +291,15 @@ describe('batch support', function() {
         });
   });
 
-  it('cannot append to committed batch', function() {
-    let documentName = firestore.doc('col/doc');
+  it('cannot append to committed batch', () => {
+    const documentName = firestore.doc('col/doc');
 
-    let batch = firestore.batch();
+    const batch = firestore.batch();
     batch.set(documentName, {foo: Firestore.FieldValue.serverTimestamp()});
     batch.update(documentName, {foo: 'bar'});
     batch.create(documentName, {});
     batch.delete(documentName);
-    let promise = batch.commit();
+    const promise = batch.commit();
 
     assert.throws(() => {
       batch.set(documentName, {});
@@ -310,10 +308,10 @@ describe('batch support', function() {
     return promise;
   });
 
-  it('can commit an unmodified batch multiple times', function() {
-    let documentName = firestore.doc('col/doc');
+  it('can commit an unmodified batch multiple times', () => {
+    const documentName = firestore.doc('col/doc');
 
-    let batch = firestore.batch();
+    const batch = firestore.batch();
     batch.set(documentName, {foo: Firestore.FieldValue.serverTimestamp()});
     batch.update(documentName, {foo: 'bar'});
     batch.create(documentName, {});
@@ -321,7 +319,7 @@ describe('batch support', function() {
     return batch.commit().then(() => batch.commit);
   });
 
-  it('can return same write result', function() {
+  it('can return same write result', () => {
     const overrides = {
       commit: (request, options, callback) => {
         callback(null, {
@@ -345,9 +343,9 @@ describe('batch support', function() {
     };
 
     return createInstance(overrides).then(firestore => {
-      let documentName = firestore.doc('col/doc');
+      const documentName = firestore.doc('col/doc');
 
-      let batch = firestore.batch();
+      const batch = firestore.batch();
       batch.set(documentName, {});
       batch.set(documentName, {});
 
@@ -357,7 +355,7 @@ describe('batch support', function() {
     });
   });
 
-  it('uses transactions on GCF', function() {
+  it('uses transactions on GCF', () => {
     // We use this environment variable during initialization to detect whether
     // we are running on GCF.
     process.env.FUNCTION_TRIGGER_TYPE = 'http-trigger';
@@ -377,13 +375,13 @@ describe('batch support', function() {
             nanos: 0,
             seconds: 0,
           },
-        })
+        });
       }
     };
 
     return createInstance(overrides).then(firestore => {
-      firestore._preferTransactions = true;
-      firestore._lastSuccessfulRequest = null;
+      firestore['_preferTransactions'] = true;
+      firestore['_lastSuccessfulRequest'] = 0;
 
       return firestore.batch()
           .commit()
@@ -398,7 +396,7 @@ describe('batch support', function() {
             // within two minutes.
             assert.equal(1, beginCalled);
             assert.equal(2, commitCalled);
-            firestore._lastSuccessfulRequest = new Date(1337);
+            firestore['_lastSuccessfulRequest'] = 1337;
             return firestore.batch().commit();
           })
           .then(() => {


### PR DESCRIPTION
This converts all manually created tests to TS. The auto-generated test of the Veneer library remains in JS (gapic-v1beta1.js).

There is still lots of room for cleanup (especially regarding the helper functions), which will come in subsequent PRs. 