### PR TITLE
 Add Credentials to JSDoc

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -240,8 +240,15 @@ export class Firestore {
    * {@see https://cloud.google.com/docs/authentication}
    * @param {string=} settings.keyFilename Local file containing the Service
    * Account credentials. Can be omitted in environments that support
-   * `Application Default Credentials`
-   * {@see https://cloud.google.com/docs/authentication}
+   * `Application Default Credentials`.
+   * {@see https://cloud.google.com/docs/authentication}. If your credentials
+   * are not stored on disk, you can use `settings.credentials` to just provide
+   * the 'client_email' and 'private_key' of your service account.
+   * @param {{client_email:string, private_key:string}} settings.credentials Local file containing the Service
+   * Account credentials. Can be omitted in environments that support
+   * `Application Default Credentials`.
+   * {@see https://cloud.google.com/docs/authentication}. If your credentials
+   * are stored in a JSON file, you can load them using `settings.keyFilename`.
    * @param {boolean=} settings.timestampsInSnapshots Enables the use of
    * `Timestamp`s for timestamp fields in `DocumentSnapshots`.<br/>
    * Currently, Firestore returns timestamp fields as `Date` but `Date` only

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -235,20 +235,25 @@ export class Firestore {
 
   /**
    * @param {Object=} settings [Configuration object](#/docs).
-   * @param {string=} settings.projectId The Firestore Project ID. Can be
-   * omitted in environments that support `Application Default Credentials`
-   * {@see https://cloud.google.com/docs/authentication}
+   * @param {string=} settings.projectId The project ID from the Google
+   * Developer's Console, e.g. 'grape-spaceship-123'. We will also check the
+   * environment variable GCLOUD_PROJECT for your project ID.  Can be omitted in
+   * environments that support
+   * {@link https://cloud.google.com/docs/authentication Application Default
+   * Credentials}
    * @param {string=} settings.keyFilename Local file containing the Service
-   * Account credentials. Can be omitted in environments that support
-   * `Application Default Credentials`.
-   * {@see https://cloud.google.com/docs/authentication}. If your credentials
-   * are not stored on disk, you can use `settings.credentials` to just provide
-   * the 'client_email' and 'private_key' of your service account.
-   * @param {{client_email:string, private_key:string}} settings.credentials Local file containing the Service
-   * Account credentials. Can be omitted in environments that support
-   * `Application Default Credentials`.
-   * {@see https://cloud.google.com/docs/authentication}. If your credentials
-   * are stored in a JSON file, you can load them using `settings.keyFilename`.
+   * Account credentials as downloaded from the Google Developers Console. Can
+   * be omitted in environments that support
+   * {@link https://cloud.google.com/docs/authentication Application Default
+   * Credentials}. To configure Firestore with custom credentials, use
+   * `settings.credentials` and provide the `client_email` and `private_key` of
+   * your service account.
+   * @param {{client_email:string=, private_key:string=}=} settings.credentials
+   * The `client_email` and `private_key` properties of the service account
+   * to use with your Firestore project. Can be omitted in environments that
+   * support {@link https://cloud.google.com/docs/authentication Application
+   * Default Credentials}. If your credentials are stored in a JSON file, you
+   * can specify a `keyFilename` instead.
    * @param {boolean=} settings.timestampsInSnapshots Enables the use of
    * `Timestamp`s for timestamp fields in `DocumentSnapshots`.<br/>
    * Currently, Firestore returns timestamp fields as `Date` but `Date` only

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -44,17 +44,32 @@ declare namespace FirebaseFirestore {
    */
   export interface Settings {
     /**
-     * The Firestore Project ID. Can be omitted in environments that support
-     * `Application Default Credentials` {@see https://cloud.google.com/docs/authentication}
+     * The project ID from the Google Developer's Console, e.g.
+     * 'grape-spaceship-123'. We will also check the environment variable
+     * GCLOUD_PROJECT for your project ID.  Can be omitted in environments that
+     * support {@link https://cloud.google.com/docs/authentication Application
+     * Default Credentials}
      */
     projectId?: string;
 
     /**
-     * Local file containing the Service Account credentials. Can be omitted
-     * in environments that support `Application Default Credentials`
-     * {@see https://cloud.google.com/docs/authentication}
+     * Local file containing the Service Account credentials as downloaded from
+     * the Google Developers Console. Can  be omitted in environments that
+     * support {@link https://cloud.google.com/docs/authentication Application
+     * Default Credentials}. To configure Firestore with custom credentials, use
+     * the `credentials` property to provide the `client_email` and
+     * `private_key` of your service account.
      */
     keyFilename?: string;
+
+    /**
+     * The 'client_email' and 'private_key' properties of the service account
+     * to use with your Firestore project. Can be omitted in environments that
+     * support {@link https://cloud.google.com/docs/authentication Application
+     * Default Credentials}. If your credentials are stored in a JSON file, you
+     * can specify a `keyFilename` instead.
+     */
+    credentials?: {client_email?:string, private_key?:string};
 
     /**
      * Enables the use of `Timestamp`s for timestamp fields in


### PR DESCRIPTION
This fixes https://github.com/googleapis/nodejs-firestore/issues/397 and explains the `credentials` properies that can be passed to the SDK.