### PR TITLE
Prepare v0.18 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -13,7 +13,7 @@
     "test": "npm run ava"
   },
   "dependencies": {
-    "@google-cloud/firestore": "^0.17.0"
+    "@google-cloud/firestore": "^0.18.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^2.3.0",


### PR DESCRIPTION
Includes the following changes:

[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style&#x3D;flat)](https://cloud.google.com/terms/launch-stages)

## Breaking Changes
- (#401) Removed undocumented `GeoPoint.toString()` method to improve consistency among types.

## Deprecations
- (#373) Deprecated `getCollections()` in favor of `listCollections()`.

## Features
 - (#368) Add support for `CollectionReference.listDocuments()`, which returns the `DocumentReferences` for all documents in a collection, including missing documents that contain further subcollections.

## Fixed
- (#375) Addressed an issue that  dropped an HTTP header that is used for efficient routing.

## Changed
- (#357) Updated all dependencies to their newest version. 