### PR TITLE
Retiring assert.ok

### DIFF
--- a/dev/test/backoff.ts
+++ b/dev/test/backoff.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {expect} from 'chai';
 import assert from 'power-assert';
 
 import {ExponentialBackoff, setTimeoutHandler} from '../src/backoff';
@@ -45,8 +46,8 @@ describe('ExponentialBackoff', () => {
 
   function assertDelayBetween(low, high) {
     const actual = observedDelays.shift()!;
-    assert.ok(actual >= low);
-    assert.ok(actual <= high);
+    expect(actual).to.be.at.least(low);
+    expect(actual).to.be.at.most(high);
   }
 
   it('doesn\'t delay first attempt', async () => {

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -17,7 +17,6 @@
 
 import {expect} from 'chai';
 
-
 import * as Firestore from '../src/index';
 import DocumentReference = Firestore.DocumentReference;
 import {createInstance, DATABASE_ROOT, document} from './util/helpers';

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {expect} from 'chai';
 import extend from 'extend';
 import is from 'is';
 import assert from 'power-assert';
@@ -256,8 +257,8 @@ describe('DocumentReference interface', () => {
     const doc1 = firestore.doc('coll/doc1');
     const doc1Equals = firestore.doc('coll/doc1');
     const doc2 = firestore.doc('coll/doc1/coll/doc1');
-    assert.ok(doc1.isEqual(doc1Equals));
-    assert.ok(!doc1.isEqual(doc2));
+    expect(doc1.isEqual(doc1Equals)).to.be.true;
+    expect(doc1.isEqual(doc2)).to.be.false;
   });
 });
 
@@ -366,9 +367,8 @@ describe('serialize document', () => {
     const overrides = {
       commit: (request, options, callback) => {
         const fields = request.writes[0].update.fields;
-        assert.ok(
-            typeof fields.nanValue.doubleValue === 'number' &&
-            isNaN(fields.nanValue.doubleValue));
+        expect(fields.nanValue.doubleValue).to.be.a('number');
+        expect(fields.nanValue.doubleValue).to.be.NaN;
         assert.equal(fields.posInfinity.doubleValue, Infinity);
         assert.equal(fields.negInfinity.doubleValue, -Infinity);
 
@@ -650,9 +650,12 @@ describe('get document', () => {
 
     return createInstance(overrides).then(firestore => {
       return firestore.doc('collectionId/documentId').get().then((result) => {
-        assert.ok(result.createTime!.isEqual(new Firestore.Timestamp(1, 2)));
-        assert.ok(result.updateTime!.isEqual(new Firestore.Timestamp(3, 4)));
-        assert.ok(result.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+        expect(result.createTime!.isEqual(new Firestore.Timestamp(1, 2)))
+            .to.be.true;
+        expect(result.updateTime!.isEqual(new Firestore.Timestamp(3, 4)))
+            .to.be.true;
+        expect(result.readTime.isEqual(new Firestore.Timestamp(5, 6)))
+            .to.be.true;
       });
     });
   });
@@ -667,7 +670,8 @@ describe('get document', () => {
     return createInstance(overrides).then(firestore => {
       return firestore.doc('collectionId/documentId').get().then(result => {
         assert.equal(result.exists, false);
-        assert.ok(result.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+        expect(result.readTime.isEqual(new Firestore.Timestamp(5, 6)))
+            .to.be.true;
         assert.equal(null, result.data());
         assert.equal(null, result.get('foo'));
       });
@@ -756,8 +760,9 @@ describe('delete document', () => {
 
     return createInstance(overrides).then(firestore => {
       return firestore.doc('collectionId/documentId').delete().then(res => {
-        assert.ok(res.writeTime.isEqual(
-            new Firestore.Timestamp(479978400, 123000000)));
+        expect(res.writeTime.isEqual(
+                   new Firestore.Timestamp(479978400, 123000000)))
+            .to.be.true;
       });
     });
   });
@@ -1389,8 +1394,9 @@ describe('update document', () => {
       return firestore.doc('collectionId/documentId')
           .update({foo: 'bar'})
           .then(res => {
-            assert.ok(res.writeTime.isEqual(
-                new Firestore.Timestamp(479978400, 123000000)));
+            expect(res.writeTime.isEqual(
+                       new Firestore.Timestamp(479978400, 123000000)))
+                .to.be.true;
           });
     });
   });

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {expect} from 'chai';
 import extend from 'extend';
 import * as gax from 'google-gax';
 import is from 'is';
@@ -426,36 +427,37 @@ describe('instantiation', () => {
 
   it('exports all types', () => {
     // Ordering as per firestore.d.ts
-    assert.ok(is.defined(Firestore.Firestore));
+    expect((Firestore.Firestore)).to.exist;
     assert.equal(Firestore.Firestore.name, 'Firestore');
-    assert.ok(is.defined(Firestore.Timestamp));
+    expect((Firestore.Timestamp)).to.exist;
     assert.equal(Firestore.Timestamp.name, 'Timestamp');
-    assert.ok(is.defined(Firestore.GeoPoint));
+    expect((Firestore.GeoPoint)).to.exist;
     assert.equal(Firestore.GeoPoint.name, 'GeoPoint');
-    assert.ok(is.defined(Firestore.Transaction));
+    expect((Firestore.Transaction)).to.exist;
     assert.equal(Firestore.Transaction.name, 'Transaction');
-    assert.ok(is.defined(Firestore.WriteBatch));
+    expect((Firestore.WriteBatch)).to.exist;
     assert.equal(Firestore.WriteBatch.name, 'WriteBatch');
-    assert.ok(is.defined(Firestore.DocumentReference));
+    expect((Firestore.DocumentReference)).to.exist;
     assert.equal(Firestore.DocumentReference.name, 'DocumentReference');
-    assert.ok(is.defined(Firestore.WriteResult));
+    expect((Firestore.WriteResult)).to.exist;
     assert.equal(Firestore.WriteResult.name, 'WriteResult');
-    assert.ok(is.defined(Firestore.DocumentSnapshot));
+    expect((Firestore.DocumentSnapshot)).to.exist;
     assert.equal(Firestore.DocumentSnapshot.name, 'DocumentSnapshot');
-    assert.ok(is.defined(Firestore.QueryDocumentSnapshot));
+    expect((Firestore.QueryDocumentSnapshot)).to.exist;
     assert.equal(Firestore.QueryDocumentSnapshot.name, 'QueryDocumentSnapshot');
-    assert.ok(is.defined(Firestore.Query));
+    expect((Firestore.Query)).to.exist;
     assert.equal(Firestore.Query.name, 'Query');
-    assert.ok(is.defined(Firestore.QuerySnapshot));
+    expect(Firestore.QuerySnapshot).to.exist;
     assert.equal(Firestore.QuerySnapshot.name, 'QuerySnapshot');
-    assert.ok(is.defined(Firestore.CollectionReference));
+    expect((Firestore.CollectionReference)).to.exist;
     assert.equal(Firestore.CollectionReference.name, 'CollectionReference');
-    assert.ok(is.defined(Firestore.FieldValue));
+    expect((Firestore.FieldValue)).to.exist;
     assert.equal(Firestore.FieldValue.name, 'FieldValue');
-    assert.ok(is.defined(Firestore.FieldPath));
+    expect((Firestore.FieldPath)).to.exist;
     assert.equal(Firestore.Firestore.name, 'Firestore');
-    assert.ok(!Firestore.FieldValue.serverTimestamp().isEqual(
-        Firestore.FieldValue.delete()));
+    expect(Firestore.FieldValue.serverTimestamp().isEqual(
+               Firestore.FieldValue.delete()))
+        .to.be.false;
   });
 });
 
@@ -505,8 +507,9 @@ describe('snapshot_() method', () => {
     assert.equal(
         data.geoPointValue.toString(),
         'GeoPoint { latitude: 50.1430847, longitude: -122.947778 }');
-    assert.ok(data.geoPointValue.isEqual(
-        new Firestore.GeoPoint(50.1430847, -122.947778)));
+    expect(data.geoPointValue.isEqual(
+               new Firestore.GeoPoint(50.1430847, -122.947778)))
+        .to.be.true;
   }
 
   beforeEach(() => {
@@ -529,9 +532,9 @@ describe('snapshot_() method', () => {
 
     assert.equal(true, doc.exists);
     assert.deepStrictEqual({foo: bytesData}, doc.data());
-    assert.ok(doc.createTime.isEqual(new Firestore.Timestamp(1, 2)));
-    assert.ok(doc.updateTime.isEqual(new Firestore.Timestamp(3, 4)));
-    assert.ok(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+    expect(doc.createTime.isEqual(new Firestore.Timestamp(1, 2))).to.be.true;
+    expect(doc.updateTime.isEqual(new Firestore.Timestamp(3, 4))).to.be.true;
+    expect(doc.readTime.isEqual(new Firestore.Timestamp(5, 6))).to.be.true;
   });
 
   it('handles Proto3 JSON together with existing types', () => {
@@ -559,9 +562,10 @@ describe('snapshot_() method', () => {
       b: Firestore.Timestamp.fromDate(new Date('1985-03-18T07:20:00.000Z')),
       c: bytesData,
     });
-    assert.ok(doc.createTime.isEqual(new Firestore.Timestamp(1, 2000000)));
-    assert.ok(doc.updateTime.isEqual(new Firestore.Timestamp(3, 4000)));
-    assert.ok(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+    expect(doc.createTime.isEqual(new Firestore.Timestamp(1, 2000000)))
+        .to.be.true;
+    expect(doc.updateTime.isEqual(new Firestore.Timestamp(3, 4000))).to.be.true;
+    expect(doc.readTime.isEqual(new Firestore.Timestamp(5, 6))).to.be.true;
   });
 
   it('deserializes all supported types from Protobuf JS', () => {
@@ -620,7 +624,7 @@ describe('snapshot_() method', () => {
         '1970-01-01T00:00:05.000000006Z', 'json');
 
     assert.equal(false, doc.exists);
-    assert.ok(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+    expect(doc.readTime.isEqual(new Firestore.Timestamp(5, 6))).to.be.true;
   });
 
   it('handles invalid encoding format ', () => {
@@ -643,7 +647,7 @@ describe('doc() method', () => {
 
   it('returns DocumentReference', () => {
     const documentRef = firestore.doc('collectionId/documentId');
-    assert.ok(documentRef instanceof Firestore.DocumentReference);
+    expect(documentRef).to.be.an.instanceOf(Firestore.DocumentReference);
   });
 
   it('requires document path', () => {
@@ -682,7 +686,7 @@ describe('collection() method', () => {
 
   it('returns collection', () => {
     const collection = firestore.collection('col1/doc1/col2');
-    assert.ok(is.instance(collection, Firestore.CollectionReference));
+    expect(collection).to.be.an.instanceOf(Firestore.CollectionReference);
   });
 
   it('requires collection id', () => {
@@ -700,8 +704,8 @@ describe('collection() method', () => {
 
   it('exposes properties', () => {
     const collection = firestore.collection('collectionId');
-    assert.ok(collection.id);
-    assert.ok(collection.doc);
+    expect(collection.id).to.exist;
+    expect(collection.doc).to.exist;
     assert.equal(collection.id, 'collectionId');
   });
 });
@@ -736,10 +740,10 @@ describe('getAll() method', () => {
       const doc = arguments[i + 1];
 
       if (doc.found) {
-        assert.ok(result[i].exists);
+        expect(result[i].exists).to.be.true;
         assert.equal(result[i].ref.formattedName, doc.found.name);
       } else {
-        assert.ok(!result[i].exists);
+        expect(result[i].exists).to.be.false;
         assert.equal(result[i].ref.formattedName, doc.missing);
       }
     }

--- a/dev/test/path.ts
+++ b/dev/test/path.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {expect} from 'chai';
 import assert from 'power-assert';
 
 import {FieldPath, ResourcePath} from '../src/path';
@@ -112,7 +113,7 @@ describe('FieldPath', () => {
     const path = new FieldPath('a');
     const equals = new FieldPath('a');
     const notEquals = new FieldPath('a', 'b', 'a');
-    assert.ok(path.isEqual(equals));
-    assert.ok(!path.isEqual(notEquals));
+    expect(path.isEqual(equals)).to.be.true;
+    expect(path.isEqual(notEquals)).to.be.false;
   });
 });

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {expect} from 'chai';
 import extend from 'extend';
 import is from 'is';
 import assert from 'power-assert';
@@ -283,44 +284,19 @@ describe('query interface', () => {
     });
   });
 
-  it('has limit() method', () => {
-    const query = firestore.collection('collectionId');
-    assert.ok(query.limit);
-  });
-
-  it('has orderBy() method', () => {
-    const query = firestore.collection('collectionId');
-    assert.ok(query.orderBy);
-  });
-
-  it('has where() method', () => {
-    const query = firestore.collection('collectionId');
-    assert.ok(query.where);
-  });
-
-  it('has stream() method', () => {
-    const query = firestore.collection('collectionId');
-    assert.ok(query.stream);
-  });
-
-  it('has get() method', () => {
-    const query = firestore.collection('collectionId');
-    assert.ok(query.get);
-  });
-
   it('has isEqual() method', () => {
     const query = firestore.collection('collectionId');
 
     const queryEquals = (equals, notEquals) => {
       for (let i = 0; i < equals.length; ++i) {
         for (const equal of equals) {
-          assert.ok(equals[i].isEqual(equal));
-          assert.ok(equal.isEqual(equals[i]));
+          expect(equals[i].isEqual(equal)).to.be.true;
+          expect(equal.isEqual(equals[i])).to.be.true;
         }
 
         for (const notEqual of notEquals) {
-          assert.ok(!equals[i].isEqual(notEqual));
-          assert.ok(!notEqual.isEqual(equals[i]));
+          expect(equals[i].isEqual(notEqual)).to.be.false;
+          expect(notEqual.isEqual(equals[i])).to.be.false;
         }
       }
     };
@@ -430,7 +406,8 @@ describe('query interface', () => {
       return query.get().then(results => {
         assert.equal(0, results.size);
         assert.equal(true, results.empty);
-        assert.ok(results.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+        expect(results.readTime.isEqual(new Firestore.Timestamp(5, 6)))
+            .to.be.true;
       });
     });
   });
@@ -490,7 +467,8 @@ describe('query interface', () => {
       return query.get().then(results => {
         assert.equal(2, results.size);
         assert.equal(false, results.empty);
-        assert.ok(results.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+        expect(results.readTime.isEqual(new Firestore.Timestamp(5, 6)))
+            .to.be.true;
         assert.equal('first', results.docs[0].get('first'));
         assert.equal('second', results.docs[1].get('second'));
         assert.equal(2, results.docChanges().length);
@@ -498,10 +476,13 @@ describe('query interface', () => {
         let count = 0;
 
         results.forEach(doc => {
-          assert.ok(is.instanceof(doc, DocumentSnapshot));
-          assert.ok(doc.createTime.isEqual(new Firestore.Timestamp(1, 2)));
-          assert.ok(doc.updateTime.isEqual(new Firestore.Timestamp(3, 4)));
-          assert.ok(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)));
+          expect(is.instanceof(doc, DocumentSnapshot)).to.be.true;
+          expect(doc.createTime.isEqual(new Firestore.Timestamp(1, 2)))
+              .to.be.true;
+          expect(doc.updateTime.isEqual(new Firestore.Timestamp(3, 4)))
+              .to.be.true;
+          expect(doc.readTime.isEqual(new Firestore.Timestamp(5, 6)))
+              .to.be.true;
           ++count;
         });
 
@@ -579,7 +560,7 @@ describe('query interface', () => {
       query.stream()
           .on('data',
               doc => {
-                assert.ok(is.instanceof(doc, DocumentSnapshot));
+                expect(doc).to.be.an.instanceOf(DocumentSnapshot);
                 ++received;
               })
           .on('end', () => {

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -15,6 +15,7 @@
  */
 
 import assert from 'assert';
+import {expect} from 'chai';
 import is from 'is';
 import through2 from 'through2';
 
@@ -74,8 +75,8 @@ describe('timestamps', () => {
         .then(firestore => {
           const expected = new Firestore.Timestamp(-14182920, 123000123);
           return firestore.doc('coll/doc').get().then(res => {
-            assert.ok(res.data()!['moonLanding'].isEqual(expected));
-            assert.ok(res.get('moonLanding')!.isEqual(expected));
+            expect(res.data()!['moonLanding'].isEqual(expected)).to.be.true;
+            expect(res.get('moonLanding')!.isEqual(expected)).to.be.true;
           });
         });
   });
@@ -90,8 +91,8 @@ describe('timestamps', () => {
                {timestampsInSnapshots: false}, DOCUMENT_WITH_TIMESTAMP)
         .then(firestore => {
           return firestore.doc('coll/doc').get().then(res => {
-            assert.ok(is.date(res.data()!['moonLanding']));
-            assert.ok(is.date(res.get('moonLanding')));
+            expect(is.date(res.data()!['moonLanding'])).to.be.true;
+            expect(is.date(res.get('moonLanding'))).to.be.true;
             console.error = oldErrorLog;
           });
         });
@@ -140,21 +141,21 @@ describe('timestamps', () => {
           const expected = new Firestore.Timestamp(0, 0);
 
           return firestore.doc('coll/doc').get().then(res => {
-            assert.ok(res.get('moonLanding').isEqual(expected));
+            expect(res.get('moonLanding').isEqual(expected)).to.be.true;
           });
         });
   });
 
   it('constructed using helper', () => {
-    assert.ok(is.instance(Firestore.Timestamp.now(), Firestore.Timestamp));
+    expect(Firestore.Timestamp.now()).to.be.an.instanceOf(Firestore.Timestamp);
 
     let actual = Firestore.Timestamp.fromDate(new Date(123123));
     let expected = new Firestore.Timestamp(123, 123000000);
-    assert.ok(actual.isEqual(expected));
+    expect(actual.isEqual(expected)).to.be.true;
 
     actual = Firestore.Timestamp.fromMillis(123123);
     expected = new Firestore.Timestamp(123, 123000000);
-    assert.ok(actual.isEqual(expected));
+    expect(actual.isEqual(expected)).to.be.true;
   });
 
   it('validates nanoseconds', () => {

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {expect} from 'chai';
 import duplexify from 'duplexify';
 import is from 'is';
 import assert from 'power-assert';
@@ -46,8 +47,8 @@ function docsEqual(actual, expected) {
   for (let i = 0; i < actual.size; i++) {
     assert.equal(actual[i].ref.id, expected[i].ref.id);
     assert.deepStrictEqual(actual[i].data(), expected[i].data());
-    assert.ok(is.string(expected[i].createTime));
-    assert.ok(is.string(expected[i].updateTime));
+    expect((expected[i].createTime)).to.be.a('string');
+    expect((expected[i].updateTime)).to.be.a('string');
   }
 }
 
@@ -72,8 +73,9 @@ function snapshotsEqual(lastSnapshot, version, actual, expected) {
         actualDocChanges[i].doc.data(), expected.docChanges[i].doc.data());
     const readVersion =
         actualDocChanges[i].type === 'removed' ? version - 1 : version;
-    assert.ok(actualDocChanges[i].doc.readTime.isEqual(
-        new Firestore.Timestamp(0, readVersion)));
+    expect(actualDocChanges[i].doc.readTime.isEqual(
+               new Firestore.Timestamp(0, readVersion)))
+        .to.be.true;
 
     if (actualDocChanges[i].oldIndex !== -1) {
       localDocs.splice(actualDocChanges[i].oldIndex, 1);
@@ -87,7 +89,8 @@ function snapshotsEqual(lastSnapshot, version, actual, expected) {
 
   docsEqual(actual.docs, expected.docs);
   docsEqual(localDocs, expected.docs);
-  assert.ok(actual.readTime.isEqual(new Firestore.Timestamp(0, version)));
+  expect(actual.readTime.isEqual(new Firestore.Timestamp(0, version)))
+      .to.be.true;
   assert.equal(actual.size, expected.docs.length);
 
   return {docs: actual.docs, docChanges: actualDocChanges};
@@ -1803,7 +1806,8 @@ describe('Query watch', () => {
                           snapshot,
                           snapshot => {
                             firstSnapshot = snapshot;
-                            assert.ok(firstSnapshot.isEqual(firstSnapshot));
+                            expect(firstSnapshot.isEqual(firstSnapshot))
+                                .to.be.true;
                             watchHelper.sendDoc(doc1, {foo: 'a'});
                             watchHelper.sendDoc(doc2, {foo: 'b'});
                             watchHelper.sendDoc(doc3, {foo: 'c'});
@@ -1813,38 +1817,41 @@ describe('Query watch', () => {
                            snapshot,
                            snapshot => {
                              secondSnapshot = snapshot;
-                             assert.ok(secondSnapshot.isEqual(secondSnapshot));
+                             expect(secondSnapshot.isEqual(secondSnapshot))
+                                 .to.be.true;
                              watchHelper.sendDocDelete(doc1);
                              watchHelper.sendDoc(doc2, {foo: 'bar'});
                              watchHelper.sendDoc(doc4, {foo: 'd'});
                            }))
                    .then(snapshot => {
                      thirdSnapshot = snapshot;
-                     assert.ok(thirdSnapshot.isEqual(thirdSnapshot));
+                     expect(thirdSnapshot.isEqual(thirdSnapshot)).to.be.true;
                    });
              })
-          .then(() => initialSnapshot(snapshot => {
-                  return nextSnapshot(
-                             snapshot,
-                             snapshot => {
-                               assert.ok(snapshot.isEqual(firstSnapshot));
-                               watchHelper.sendDoc(doc1, {foo: 'a'});
-                               watchHelper.sendDoc(doc2, {foo: 'b'});
-                               watchHelper.sendDoc(doc3, {foo: 'c'});
-                             })
-                      .then(
-                          snapshot => nextSnapshot(
-                              snapshot,
-                              snapshot => {
-                                assert.ok(snapshot.isEqual(secondSnapshot));
-                                watchHelper.sendDocDelete(doc1);
-                                watchHelper.sendDoc(doc2, {foo: 'bar'});
-                                watchHelper.sendDoc(doc4, {foo: 'd'});
-                              }))
-                      .then(snapshot => {
-                        assert.ok(snapshot.isEqual(thirdSnapshot));
-                      });
-                }));
+          .then(
+              () => initialSnapshot(snapshot => {
+                return nextSnapshot(
+                           snapshot,
+                           snapshot => {
+                             expect(snapshot.isEqual(firstSnapshot)).to.be.true;
+                             watchHelper.sendDoc(doc1, {foo: 'a'});
+                             watchHelper.sendDoc(doc2, {foo: 'b'});
+                             watchHelper.sendDoc(doc3, {foo: 'c'});
+                           })
+                    .then(
+                        snapshot => nextSnapshot(
+                            snapshot,
+                            snapshot => {
+                              expect(snapshot.isEqual(secondSnapshot))
+                                  .to.be.true;
+                              watchHelper.sendDocDelete(doc1);
+                              watchHelper.sendDoc(doc2, {foo: 'bar'});
+                              watchHelper.sendDoc(doc4, {foo: 'd'});
+                            }))
+                    .then(snapshot => {
+                      expect(snapshot.isEqual(thirdSnapshot)).to.be.true;
+                    });
+              }));
     });
 
     it('for equal snapshots with materialized changes', () => {
@@ -1867,7 +1874,7 @@ describe('Query watch', () => {
                          }).then(snapshot => {
                     const materializedDocs = snapshot.docs;
                     assert.equal(materializedDocs.length, 3);
-                    assert.ok(snapshot.isEqual(firstSnapshot));
+                    expect(snapshot.isEqual(firstSnapshot)).to.be.true;
                   });
                 }));
     });
@@ -1887,7 +1894,7 @@ describe('Query watch', () => {
                   return nextSnapshot(snapshot, () => {
                            watchHelper.sendDoc(doc1, {foo: 'a'});
                          }).then(snapshot => {
-                    assert.ok(!snapshot.isEqual(firstSnapshot));
+                    expect(snapshot.isEqual(firstSnapshot)).to.be.false;
                   });
                 }));
     });
@@ -1900,17 +1907,19 @@ describe('Query watch', () => {
                         watchHelper.sendDoc(doc1, {foo: 'a'});
                       }).then(snapshot => {
                  firstSnapshot = snapshot;
-                 assert.ok(snapshot.docChanges()[0].isEqual(
-                     firstSnapshot.docChanges()[0]));
+                 expect(snapshot.docChanges()[0].isEqual(
+                            firstSnapshot.docChanges()[0]))
+                     .to.be.true;
                });
              })
           .then(() => initialSnapshot(snapshot => {
                   return nextSnapshot(snapshot, () => {
                            watchHelper.sendDoc(doc1, {foo: 'b'});
                          }).then(snapshot => {
-                    assert.ok(!snapshot.isEqual(firstSnapshot));
-                    assert.ok(!snapshot.docChanges()[0].isEqual(
-                        firstSnapshot.docChanges()[0]));
+                    expect(snapshot.isEqual(firstSnapshot)).to.be.false;
+                    expect(snapshot.docChanges()[0].isEqual(
+                               firstSnapshot.docChanges()[0]))
+                        .to.be.false;
                   });
                 }));
     });
@@ -1949,7 +1958,7 @@ describe('Query watch', () => {
                                 watchHelper.sendDoc(doc3, {foo: 'c'});
                               }))
                       .then(snapshot => {
-                        assert.ok(!snapshot.isEqual(firstSnapshot));
+                        expect(snapshot.isEqual(firstSnapshot)).to.be.false;
                       });
                 }));
     });
@@ -1968,7 +1977,7 @@ describe('Query watch', () => {
                   return nextSnapshot(snapshot, () => {
                            watchHelper.sendDoc(doc1, {foo: 1});
                          }).then(snapshot => {
-                    assert.ok(!snapshot.isEqual(originalSnapshot));
+                    expect(snapshot.isEqual(originalSnapshot)).to.be.false;
                   });
                 }));
     });
@@ -1987,7 +1996,7 @@ describe('Query watch', () => {
               watchHelper.sendCurrent();
               watchHelper.sendSnapshot(1);
               return watchHelper.await('snapshot').then(snapshot => {
-                assert.ok(!snapshot.isEqual(firstSnapshot));
+                expect(snapshot.isEqual(firstSnapshot)).to.be.false;
               });
             });
           });
@@ -1995,9 +2004,9 @@ describe('Query watch', () => {
 
     it('for objects with different type', () => {
       return initialSnapshot(snapshot => {
-        assert.ok(!snapshot.isEqual('foo'));
-        assert.ok(!snapshot.isEqual({}));
-        assert.ok(!snapshot.isEqual(new Firestore.GeoPoint(0, 0)));
+        expect(snapshot.isEqual('foo')).to.be.false;
+        expect(snapshot.isEqual({})).to.be.false;
+        expect(snapshot.isEqual(new Firestore.GeoPoint(0, 0))).to.be.false;
       });
     });
   });
@@ -2174,10 +2183,10 @@ describe('DocumentReference watch', () => {
           })
           .then(snapshot => {
             assert.equal(snapshot.exists, true);
-            assert.ok(
-                snapshot.createTime.isEqual(new Firestore.Timestamp(1, 2)));
-            assert.ok(
-                snapshot.updateTime.isEqual(new Firestore.Timestamp(3, 1)));
+            expect(snapshot.createTime.isEqual(new Firestore.Timestamp(1, 2)))
+                .to.be.true;
+            expect(snapshot.updateTime.isEqual(new Firestore.Timestamp(3, 1)))
+                .to.be.true;
             assert.equal(snapshot.get('foo'), 'a');
 
             // Change the document.

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {expect} from 'chai';
 import assert from 'power-assert';
 
 import {google} from '../protos/firestore_proto_api';
@@ -243,10 +244,14 @@ describe('batch support', () => {
   });
 
   function verifyResponse(writeResults) {
-    assert.ok(writeResults[0].writeTime.isEqual(new Firestore.Timestamp(0, 0)));
-    assert.ok(writeResults[1].writeTime.isEqual(new Firestore.Timestamp(1, 1)));
-    assert.ok(writeResults[2].writeTime.isEqual(new Firestore.Timestamp(2, 2)));
-    assert.ok(writeResults[3].writeTime.isEqual(new Firestore.Timestamp(3, 3)));
+    expect(writeResults[0].writeTime.isEqual(new Firestore.Timestamp(0, 0)))
+        .to.be.true;
+    expect(writeResults[1].writeTime.isEqual(new Firestore.Timestamp(1, 1)))
+        .to.be.true;
+    expect(writeResults[2].writeTime.isEqual(new Firestore.Timestamp(2, 2)))
+        .to.be.true;
+    expect(writeResults[3].writeTime.isEqual(new Firestore.Timestamp(3, 3)))
+        .to.be.true;
   }
 
   it('accepts multiple operations', () => {
@@ -350,7 +355,7 @@ describe('batch support', () => {
       batch.set(documentName, {});
 
       return batch.commit().then(results => {
-        assert.ok(results[0].isEqual(results[1]));
+        expect(results[0].isEqual(results[1])).to.be.true;
       });
     });
   });


### PR DESCRIPTION
This uses chai instead of `assert.ok`.

I also removed some API tests that add little value on their own.