### PR TITLE
Validate that at least one argument is provided for Cursor

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1355,9 +1355,9 @@ export class Query {
    */
   startAt(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot|UserInput>):
       Query {
-    const options = extend(true, {}, this._queryOptions);
+    this._validator.minNumberOfArguments('startAt', arguments, 1);
 
-    fieldValuesOrDocumentSnapshot = [].slice.call(arguments);
+    const options = extend(true, {}, this._queryOptions);
 
     const fieldOrders =
         this.createImplicitOrderBy(fieldValuesOrDocumentSnapshot);
@@ -1390,9 +1390,9 @@ export class Query {
    */
   startAfter(...fieldValuesOrDocumentSnapshot:
                  Array<DocumentSnapshot|UserInput>): Query {
-    const options = extend(true, {}, this._queryOptions);
+    this._validator.minNumberOfArguments('startAfter', arguments, 1);
 
-    fieldValuesOrDocumentSnapshot = [].slice.call(arguments);
+    const options = extend(true, {}, this._queryOptions);
 
     const fieldOrders =
         this.createImplicitOrderBy(fieldValuesOrDocumentSnapshot);
@@ -1424,9 +1424,9 @@ export class Query {
    */
   endBefore(...fieldValuesOrDocumentSnapshot:
                 Array<DocumentSnapshot|UserInput>): Query {
-    const options = extend(true, {}, this._queryOptions);
+    this._validator.minNumberOfArguments('endBefore', arguments, 1);
 
-    fieldValuesOrDocumentSnapshot = [].slice.call(arguments);
+    const options = extend(true, {}, this._queryOptions);
 
     const fieldOrders =
         this.createImplicitOrderBy(fieldValuesOrDocumentSnapshot);
@@ -1458,9 +1458,9 @@ export class Query {
    */
   endAt(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot|UserInput>):
       Query {
-    const options = extend(true, {}, this._queryOptions);
+    this._validator.minNumberOfArguments('endAt', arguments, 1);
 
-    fieldValuesOrDocumentSnapshot = [].slice.call(arguments);
+    const options = extend(true, {}, this._queryOptions);
 
     const fieldOrders =
         this.createImplicitOrderBy(fieldValuesOrDocumentSnapshot);

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -1228,6 +1228,14 @@ describe('startAt() interface', () => {
             /Only a direct child can be used as a query boundary. Found: 'coll\/doc\/coll\/doc\/coll'./);
   });
 
+  it('requires at least one value', () => {
+    const query = firestore.collection('coll/doc/coll');
+
+    expect(() => {
+      query.startAt();
+    }).to.throw(/Function 'startAt\(\)' requires at least 1 argument./);
+  });
+
   it('can specify document snapshot', () => {
     const overrides = {
       runQuery: (request) => {


### PR DESCRIPTION
We currently fail requests that call .startAt() with no arguments... but we do so deep inside the GRPC layer.