### PR TITLE
Adding FieldMask support to GetAll()

### DIFF
--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -1090,7 +1090,7 @@ export function validateSetOptions(
         FieldPath.validateFieldPath(options.mergeFields[i]);
       } catch (err) {
         throw new Error(
-            `Argument at index ${i} is not a valid FieldPath. ${err.message}`);
+            `Element at index ${i} is not a valid FieldPath. ${err.message}`);
       }
     }
   }

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -37,9 +37,9 @@ import {DocumentReference} from './reference';
 import {isPlainObject, Serializer} from './serializer';
 import {Timestamp} from './timestamp';
 import {Transaction} from './transaction';
-import {DocumentData, GapicClient, Settings, ValidationOptions} from './types';
+import {DocumentData, GapicClient, ReadOptions, Settings, ValidationOptions} from './types';
 import {AnyDuringMigration, AnyJs} from './types';
-import {requestTag} from './util';
+import {parseGetAllArguments, requestTag} from './util';
 import {customObjectError, Validator} from './validate';
 import {WriteBatch, WriteResult} from './write-batch';
 import {validateUpdateMap} from './write-batch';
@@ -161,6 +161,18 @@ const MAX_DEPTH = 20;
  * It is an error to pass a SetOptions object to a set() call that is missing a
  * value for any of the fields specified here.
  * @typedef {Object} SetOptions
+ */
+
+/**
+ * An options object that can be used to configure the behavior of
+ * [getAll()]{@link Firestore#getAll} calls. By providing a `fieldMask`, these
+ * calls can be configured to only return a subset of fields.
+ *
+ * @property {Array<(string|FieldPath)>} fieldMask Specifies the set of fields
+ * to return and reduces the amount of data transmitted by the backend.
+ * Adding a field mask does not filter results. Documents do not need to
+ * contain values for all the fields in the mask to be part of the result set.
+ * @typedef {Object} ReadOptions
  */
 
 /**
@@ -296,6 +308,7 @@ export class Firestore {
       QueryValue: validateFieldValue,
       ResourcePath: ResourcePath.validateResourcePath,
       SetOptions: validateSetOptions,
+      ReadOptions: validateReadOptions,
       UpdateMap: validateUpdateMap,
       UpdatePrecondition: precondition =>
           validatePrecondition(precondition, /* allowExists= */ false),
@@ -680,28 +693,31 @@ export class Firestore {
   /**
    * Retrieves multiple documents from Firestore.
    *
-   * @param {...DocumentReference} documents The document references to receive.
+   * @param {DocumentReference} documentRef A `DocumentReference` to receive.
+   * @param {Array.<DocumentReference|ReadOptions>} moreDocumentRefsOrReadOptions
+   * Additional `DocumentReferences` to receive, followed by an optional field
+   * mask.
    * @returns {Promise<Array.<DocumentSnapshot>>} A Promise that
    * contains an array with the resulting document snapshots.
    *
    * @example
-   * let documentRef1 = firestore.doc('col/doc1');
-   * let documentRef2 = firestore.doc('col/doc2');
+   * let docRef1 = firestore.doc('col/doc1');
+   * let docRef2 = firestore.doc('col/doc2');
    *
-   * firestore.getAll(documentRef1, documentRef2).then(docs => {
+   * firestore.getAll(docRef1, docRef2, { fieldMask: ['user'] }).then(docs => {
    *   console.log(`First document: ${JSON.stringify(docs[0])}`);
    *   console.log(`Second document: ${JSON.stringify(docs[1])}`);
    * });
    */
-  getAll(...documents: DocumentReference[]): Promise<DocumentSnapshot[]> {
-    documents = is.array(arguments[0]) ? arguments[0].slice() :
-                                         Array.prototype.slice.call(arguments);
+  getAll(
+      documentRef: DocumentReference,
+      ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
+      Promise<DocumentSnapshot[]> {
+    this._validator.minNumberOfArguments('Firestore.getAll', arguments, 1);
 
-    for (let i = 0; i < documents.length; ++i) {
-      this._validator.isDocumentReference(i, documents[i]);
-    }
-
-    return this.getAll_(documents, requestTag());
+    const {documents, fieldMask} = parseGetAllArguments(
+        this._validator, [documentRef, ...moreDocumentRefsOrReadOptions]);
+    return this.getAll_(documents, fieldMask, requestTag());
   }
 
   /**
@@ -709,30 +725,33 @@ export class Firestore {
    * as part of a transaction.
    *
    * @private
-   * @param {Array.<DocumentReference>} docRefs The documents to receive.
-   * @param {string} requestTag A unique client-assigned identifier for this
-   * request.
-   * @param {bytes=} transactionId transactionId - The transaction ID to use
-   * for this read.
-   * @returns {Promise<Array.<DocumentSnapshot>>} A Promise that contains an
-   * array with the resulting documents.
+   * @param docRefs The documents to receive.
+   * @param fieldMask An optional field mask to apply to this read.
+   * @param requestTag A unique client-assigned identifier for this request.
+   * @param transactionId The transaction ID to use for this read.
+   * @returns A Promise that contains an array with the resulting documents.
    */
   getAll_(
-      docRefs: DocumentReference[], requestTag: string,
+      docRefs: DocumentReference[], fieldMask: FieldPath[]|null,
+      requestTag: string,
       transactionId?: Uint8Array): Promise<DocumentSnapshot[]> {
     const requestedDocuments = new Set();
     const retrievedDocuments = new Map();
-
-    const request: api.IBatchGetDocumentsRequest = {
-      database: this.formattedName,
-      transaction: transactionId,
-    };
 
     for (const docRef of docRefs) {
       requestedDocuments.add(docRef.formattedName);
     }
 
-    request.documents = Array.from(requestedDocuments);
+    const request: api.IBatchGetDocumentsRequest = {
+      database: this.formattedName,
+      transaction: transactionId,
+      documents: Array.from(requestedDocuments)
+    };
+
+    if (fieldMask) {
+      const fieldPaths = fieldMask.map(fieldPath => fieldPath.formattedName);
+      request.mask = {fieldPaths};
+    }
 
     const self = this;
 
@@ -1340,6 +1359,39 @@ function validateDocumentData(
 
   if (options.allowEmpty === false && isEmpty) {
     throw new Error('At least one field must be updated.');
+  }
+
+  return true;
+}
+
+/**
+ * Validates the use of 'options' as ReadOptions and enforces that 'fieldMask'
+ * is an array of strings or field paths.
+ *
+ * @private
+ * @param options.fieldMask - The subset of fields to return from a read
+ * operation.
+ */
+export function validateReadOptions(options: ReadOptions): boolean {
+  if (!is.object(options)) {
+    throw new Error('Input is not an object.');
+  }
+
+  if (options.fieldMask === undefined) {
+    return true;
+  }
+
+  if (!Array.isArray(options.fieldMask)) {
+    throw new Error('"fieldMask" is not an array.');
+  }
+
+  for (let i = 0; i < options.fieldMask.length; ++i) {
+    try {
+      FieldPath.validateFieldPath(options.fieldMask[i]);
+    } catch (err) {
+      throw new Error(
+          `Element at index ${i} is not a valid FieldPath. ${err.message}`);
+    }
   }
 
   return true;

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -118,7 +118,9 @@ export class Transaction {
 
     if (refOrQuery instanceof DocumentReference) {
       return this._firestore
-          .getAll_([refOrQuery], null, this._requestTag, this._transactionId)
+          .getAll_(
+              [refOrQuery], /* fieldMask= */ null, this._requestTag,
+              this._transactionId)
           .then(res => {
             return Promise.resolve(res[0]);
           });

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -146,6 +146,22 @@ export interface SetOptions {
 }
 
 /**
+ * An options object that can be used to configure the behavior of `getAll()`
+ * calls. By providing a `fieldMask`, these calls can be configured to only
+ * return a subset of fields.
+ */
+export interface ReadOptions {
+  /**
+   * Specifies the set of fields to return and reduces the amount of data
+   * transmitted by the backend.
+   *
+   * Adding a field mask does not filter results. Documents do not need to
+   * contain values for all the fields in the mask to be part of the result set.
+   */
+  readonly fieldMask?: Array<string|FieldPath>;
+}
+
+/**
  * Internal user data validation options.
  * @private
  */

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -65,9 +65,18 @@ export function parseGetAllArguments(
   let documents: DocumentReference[];
   let readOptions: ReadOptions|undefined = undefined;
 
-  const usesVarags = !Array.isArray(documentRefsOrReadOptions[0]);
+  // In the original release of the SDK, getAll() was documented to accept
+  // either a varargs list of DocumentReferences or a single array of
+  // DocumentReferences. To support this usage in the TypeScript client, we have
+  // to manually verify the arguments to determine which input the user
+  // provided.
+  const usesDeprecatedArgumentStyle =
+      Array.isArray(documentRefsOrReadOptions[0]);
 
-  if (usesVarags) {
+  if (usesDeprecatedArgumentStyle) {
+    documents = documentRefsOrReadOptions[0] as DocumentReference[];
+    readOptions = documentRefsOrReadOptions[1] as ReadOptions;
+  } else {
     if (documentRefsOrReadOptions.length > 0 &&
         isPlainObject(
             documentRefsOrReadOptions[documentRefsOrReadOptions.length - 1])) {
@@ -76,11 +85,6 @@ export function parseGetAllArguments(
     } else {
       documents = documentRefsOrReadOptions as DocumentReference[];
     }
-  } else {
-    // Support an array of document references as the first argument for
-    // backwards compatibility.
-    documents = documentRefsOrReadOptions[0] as DocumentReference[];
-    readOptions = documentRefsOrReadOptions[1] as ReadOptions;
   }
 
   for (let i = 0; i < documents.length; ++i) {

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -76,6 +76,17 @@ describe('Firestore class', () => {
           expect(docs.length).to.equal(2);
         });
   });
+
+  it('getAll() supports field mask', () => {
+    const ref1 = randomCol.doc('doc1');
+    return ref1.set({foo: 'a', bar: 'b'})
+        .then(() => {
+          return firestore.getAll(ref1, {fieldMask: ['foo']});
+        })
+        .then(docs => {
+          expect(docs[0].data()).to.deep.equal({foo: 'a'});
+        });
+  });
 });
 
 describe('CollectionReference class', () => {
@@ -1370,6 +1381,20 @@ describe('Transaction class', () => {
         .then(res => {
           expect(res).to.equal(2);
         });
+  });
+
+  it('getAll() supports field mask', () => {
+    const ref1 = randomCol.doc('doc1');
+    return ref1.set({foo: 'a', bar: 'b'}).then(() => {
+      return firestore
+          .runTransaction(updateFunction => {
+            return updateFunction.getAll(ref1, {fieldMask: ['foo']})
+                .then(([doc]) => doc);
+          })
+          .then(doc => {
+            expect(doc.data()).to.deep.equal({foo: 'a'});
+          });
+    });
   });
 
   it('has get() with query', () => {

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -971,7 +971,7 @@ describe('set document', () => {
       });
     })
         .to.throw(
-            /Argument "options" is not a valid SetOptions. Argument at index 0 is not a valid FieldPath./);
+            /Argument "options" is not a valid SetOptions. Element at index 0 is not a valid FieldPath./);
 
     expect(() => {
       firestore.doc('collectionId/documentId').set({foo: 'bar'}, {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -19,8 +19,10 @@ import * as extend from 'extend';
 import * as gax from 'google-gax';
 
 import * as Firestore from '../src';
+import {FieldPath} from '../src';
 import {ResourcePath} from '../src/path';
 import {AnyDuringMigration, GrpcError} from '../src/types';
+
 import {createInstance, document, DOCUMENT_NAME, found, InvalidApiUsage, missing, stream} from './util/helpers';
 
 const {grpc} = new gax.GrpcClient({} as AnyDuringMigration);
@@ -711,20 +713,6 @@ describe('getAll() method', () => {
     }
   }
 
-  it('accepts empty list', () => {
-    const overrides = {
-      batchGetDocuments: () => {
-        return stream();
-      }
-    };
-
-    return createInstance(overrides).then(firestore => {
-      return firestore.getAll().then(result => {
-        resultEquals(result);
-      });
-    });
-  });
-
   it('accepts single document', () => {
     const overrides = {
       batchGetDocuments: () => {
@@ -872,9 +860,17 @@ describe('getAll() method', () => {
     });
   });
 
-  it('requires document reference', () => {
+  it('requires at least one argument', () => {
     return createInstance().then(firestore => {
-      expect(() => (firestore as InvalidApiUsage).getAll({}))
+      expect(() => (firestore as InvalidApiUsage).getAll())
+          .to.throw(
+              /Function 'Firestore.getAll\(\)' requires at least 1 argument\./);
+    });
+  });
+
+  it('validates document references', () => {
+    return createInstance().then(firestore => {
+      expect(() => firestore.getAll(null as InvalidApiUsage))
           .to.throw(/Argument at index 0 is not a valid DocumentReference\./);
     });
   });
@@ -883,7 +879,8 @@ describe('getAll() method', () => {
     const overrides = {batchGetDocuments: () => stream(found('documentId'))};
 
     return createInstance(overrides).then(firestore => {
-      return firestore.getAll(firestore.doc('collectionId/documentId'))
+      return (firestore as InvalidApiUsage)
+          .getAll([firestore.doc('collectionId/documentId')])
           .then(result => {
             resultEquals(result, found('documentId'));
           });
@@ -947,6 +944,39 @@ describe('getAll() method', () => {
             resultEquals(
                 result, found('a'), found('a'), found('b'), found('a'));
           });
+    });
+  });
+
+  it('applies field mask', () => {
+    const overrides = {
+      batchGetDocuments: request => {
+        expect(request.mask.fieldPaths).to.have.members([
+          'foo.bar', '`foo.bar`'
+        ]);
+        return stream(found('a'));
+      }
+    };
+
+    return createInstance(overrides).then(firestore => {
+      return firestore.getAll(
+          firestore.doc('collectionId/a'),
+          {fieldMask: ['foo.bar', new FieldPath('foo.bar')]});
+    });
+  });
+
+  it('validates field mask', () => {
+    return createInstance().then(firestore => {
+      expect(() => firestore.getAll(firestore.doc('collectionId/a'), {
+        fieldMask: null
+      } as InvalidApiUsage))
+          .to.throw(
+              'Argument "options" is not a valid ReadOptions. "fieldMask" is not an array.');
+
+      expect(() => firestore.getAll(firestore.doc('collectionId/a'), {
+        fieldMask: ['a', new FieldPath('b'), null]
+      } as InvalidApiUsage))
+          .to.throw(
+              'Argument "options" is not a valid ReadOptions. Element at index 2 is not a valid FieldPath. Invalid use of type "object" as a Firestore argument.');
     });
   });
 });

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -67,6 +67,11 @@ xdescribe('firestore.d.ts', () => {
     const docRef1: DocumentReference = firestore.doc('coll/doc');
     const docRef2: DocumentReference = firestore.doc('coll/doc');
     firestore.getAll(docRef1, docRef2).then((docs: DocumentSnapshot[]) => {});
+    firestore.getAll(docRef1, docRef2, {})
+        .then((docs: DocumentSnapshot[]) => {});
+    firestore
+        .getAll(docRef1, docRef2, {fieldMask: ['foo', new FieldPath('foo')]})
+        .then((docs: DocumentSnapshot[]) => {});
     firestore.getCollections().then((collections: CollectionReference[]) => {});
     firestore.listCollections().then(
         (collections: CollectionReference[]) => {});

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -140,11 +140,16 @@ declare namespace FirebaseFirestore {
     /**
      * Retrieves multiple documents from Firestore.
      *
-     * @param documentRef The `DocumentReferences` to receive.
+     * @param documentRef A `DocumentReference` to receive.
+     * @param moreDocumentRefsOrReadOptions Additional `DocumentReferences` to
+     * receive, followed by an optional field mask.
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll(...documentRef: DocumentReference[]): Promise<DocumentSnapshot[]>;
+    getAll(
+        documentRef: DocumentReference,
+        ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>
+    ): Promise<DocumentSnapshot[]>;
 
     /**
      * Fetches the root collections that are associated with this Firestore
@@ -255,11 +260,16 @@ declare namespace FirebaseFirestore {
      * Retrieves multiple documents from Firestore. Holds a pessimistic lock on
      * all returned documents.
      *
-     * @param documentRef The `DocumentReferences` to receive.
+     * @param documentRef A `DocumentReference` to receive.
+     * @param moreDocumentRefsOrReadOptions Additional `DocumentReferences` to
+     * receive, followed by an optional field mask.
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll(...documentRef: DocumentReference[]): Promise<DocumentSnapshot[]>;
+    getAll(
+        documentRef: DocumentReference,
+        ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>
+    ): Promise<DocumentSnapshot[]>;
 
     /**
      * Create the document referred to by the provided `DocumentReference`.
@@ -466,6 +476,23 @@ declare namespace FirebaseFirestore {
      * missing a value for any of the fields specified here.
      */
     readonly mergeFields?: (string|FieldPath)[];
+  }
+
+  /**
+   * An options object that can be used to configure the behavior of `getAll()`
+   * calls. By providing a `fieldMask`, these calls can be configured to only
+   * return a subset of fields.
+   */
+  export interface ReadOptions {
+    /**
+     * Specifies the set of fields to return and reduces the amount of data
+     * transmitted by the backend.
+     *
+     * Adding a field mask does not filter results. Documents do not need to
+     * contain values for all the fields in the mask to be part of the result
+     * set.
+     */
+    readonly fieldMask?: (string|FieldPath)[];
   }
 
   /**


### PR DESCRIPTION
This adds a `ReadOptions` argument to getAll() to allow users to specify a field mask.

I tried to keep the API useable and declared the first argument of the varargs method so that it is known the DocumentReferences have to be passed first.

Fixes: https://github.com/googleapis/nodejs-firestore/issues/42