### PR TITLE
Remove google-proto-files

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -16,7 +16,6 @@
 
 import {expect} from 'chai';
 const duplexify = require('duplexify');
-const googleProtoFiles = require('google-proto-files');
 
 import * as is from 'is';
 import * as path from 'path';
@@ -50,7 +49,7 @@ const CONFORMANCE_TEST_PROJECT_ID = 'projectID';
 const protobufRoot = new protobufjs.Root();
 protobufRoot.resolvePath = (origin, target) => {
   if (/^google\/.*/.test(target)) {
-    target = path.join(googleProtoFiles(), target.substr('google/'.length));
+    target = path.join(__dirname, '../protos', target);
   }
   return target;
 };

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.0.2",
     "duplexify": "^3.6.0",
-    "google-proto-files": "^0.17.0",
     "gts": "^0.8.0",
     "hard-rejection": "^1.0.0",
     "ink-docstrap": "git+https://github.com/docstrap/docstrap.git",


### PR DESCRIPTION
https://github.com/googleapis/nodejs-firestore/pull/445 copies all necessary proto files under `/protos`.

This PR uses these files and removes the dependency on `google-proto-files`.