### PR TITLE
Remove GeoPoint.toString()

### DIFF
--- a/dev/src/geo-point.ts
+++ b/dev/src/geo-point.ts
@@ -79,16 +79,6 @@ export class GeoPoint implements Serializable {
   }
 
   /**
-   * Returns a string representation for this GeoPoint.
-   *
-   * @return {string} The string representation.
-   */
-  toString(): string {
-    return `GeoPoint { latitude: ${this.latitude}, longitude: ${
-        this.longitude} }`;
-  }
-
-  /**
    * Returns true if this `GeoPoint` is equal to the provided value.
    *
    * @param {*} other The value to compare against.

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -465,8 +465,6 @@ describe('snapshot_() method', () => {
     // coverage.
     expect(data.geoPointValue.latitude).to.equal(50.1430847);
     expect(data.geoPointValue.longitude).to.equal(-122.947778);
-    expect(data.geoPointValue.toString())
-        .to.equal('GeoPoint { latitude: 50.1430847, longitude: -122.947778 }');
     expect(data.geoPointValue.isEqual(
                new Firestore.GeoPoint(50.1430847, -122.947778)))
         .to.be.true;


### PR DESCRIPTION
- This is not in our Mobile API.
- It's not in our TS types.
- We don't have .toString in any other types.
- The next release is already a breaking change.