### PR TITLE
Slightly better error messages

### DIFF
--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -28,9 +28,6 @@ import {Timestamp} from './timestamp';
 import {AnyDuringMigration, AnyJs, ApiMapValue, DocumentData, UpdateData, UserInput} from './types';
 
 import api = google.firestore.v1beta1;
-import {Validator} from './validate';
-import Any = google.protobuf.Any;
-import ArrayValue = google.firestore.v1beta1.ArrayValue;
 
 /**
  * Returns a builder for DocumentSnapshot and QueryDocumentSnapshot instances.
@@ -788,8 +785,8 @@ export class DocumentMask {
     const result = applyDocumentMask(data);
 
     if (result.remainingPaths.length !== 0) {
-      throw new Error(`Input data is missing for field '${
-          result.remainingPaths[0].toString()}'.`);
+      throw new Error(`Input data is missing for field "${
+          result.remainingPaths[0].toString()}".`);
     }
 
     return result.filteredData;

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -290,7 +290,7 @@ export class Firestore {
   constructor(settings?: Settings) {
     this._validator = new Validator({
       ArrayElement: (name, value) => validateFieldValue(
-          name, value, /* path */ undefined, /*level=*/0,
+          name, value, /*path=*/undefined, /*level=*/0,
           /*inArray=*/true),
       DeletePrecondition: precondition =>
           validatePrecondition(precondition, /* allowExists= */ true),
@@ -1264,7 +1264,7 @@ follow these steps, YOUR APP MAY BREAK.`);
  * @param val JavaScript value to validate.
  * @param path The field path to validate.
  * @param options Validation options
- * @param level The current depth of the traversal. This is used to decided
+ * @param level The current depth of the traversal. This is used to decide
  * whether deletes are allowed in conjunction with `allowDeletes: root`.
  * @param inArray Whether we are inside an array.
  * @returns 'true' when the object is valid.

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -65,7 +65,7 @@ abstract class Path<T> {
    *
    * @private
    * @hideconstructor
-   * @param {string[]} segments Sequence of parts of a path.
+   * @param segments Sequence of parts of a path.
    */
   constructor(protected readonly segments: string[]) {}
 
@@ -73,10 +73,18 @@ abstract class Path<T> {
    * String representation as expected by the proto API.
    *
    * @private
-   * @type {string}
    */
   get formattedName(): string {
     return this.canonicalString()!;
+  }
+
+  /**
+   * Returns the number of segments of this field path.
+   *
+   * @private
+   */
+  get size(): number {
+    return this.segments.length;
   }
 
   abstract construct(segments: string[]|string): T;
@@ -87,9 +95,8 @@ abstract class Path<T> {
    * Create a child path beneath the current level.
    *
    * @private
-   * @param {string|T} relativePath Relative path to append to the current path.
-   * @returns {T} The new path.
-   * @template T
+   * @param relativePath Relative path to append to the current path.
+   * @returns The new path.
    */
   append(relativePath: Path<T>|string): T {
     if (relativePath instanceof Path) {
@@ -102,9 +109,7 @@ abstract class Path<T> {
    * Returns the path of the parent node.
    *
    * @private
-   * @returns {T|null} The new path or null if we are already at the root.
-   * @returns {T} The new path.
-   * @template T
+   * @returns The new path or null if we are already at the root.
    */
   parent(): T|null {
     if (this.segments.length === 0) {
@@ -119,8 +124,7 @@ abstract class Path<T> {
    *
    * @private
    * @param other The path to check against.
-   * @returns 'true' iff the current path is a prefix match with
-   * 'other'.
+   * @returns 'true' iff the current path is a prefix match with 'other'.
    */
   isPrefixOf(other: Path<T>): boolean {
     if (other.segments.length < this.segments.length) {
@@ -140,7 +144,7 @@ abstract class Path<T> {
    * Returns a string representation of this path.
    *
    * @private
-   * @returns {string} A string representing this path.
+   * @returns A string representing this path.
    */
   toString(): string {
     return this.formattedName;
@@ -176,7 +180,7 @@ abstract class Path<T> {
    * Returns a copy of the underlying segments.
    *
    * @private
-   * @returns {Array.<string>} A copy of the segments that make up this path.
+   * @returns A copy of the segments that make up this path.
    */
   toArray(): string[] {
     return this.segments.slice();
@@ -186,8 +190,8 @@ abstract class Path<T> {
    * Returns true if this `Path` is equal to the provided value.
    *
    * @private
-   * @param {*} other The value to compare against.
-   * @return {boolean} true if this `Path` is equal to the provided value.
+   * @param other The value to compare against.
+   * @return true if this `Path` is equal to the provided value.
    */
   isEqual(other: Path<T>): boolean {
     return (
@@ -450,7 +454,7 @@ export class FieldPath extends Path<FieldPath> {
     for (let i = 0; i < elements.length; ++i) {
       validate.isString(i, elements[i]);
       if (elements[i].length === 0) {
-        throw new Error(`Argument at index ${i} should not be empty.`);
+        throw new Error(`Element at index ${i} should not be an empty string.`);
       }
     }
 
@@ -477,20 +481,29 @@ export class FieldPath extends Path<FieldPath> {
    */
   static validateFieldPath(fieldPath: string|FieldPath) {
     if (!(fieldPath instanceof FieldPath)) {
-      if (!is.string(fieldPath)) {
+      if (fieldPath === undefined) {
+        throw new Error('Path cannot be ommitted.');
+      }
+
+      if (is.object(fieldPath) && fieldPath.constructor.name === 'FieldPath') {
         throw customObjectError(fieldPath);
       }
 
+      if (!is.string(fieldPath)) {
+        throw new Error(
+            'Paths can only be specified as strings or via a FieldPath object.');
+      }
+
       if (fieldPath.indexOf('..') >= 0) {
-        throw new Error(`Paths must not contain '..' in them.`);
+        throw new Error(`Paths must not contain ".." in them.`);
       }
 
       if (fieldPath.startsWith('.') || fieldPath.endsWith('.')) {
-        throw new Error(`Paths must not start or end with '.'.`);
+        throw new Error(`Paths must not start or end with ".".`);
       }
 
       if (!FIELD_PATH_RE.test(fieldPath)) {
-        throw new Error(`Paths can't be empty and must not contain '*~/[]'.`);
+        throw new Error(`Paths can't be empty and must not contain "*~/[]".`);
       }
     }
 

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -475,21 +475,22 @@ export class FieldPath extends Path<FieldPath> {
    * Returns true if the provided value can be used as a field path argument.
    *
    * @private
-   * @param {string|FieldPath} fieldPath The value to verify.
+   * @param fieldPath The value to verify.
    * @throws if the string can't be used as a field path.
-   * @returns {boolean} 'true' when the path is valid.
+   * @returns 'true' when the path is valid.
    */
-  static validateFieldPath(fieldPath: string|FieldPath) {
+  static validateFieldPath(fieldPath: unknown): boolean {
     if (!(fieldPath instanceof FieldPath)) {
       if (fieldPath === undefined) {
-        throw new Error('Path cannot be ommitted.');
+        throw new Error('Path cannot be omitted.');
       }
 
-      if (is.object(fieldPath) && fieldPath.constructor.name === 'FieldPath') {
+      if (is.object(fieldPath) &&
+          (fieldPath as object).constructor.name === 'FieldPath') {
         throw customObjectError(fieldPath);
       }
 
-      if (!is.string(fieldPath)) {
+      if (typeof fieldPath !== 'string') {
         throw new Error(
             'Paths can only be specified as strings or via a FieldPath object.');
       }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -940,11 +940,11 @@ export class Query {
         const fieldValue = documentSnapshot.get(fieldOrder.field);
         if (fieldValue === undefined) {
           throw new Error(
-              `Field '${
+              `Field "${
                   fieldOrder
-                      .field}' is missing in the provided DocumentSnapshot. Please provide a ` +
-              'document that contains values for all specified orderBy() and ' +
-              'where() constraints.');
+                      .field}" is missing in the provided DocumentSnapshot. ` +
+              'Please provide a document that contains values for all specified ' +
+              'orderBy() and where() constraints.');
         } else {
           fieldValues.push(fieldValue);
         }
@@ -1319,7 +1319,7 @@ export class Query {
     } else if (reference instanceof DocumentReference) {
       if (!this._path.isPrefixOf(reference._path)) {
         throw new Error(
-            `'${reference.path}' is not part of the query result set and ` +
+            `"${reference.path}" is not part of the query result set and ` +
             'cannot be used as a query boundary.');
       }
     } else {
@@ -1331,7 +1331,7 @@ export class Query {
     if (reference._path.parent()!.compareTo(this._path) !== 0) {
       throw new Error(
           'Only a direct child can be used as a query boundary. ' +
-          `Found: '${reference.path}'.`);
+          `Found: "${reference.path}".`);
     }
     return reference;
   }

--- a/dev/src/validate.ts
+++ b/dev/src/validate.ts
@@ -15,6 +15,8 @@
  */
 
 import * as is from 'is';
+
+import {FieldPath} from './path';
 import {AnyDuringMigration} from './types';
 
 /**
@@ -130,7 +132,7 @@ export class Validator {
   minNumberOfArguments(funcName, args, minSize): boolean {
     if (args.length < minSize) {
       throw new Error(
-          `Function '${funcName}()' requires at least ` +
+          `Function "${funcName}()" requires at least ` +
           `${formatPlural(minSize, 'argument')}.`);
     }
 
@@ -150,7 +152,7 @@ export class Validator {
   maxNumberOfArguments(funcName, args, maxSize): boolean {
     if (args.length > maxSize) {
       throw new Error(
-          `Function '${funcName}()' accepts at most ` +
+          `Function "${funcName}()" accepts at most ` +
           `${formatPlural(maxSize, 'argument')}.`);
     }
 
@@ -158,7 +160,9 @@ export class Validator {
   }
 }
 
-export function customObjectError(val): Error {
+export function customObjectError(val, path?: FieldPath): Error {
+  const fieldPathMessage = path ? ` (found in field ${path.toString()})` : '';
+
   if (is.object(val) && val.constructor.name !== 'Object') {
     const typeName = val.constructor.name;
     switch (typeName) {
@@ -169,17 +173,21 @@ export function customObjectError(val): Error {
       case 'Timestamp':
         return new Error(
             `Detected an object of type "${typeName}" that doesn't match the ` +
-            'expected instance. Please ensure that the Firestore types you ' +
-            'are using are from the same NPM package.');
+            `expected instance${fieldPathMessage}. Please ensure that the ` +
+            'Firestore types you are using are from the same NPM package.');
       default:
         return new Error(
-            `Couldn't serialize object of type "${typeName}". Firestore ` +
-            'doesn\'t support JavaScript objects with custom prototypes ' +
-            '(i.e. objects that were created via the \'new\' operator).');
+            `Couldn't serialize object of type "${typeName}"${
+                fieldPathMessage}. Firestore doesn't support JavaScript ` +
+            'objects with custom prototypes (i.e. objects that were created ' +
+            'via the "new" operator).');
     }
+  } else if (!is.object(val)) {
+    throw new Error(
+        `Input is not a plain JavaScript object${fieldPathMessage}.`);
   } else {
-    return new Error(
-        `Invalid use of type "${typeof val}" as a Firestore argument.`);
+    return new Error(`Invalid use of type "${
+        typeof val}" as a Firestore argument${fieldPathMessage}.`);
   }
 }
 

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -371,12 +371,15 @@ export class WriteBatch {
           } else {
             this._validator.isFieldPath(i, arguments[i]);
             this._validator.minNumberOfArguments('update', arguments, i + 1);
-            this._validator.isFieldValue(i, arguments[i + 1], {
-              allowDeletes: 'root',
-              allowTransforms: true,
-            });
-            updateMap.set(
-                FieldPath.fromArgument(arguments[i]), arguments[i + 1]);
+
+            const fieldPath = FieldPath.fromArgument(arguments[i]);
+            this._validator.isFieldValue(
+                i, arguments[i + 1], {
+                  allowDeletes: 'root',
+                  allowTransforms: true,
+                },
+                fieldPath);
+            updateMap.set(fieldPath, arguments[i + 1]);
           }
         }
       } catch (err) {

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -44,19 +44,19 @@ describe('Collection interface', () => {
 
     expect(() => collectionRef.doc(false))
         .to.throw(
-            /Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string./);
+            'Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string.');
     expect(() => collectionRef.doc(null))
         .to.throw(
-            /Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string./);
+            'Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string.');
     expect(() => collectionRef.doc(''))
         .to.throw(
-            /Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string./);
+            'Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string.');
     expect(() => collectionRef.doc(undefined))
         .to.throw(
-            /Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string./);
+            'Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string.');
     expect(() => collectionRef.doc('doc/coll'))
         .to.throw(
-            /Argument "documentPath" must point to a document, but was "doc\/coll". Your path does not contain an even number of components\./);
+            'Argument "documentPath" must point to a document, but was "doc\/coll". Your path does not contain an even number of components.');
 
     documentRef = collectionRef.doc('docId/colId/docId');
     expect(documentRef).to.be.an.instanceOf(DocumentReference);

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -543,7 +543,7 @@ describe('get document', () => {
       return firestore.doc('collectionId/documentId').get().then(doc => {
         expect(() => (doc as InvalidApiUsage).get())
             .to.throw(
-                'Argument "field" is not a valid FieldPath. Path cannot be ommitted.');
+                'Argument "field" is not a valid FieldPath. Path cannot be omitted.');
       });
     });
   });

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -48,14 +48,14 @@ describe('DocumentReference interface', () => {
   it('has collection() method', () => {
     expect(() => documentRef.collection(42))
         .to.throw(
-            /Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string./);
+            'Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string.');
 
     let collection = documentRef.collection('col');
     expect(collection.id).to.equal('col');
 
     expect(() => documentRef.collection('col/doc'))
         .to.throw(
-            /Argument "collectionPath" must point to a collection, but was "col\/doc". Your path does not contain an odd number of components\./);
+            'Argument "collectionPath" must point to a collection, but was "col\/doc". Your path does not contain an odd number of components.');
 
     collection = documentRef.collection('col/doc/col');
     expect(collection.id).to.equal('col');
@@ -109,20 +109,31 @@ describe('serialize document', () => {
   it('doesn\'t serialize unsupported types', () => {
     expect(() => {
       firestore.doc('collectionId/documentId').set({foo: undefined});
-    }).to.throw(/Invalid use of type "undefined" as a Firestore argument./);
+    })
+        .to.throw(
+            'Argument "data" is not a valid Document. Cannot use "undefined" as a Firestore value (found in field foo).');
 
     expect(() => {
       firestore.doc('collectionId/documentId').set({
         foo: Firestore.FieldPath.documentId()
       });
-    }).to.throw(/Cannot use object of type "FieldPath" as a Firestore value./);
+    })
+        .to.throw(
+            'Argument "data" is not a valid Document. Cannot use object of type "FieldPath" as a Firestore value (found in field foo).');
 
     expect(() => {
       class Foo {}
       firestore.doc('collectionId/documentId').set({foo: new Foo()});
     })
         .to.throw(
-            /Argument "data" is not a valid Document. Couldn't serialize object of type "Foo". Firestore doesn't support JavaScript objects with custom prototypes \(i.e. objects that were created via the 'new' operator\)./);
+            'Argument "data" is not a valid Document. Couldn\'t serialize object of type "Foo" (found in field foo). Firestore doesn\'t support JavaScript objects with custom prototypes (i.e. objects that were created via the "new" operator).');
+
+    expect(() => {
+      class Foo {}
+      firestore.doc('collectionId/documentId').set(new Foo());
+    })
+        .to.throw(
+            'Argument "data" is not a valid Document. Couldn\'t serialize object of type "Foo". Firestore doesn\'t support JavaScript objects with custom prototypes (i.e. objects that were created via the "new" operator).');
   });
 
   it('serializes date before 1970', () => {
@@ -211,35 +222,35 @@ describe('serialize document', () => {
   it('with invalid geopoint', () => {
     expect(() => {
       new Firestore.GeoPoint(57.2999988, 'INVALID' as InvalidApiUsage);
-    }).to.throw(/Argument "longitude" is not a valid number/);
+    }).to.throw('Argument "longitude" is not a valid number');
 
     expect(() => {
       new Firestore.GeoPoint('INVALID' as InvalidApiUsage, -4.4499982);
-    }).to.throw(/Argument "latitude" is not a valid number/);
+    }).to.throw('Argument "latitude" is not a valid number');
 
     expect(() => {
       new (Firestore as InvalidApiUsage).GeoPoint();
-    }).to.throw(/Argument "latitude" is not a valid number/);
+    }).to.throw('Argument "latitude" is not a valid number');
 
     expect(() => {
       new Firestore.GeoPoint(NaN as InvalidApiUsage, 0);
-    }).to.throw(/Argument "latitude" is not a valid number/);
+    }).to.throw('Argument "latitude" is not a valid number');
 
     expect(() => {
       new Firestore.GeoPoint(Infinity as InvalidApiUsage, 0);
-    }).to.throw(/Argument "latitude" is not a valid number/);
+    }).to.throw('Argument "latitude" is not a valid number');
 
     expect(() => {
       new Firestore.GeoPoint(91, 0);
     })
         .to.throw(
-            /Argument "latitude" is not a valid number. Value must be within \[-90, 90] inclusive, but was: 91/);
+            'Argument "latitude" is not a valid number. Value must be within \[-90, 90] inclusive, but was: 91');
 
     expect(() => {
       new Firestore.GeoPoint(90, 181);
     })
         .to.throw(
-            /Argument "longitude" is not a valid number. Value must be within \[-180, 180] inclusive, but was: 181/);
+            'Argument "longitude" is not a valid number. Value must be within \[-180, 180] inclusive, but was: 181');
   });
 
   it('resolves infinite nesting', () => {
@@ -250,7 +261,7 @@ describe('serialize document', () => {
       firestore.doc('collectionId/documentId').update(obj);
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid Document. Input object is deeper than 20 levels or contains a cycle./);
+            'Argument "dataOrField" is not a valid Document. Input object is deeper than 20 levels or contains a cycle.');
   });
 
   it('is able to write a document reference with cycles', () => {
@@ -387,7 +398,7 @@ describe('deserialize document', () => {
           doc.data();
         })
             .to.throw(
-                /Cannot decode type from Firestore Value: {"valueType":"foo"}/);
+                'Cannot decode type from Firestore Value: {"valueType":"foo"}');
       });
     });
   });
@@ -407,7 +418,7 @@ describe('deserialize document', () => {
     return createInstance(overrides).then(firestore => {
       return firestore.doc('collectionId/documentId').get().then(doc => {
         expect(() => doc.data())
-            .to.throw(/Argument "latitude" is not a valid number\./);
+            .to.throw('Argument "latitude" is not a valid number.');
       });
     });
   });
@@ -427,7 +438,7 @@ describe('deserialize document', () => {
     return createInstance(overrides).then(firestore => {
       return firestore.doc('collectionId/documentId').get().then(doc => {
         expect(() => doc.data())
-            .to.throw(/Argument "longitude" is not a valid number\./);
+            .to.throw('Argument "longitude" is not a valid number.');
       });
     });
   });
@@ -515,7 +526,7 @@ describe('get document', () => {
     });
   });
 
-  it('requires field path', () => {
+  it('cannot obtain field value without field path', () => {
     const overrides = {
       batchGetDocuments: () => {
         return stream(found(document('documentId', 'foo', {
@@ -535,7 +546,7 @@ describe('get document', () => {
       return firestore.doc('collectionId/documentId').get().then(doc => {
         expect(() => (doc as InvalidApiUsage).get())
             .to.throw(
-                /Argument "field" is not a valid FieldPath. Invalid use of type "undefined" as a Firestore argument./);
+                'Argument "field" is not a valid FieldPath. Path cannot be ommitted.');
       });
     });
   });
@@ -624,26 +635,26 @@ describe('delete document', () => {
       return firestore.doc('collectionId/documentId').delete({
         lastUpdateTime: 1337
       });
-    }).to.throw(/"lastUpdateTime" is not a Firestore Timestamp./);
+    }).to.throw('"lastUpdateTime" is not a Firestore Timestamp.');
   });
 
   it('throws if "exists" is not a boolean', () => {
     expect(() => {
       return firestore.doc('collectionId/documentId').delete({exists: 42});
-    }).to.throw(/"exists" is not a boolean./);
+    }).to.throw('"exists" is not a boolean.');
   });
 
   it('throws if no delete conditions are provided', () => {
     expect(() => {
       return firestore.doc('collectionId/documentId').delete(42);
-    }).to.throw(/Input is not an object./);
+    }).to.throw('Input is not an object.');
   });
 
   it('throws if more than one condition is provided', () => {
     expect(() => {
       return firestore.doc('collectionId/documentId')
           .delete({exists: false, lastUpdateTime: Firestore.Timestamp.now()});
-    }).to.throw(/Input contains more than one condition./);
+    }).to.throw('Input contains more than one condition.');
   });
 });
 
@@ -949,13 +960,13 @@ describe('set document', () => {
       firestore.doc('collectionId/documentId').set({foo: 'bar'}, 'foo');
     })
         .to.throw(
-            /Argument "options" is not a valid SetOptions. Input is not an object./);
+            'Argument "options" is not a valid SetOptions. Input is not an object.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').set({foo: 'bar'}, {merge: 42});
     })
         .to.throw(
-            /Argument "options" is not a valid SetOptions. "merge" is not a boolean./);
+            'Argument "options" is not a valid SetOptions. "merge" is not a boolean.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').set({foo: 'bar'}, {
@@ -963,7 +974,7 @@ describe('set document', () => {
       });
     })
         .to.throw(
-            /Argument "options" is not a valid SetOptions. "mergeFields" is not an array./);
+            'Argument "options" is not a valid SetOptions. "mergeFields" is not an array.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').set({foo: 'bar'}, {
@@ -971,20 +982,20 @@ describe('set document', () => {
       });
     })
         .to.throw(
-            /Argument "options" is not a valid SetOptions. Element at index 0 is not a valid FieldPath./);
+            'Argument "options" is not a valid SetOptions. Element at index 0 is not a valid FieldPath.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').set({foo: 'bar'}, {
         mergeFields: ['foobar']
       });
-    }).to.throw(/Input data is missing for field 'foobar'./);
+    }).to.throw('Input data is missing for field "foobar".');
 
     expect(() => {
       firestore.doc('collectionId/documentId')
           .set({foo: 'bar'}, {merge: true, mergeFields: []});
     })
         .to.throw(
-            /Argument "options" is not a valid SetOptions. You cannot specify both "merge" and "mergeFields"./);
+            'Argument "options" is not a valid SetOptions. You cannot specify both "merge" and "mergeFields".');
   });
 
   it('requires an object', () => {
@@ -992,7 +1003,7 @@ describe('set document', () => {
       firestore.doc('collectionId/documentId').set(null);
     })
         .to.throw(
-            /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "data" is not a valid Document. Input is not a plain JavaScript object.');
   });
 
   it('doesn\'t support non-merge deletes', () => {
@@ -1002,7 +1013,7 @@ describe('set document', () => {
       });
     })
         .to.throw(
-            /FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
+            'Argument "data" is not a valid Document. FieldValue.delete() must appear at the top-level and can only be used in update() or set() with {merge:true} (found in field foo).');
   });
 
   it('doesn\'t accept arrays', () => {
@@ -1010,7 +1021,7 @@ describe('set document', () => {
       firestore.doc('collectionId/documentId').set([42]);
     })
         .to.throw(
-            /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "data" is not a valid Document. Input is not a plain JavaScript object.');
   });
 });
 
@@ -1115,7 +1126,7 @@ describe('create document', () => {
       firestore.doc('collectionId/documentId').create(null);
     })
         .to.throw(
-            /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "data" is not a valid Document. Input is not a plain JavaScript object.');
   });
 
   it('doesn\'t accept arrays', () => {
@@ -1123,7 +1134,7 @@ describe('create document', () => {
       firestore.doc('collectionId/documentId').create([42]);
     })
         .to.throw(
-            /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "data" is not a valid Document. Input is not a plain JavaScript object.');
   });
 });
 
@@ -1295,17 +1306,17 @@ describe('update document', () => {
       firestore.doc('collectionId/documentId').update({foo: 'bar'}, {
         lastUpdateTime: 'foo'
       });
-    }).to.throw(/"lastUpdateTime" is not a Firestore Timestamp\./);
+    }).to.throw('"lastUpdateTime" is not a Firestore Timestamp.');
   });
 
   it('requires at least one field', () => {
     expect(() => {
       firestore.doc('collectionId/documentId').update({});
-    }).to.throw(/At least one field must be updated./);
+    }).to.throw('At least one field must be updated.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').update();
-    }).to.throw(/Function 'update\(\)' requires at least 1 argument./);
+    }).to.throw('Function "update()" requires at least 1 argument.');
   });
 
   it('rejects nested deletes', () => {
@@ -1315,7 +1326,7 @@ describe('update document', () => {
       });
     })
         .to.throw(
-            /FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
+            'Update() requires either a single JavaScript object or an alternating list of field/value pairs that can be followed by an optional precondition. Argument "dataOrField" is not a valid Document. FieldValue.delete() must appear at the top-level and can only be used in update() or set() with {merge:true} (found in field a.b).');
 
     expect(() => {
       firestore.doc('collectionId/documentId').update('a', {
@@ -1323,14 +1334,14 @@ describe('update document', () => {
       });
     })
         .to.throw(
-            /FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
+            'Update() requires either a single JavaScript object or an alternating list of field/value pairs that can be followed by an optional precondition. Argument at index 1 is not a valid FieldValue. FieldValue.delete() must appear at the top-level and can only be used in update() or set() with {merge:true} (found in field a.b).');
 
     expect(() => {
       firestore.doc('collectionId/documentId')
           .update(
               'a',
               Firestore.FieldValue.arrayUnion(Firestore.FieldValue.delete()));
-    }).to.throw(/FieldValue.delete\(\) cannot be used inside of an array./);
+    }).to.throw('FieldValue.delete\(\) cannot be used inside of an array.');
   });
 
   it('with top-level document', () => {
@@ -1513,7 +1524,7 @@ describe('update document', () => {
       });
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').update({
@@ -1522,7 +1533,7 @@ describe('update document', () => {
       });
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').update({
@@ -1531,7 +1542,7 @@ describe('update document', () => {
       });
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').update({
@@ -1540,7 +1551,7 @@ describe('update document', () => {
       });
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" was specified multiple times.');
 
     expect(() => {
       firestore.doc('collectionId/documentId').update({
@@ -1549,28 +1560,28 @@ describe('update document', () => {
       });
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo.bar" was specified multiple times.');
 
     expect(() => {
       firestore.doc('collectionId/documentId')
           .update('foo.bar', 'foobar', 'foo', 'foobar');
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times.');
 
     expect(() => {
       firestore.doc('collectionId/documentId')
           .update('foo', {foobar: 'foobar'}, 'foo.bar', {foobar: 'foobar'});
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times.');
 
     expect(() => {
       firestore.doc('collectionId/documentId')
           .update('foo', {foobar: 'foobar'}, 'foo.bar', {foobar: 'foobar'});
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times\./);
+            'Argument "dataOrField" is not a valid UpdateMap. Field "foo" was specified multiple times.');
   });
 
   it('with valid field paths', () => {
@@ -1581,9 +1592,18 @@ describe('update document', () => {
     }
   });
 
+  it('with empty field path', () => {
+    expect(() => {
+      const doc = {};
+      doc[''] = 'foo';
+      firestore.doc('col/doc').update(doc);
+    })
+        .to.throw(
+            'Update() requires either a single JavaScript object or an alternating list of field/value pairs that can be followed by an optional precondition. Argument \"dataOrField\" is not a valid Document. Element at index 0 should not be an empty string.');
+  });
+
   it('with invalid field paths', () => {
     const invalidFields = [
-      '',
       '.a',
       'a.',
       '.a.',
@@ -1599,7 +1619,7 @@ describe('update document', () => {
         const doc = {};
         doc[invalidFields[i]] = 'foo';
         firestore.doc('col/doc').update(doc);
-      }).to.throw(/.*Argument ".*" is not a valid FieldPath.*/);
+      }).to.throw(/Argument ".*" is not a valid FieldPath/);
     }
   });
 
@@ -1619,13 +1639,13 @@ describe('update document', () => {
   it('accepts an object', () => {
     expect(() => firestore.doc('collectionId/documentId').update(null))
         .to.throw(
-            /Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.');
   });
 
   it('doesn\'t accept arrays', () => {
     expect(() => firestore.doc('collectionId/documentId').update([42]))
         .to.throw(
-            /Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object.');
   });
 
   it('with field delete', () => {

--- a/dev/test/field-value.ts
+++ b/dev/test/field-value.ts
@@ -25,7 +25,7 @@ function genericFieldValueTests(methodName: string, sentinel: FieldValue) {
     return createInstance().then(firestore => {
       const docRef = firestore.doc('coll/doc');
       const expectedErr =
-          `${methodName}() is not supported inside of array values.`;
+          new RegExp(`${methodName}\\(\\) cannot be used inside of an array`);
       expect(() => docRef.set({a: [sentinel]})).to.throw(expectedErr);
       expect(() => docRef.set({a: {b: [sentinel]}})).to.throw(expectedErr);
       expect(() => docRef.set({
@@ -70,7 +70,7 @@ describe('FieldValue.arrayUnion()', () => {
   it('requires one argument', () => {
     expect(() => FieldValue.arrayUnion())
         .to.throw(
-            'Function \'FieldValue.arrayUnion()\' requires at least 1 argument.');
+            'Function "FieldValue.arrayUnion()" requires at least 1 argument.');
   });
 
   it('supports isEqual()', () => {
@@ -114,7 +114,7 @@ describe('FieldValue.arrayRemove()', () => {
   it('requires one argument', () => {
     expect(() => FieldValue.arrayRemove())
         .to.throw(
-            'Function \'FieldValue.arrayRemove()\' requires at least 1 argument.');
+            'Function "FieldValue.arrayRemove()" requires at least 1 argument.');
   });
 
   it('supports isEqual()', () => {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -268,7 +268,7 @@ describe('instantiation', () => {
 
     expect(() => firestore.settings({}))
         .to.throw(
-            /Firestore.settings\(\) has already be called. You can only call settings\(\) once, and only before calling any other methods on a Firestore object./);
+            'Firestore.settings() has already be called. You can only call settings() once, and only before calling any other methods on a Firestore object.');
   });
 
   it('cannot change settings after client initialized', () => {
@@ -277,7 +277,7 @@ describe('instantiation', () => {
 
     expect(() => firestore.settings({}))
         .to.throw(
-            /Firestore has already been started and its settings can no longer be changed. You can only call settings\(\) before calling any other methods on a Firestore object./);
+            'Firestore has already been started and its settings can no longer be changed. You can only call settings() before calling any other methods on a Firestore object.');
   });
 
   it('validates project ID is string', () => {
@@ -286,13 +286,13 @@ describe('instantiation', () => {
         projectId: 1337,
       });
       new Firestore.Firestore(settings);
-    }).to.throw(/Argument "settings.projectId" is not a valid string/);
+    }).to.throw('Argument "settings.projectId" is not a valid string.');
 
     expect(() => {
       new Firestore.Firestore(DEFAULT_SETTINGS).settings({
         projectId: 1337
       } as InvalidApiUsage);
-    }).to.throw(/Argument "settings.projectId" is not a valid string/);
+    }).to.throw('Argument "settings.projectId" is not a valid string.');
   });
 
   it('validates timestampsInSnapshots is boolean', () => {
@@ -303,7 +303,7 @@ describe('instantiation', () => {
       new Firestore.Firestore(settings);
     })
         .to.throw(
-            /Argument "settings.timestampsInSnapshots" is not a valid boolean/);
+            'Argument "settings.timestampsInSnapshots" is not a valid boolean.');
 
     expect(() => {
       new Firestore.Firestore(DEFAULT_SETTINGS).settings({
@@ -311,7 +311,7 @@ describe('instantiation', () => {
       } as AnyDuringMigration);
     })
         .to.throw(
-            /Argument "settings.timestampsInSnapshots" is not a valid boolean/);
+            'Argument "settings.timestampsInSnapshots" is not a valid boolean.');
   });
 
   it('uses project id from constructor', () => {
@@ -551,7 +551,7 @@ describe('snapshot_() method', () => {
             updateTime: '1970-01-01T00:00:03.000000004Z',
           },
           '1970-01-01T00:00:05.000000006Z', 'json');
-    }).to.throw(/Unable to infer type value fom '{}'./);
+    }).to.throw('Unable to infer type value fom \'{}\'.');
 
     expect(() => {
       firestore.snapshot_(
@@ -564,7 +564,7 @@ describe('snapshot_() method', () => {
           '1970-01-01T00:00:05.000000006Z', 'json');
     })
         .to.throw(
-            /Unable to infer type value fom '{"stringValue":"bar","integerValue":42}'./);
+            'Unable to infer type value fom \'{"stringValue":"bar","integerValue":42}\'.');
 
     expect(() => {
       firestore.snapshot_(
@@ -577,7 +577,7 @@ describe('snapshot_() method', () => {
           '1970-01-01T00:00:05.000000006Z', 'json');
     })
         .to.throw(
-            /Specify a valid ISO 8601 timestamp for "documentOrName.createTime"./);
+            'Specify a valid ISO 8601 timestamp for "documentOrName.createTime".');
   });
 
   it('handles missing document ', () => {
@@ -596,7 +596,7 @@ describe('snapshot_() method', () => {
           '1970-01-01T00:00:05.000000006Z', 'ascii');
     })
         .to.throw(
-            /Unsupported encoding format. Expected 'json' or 'protobufJS', but was 'ascii'./);
+            'Unsupported encoding format. Expected "json" or "protobufJS", but was "ascii".');
   });
 });
 
@@ -617,19 +617,19 @@ describe('doc() method', () => {
   it('requires document path', () => {
     expect(() => firestore.doc())
         .to.throw(
-            /Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string./);
+            'Argument "documentPath" is not a valid ResourcePath. Path must be a non-empty string.');
   });
 
   it('doesn\'t accept empty components', () => {
     expect(() => firestore.doc('coll//doc'))
         .to.throw(
-            /Argument "documentPath" is not a valid ResourcePath. Paths must not contain \/\/./);
+            'Argument "documentPath" is not a valid ResourcePath. Paths must not contain //.');
   });
 
   it('must point to document', () => {
     expect(() => firestore.doc('collectionId'))
         .to.throw(
-            /Argument "documentPath" must point to a document, but was "collectionId". Your path does not contain an even number of components\./);
+            'Argument "documentPath" must point to a document, but was "collectionId". Your path does not contain an even number of components.');
   });
 
   it('exposes properties', () => {
@@ -656,14 +656,14 @@ describe('collection() method', () => {
   it('requires collection id', () => {
     expect(() => firestore.collection())
         .to.throw(
-            /Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string./);
+            'Argument "collectionPath" is not a valid ResourcePath. Path must be a non-empty string.');
   });
 
 
   it('must point to a collection', () => {
     expect(() => firestore.collection('collectionId/documentId'))
         .to.throw(
-            /Argument "collectionPath" must point to a collection, but was "collectionId\/documentId". Your path does not contain an odd number of components\./);
+            'Argument "collectionPath" must point to a collection, but was "collectionId/documentId". Your path does not contain an odd number of components.');
   });
 
   it('exposes properties', () => {
@@ -864,14 +864,14 @@ describe('getAll() method', () => {
     return createInstance().then(firestore => {
       expect(() => (firestore as InvalidApiUsage).getAll())
           .to.throw(
-              /Function 'Firestore.getAll\(\)' requires at least 1 argument\./);
+              'Function "Firestore.getAll()" requires at least 1 argument.');
     });
   });
 
   it('validates document references', () => {
     return createInstance().then(firestore => {
       expect(() => firestore.getAll(null as InvalidApiUsage))
-          .to.throw(/Argument at index 0 is not a valid DocumentReference\./);
+          .to.throw('Argument at index 0 is not a valid DocumentReference.');
     });
   });
 
@@ -976,7 +976,7 @@ describe('getAll() method', () => {
         fieldMask: ['a', new FieldPath('b'), null]
       } as InvalidApiUsage))
           .to.throw(
-              'Argument "options" is not a valid ReadOptions. Element at index 2 is not a valid FieldPath. Invalid use of type "object" as a Firestore argument.');
+              'Argument "options" is not a valid ReadOptions. Element at index 2 is not a valid FieldPath. Paths can only be specified as strings or via a FieldPath object.');
     });
   });
 });

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -71,7 +71,7 @@ describe('Order', () => {
       order.compare(
           {valueType: 'foo'} as InvalidApiUsage,
           {valueType: 'foo'} as InvalidApiUsage);
-    }).to.throw(/Invalid use of type "object" as a Firestore argument./);
+    }).to.throw('Invalid use of type "object" as a Firestore argument.');
   });
 
   it('throws on invalid blob', () => {
@@ -83,7 +83,7 @@ describe('Order', () => {
           {
             bytesValue: new Uint8Array([1, 2, 3]),
           });
-    }).to.throw(/Blobs can only be compared if they are Buffers/);
+    }).to.throw('Blobs can only be compared if they are Buffers');
   });
 
   it('compares document snapshots by name', () => {

--- a/dev/test/path.ts
+++ b/dev/test/path.ts
@@ -52,7 +52,7 @@ describe('ResourcePath', () => {
     expect(() => {
       path =
           ResourcePath.fromSlashSeparatedString('projects/project/databases');
-    }).to.throw(/Resource name 'projects\/project\/databases' is not valid\./);
+    }).to.throw('Resource name \'projects\/project\/databases\' is not valid');
   });
 
   it('accepts newlines', () => {
@@ -76,13 +76,13 @@ describe('FieldPath', () => {
   it('doesn\'t accept empty path', () => {
     expect(() => {
       new FieldPath();
-    }).to.throw(/Function 'FieldPath\(\)' requires at least 1 argument\./);
+    }).to.throw('Function "FieldPath()" requires at least 1 argument.');
   });
 
   it('only accepts strings', () => {
     expect(() => {
       new FieldPath('foo', 'bar', 0 as InvalidApiUsage);
-    }).to.throw(/Argument at index 2 is not a valid string\./);
+    }).to.throw('Argument at index 2 is not a valid string.');
   });
 
   it('has append() method', () => {
@@ -105,7 +105,7 @@ describe('FieldPath', () => {
   it('doesn\'t allow empty components', () => {
     expect(() => {
       new FieldPath('foo', '');
-    }).to.throw(/Argument at index 1 should not be empty./);
+    }).to.throw('Element at index 1 should not be an empty string.');
   });
 
   it('has isEqual() method', () => {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -560,14 +560,14 @@ describe('query interface', () => {
           snapshot.docChanges.forEach(() => {});
         })
             .to.throw(
-                /QuerySnapshot.docChanges has been changed from a property into a method/);
+                'QuerySnapshot.docChanges has been changed from a property into a method');
 
         expect(() => {
           for (const doc of snapshot.docChanges) {
           }
         })
             .to.throw(
-                /QuerySnapshot.docChanges has been changed from a property into a method/);
+                'QuerySnapshot.docChanges has been changed from a property into a method');
       });
     });
   });
@@ -695,7 +695,7 @@ describe('where() interface', () => {
       return query.get();
     })
         .to.throw(
-            /Argument "fieldPath" is not a valid FieldPath. Invalid use of type "object" as a Firestore argument/);
+            'Argument "fieldPath" is not a valid FieldPath. Paths can only be specified as strings or via a FieldPath object.');
 
     class FieldPath {}
     expect(() => {
@@ -704,7 +704,7 @@ describe('where() interface', () => {
       return query.get();
     })
         .to.throw(
-            /Detected an object of type "FieldPath" that doesn't match the expected instance./);
+            'Detected an object of type "FieldPath" that doesn\'t match the expected instance.');
   });
 
   it('rejects field paths as value', () => {
@@ -714,7 +714,7 @@ describe('where() interface', () => {
       return query.get();
     })
         .to.throw(
-            /Argument "value" is not a valid QueryValue. Cannot use object of type "FieldPath" as a Firestore value./);
+            'Argument "value" is not a valid QueryValue. Cannot use object of type "FieldPath" as a Firestore value.');
   });
 
   it('rejects field delete as value', () => {
@@ -724,7 +724,7 @@ describe('where() interface', () => {
       return query.get();
     })
         .to.throw(
-            /FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
+            'FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}.');
   });
 
   it('rejects custom classes as value', () => {
@@ -740,31 +740,31 @@ describe('where() interface', () => {
       query.where('foo', '=', new Foo()).get();
     })
         .to.throw(
-            /Argument "value" is not a valid QueryValue. Couldn't serialize object of type "Foo". Firestore doesn't support JavaScript objects with custom prototypes \(i.e. objects that were created via the 'new' operator\)./);
+            'Argument "value" is not a valid QueryValue. Couldn\'t serialize object of type "Foo". Firestore doesn\'t support JavaScript objects with custom prototypes (i.e. objects that were created via the "new" operator).');
 
     expect(() => {
       query.where('foo', '=', new FieldPath()).get();
     })
         .to.throw(
-            /Detected an object of type "FieldPath" that doesn't match the expected instance./);
+            'Detected an object of type "FieldPath" that doesn\'t match the expected instance.');
 
     expect(() => {
       query.where('foo', '=', new FieldValue()).get();
     })
         .to.throw(
-            /Detected an object of type "FieldValue" that doesn't match the expected instance./);
+            'Detected an object of type "FieldValue" that doesn\'t match the expected instance.');
 
     expect(() => {
       query.where('foo', '=', new DocumentReference()).get();
     })
         .to.throw(
-            /Detected an object of type "DocumentReference" that doesn't match the expected instance./);
+            'Detected an object of type "DocumentReference" that doesn\'t match the expected instance.');
 
     expect(() => {
       query.where('foo', '=', new GeoPoint()).get();
     })
         .to.throw(
-            /Detected an object of type "GeoPoint" that doesn't match the expected instance./);
+            'Detected an object of type "GeoPoint" that doesn\'t match the expected instance.');
   });
 
   it('supports unary filters', () => {
@@ -791,7 +791,7 @@ describe('where() interface', () => {
       return query.get();
     })
         .to.throw(
-            /Invalid query. You can only perform equals comparisons on NaN\./);
+            'Invalid query. You can only perform equals comparisons on NaN.');
   });
 
   it('rejects invalid Null filter', () => {
@@ -801,7 +801,7 @@ describe('where() interface', () => {
       return query.get();
     })
         .to.throw(
-            /Invalid query. You can only perform equals comparisons on Null\./);
+            'Invalid query. You can only perform equals comparisons on Null.');
   });
 
   it('verifies field path', () => {
@@ -810,14 +810,14 @@ describe('where() interface', () => {
       query = query.where('foo.', '=', 'foobar');
     })
         .to.throw(
-            /Argument "fieldPath" is not a valid FieldPath. Paths must not start or end with '.'./);
+            'Argument "fieldPath" is not a valid FieldPath. Paths must not start or end with ".".');
   });
 
   it('verifies operator', () => {
     let query = firestore.collection('collectionId');
     expect(() => {
       query = query.where('foo', '@', 'foobar');
-    }).to.throw(/Operator must be one of "<", "<=", "==", ">", or ">="\./);
+    }).to.throw('Operator must be one of "<", "<=", "==", ">", or ">="\.');
   });
 });
 
@@ -882,7 +882,7 @@ describe('orderBy() interface', () => {
     let query: Query = firestore.collection('collectionId');
     expect(() => {
       query = query.orderBy('foo', 'foo');
-    }).to.throw(/Order must be one of "asc" or "desc"\./);
+    }).to.throw('Order must be one of "asc" or "desc".');
   });
 
   it('accepts field path', () => {
@@ -909,7 +909,7 @@ describe('orderBy() interface', () => {
       query = query.orderBy('foo.');
     })
         .to.throw(
-            /Argument "fieldPath" is not a valid FieldPath. Paths must not start or end with '.'./);
+            'Argument "fieldPath" is not a valid FieldPath. Paths must not start or end with ".".');
   });
 
   it('rejects call after cursor', () => {
@@ -920,7 +920,7 @@ describe('orderBy() interface', () => {
         query = query.orderBy('foo').startAt('foo').orderBy('foo');
       })
           .to.throw(
-              /Cannot specify an orderBy\(\) constraint after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
+              'Cannot specify an orderBy() constraint after calling startAt(), startAfter(), endBefore() or endAt().');
 
       expect(() => {
         query = query.where('foo', '>', 'bar')
@@ -928,13 +928,13 @@ describe('orderBy() interface', () => {
                     .where('foo', '>', 'bar');
       })
           .to.throw(
-              /Cannot specify a where\(\) filter after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
+              'Cannot specify a where() filter after calling startAt(), startAfter(), endBefore() or endAt().');
 
       expect(() => {
         query = query.orderBy('foo').endAt('foo').orderBy('foo');
       })
           .to.throw(
-              /Cannot specify an orderBy\(\) constraint after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
+              'Cannot specify an orderBy() constraint after calling startAt(), startAfter(), endBefore() or endAt().');
 
       expect(() => {
         query = query.where('foo', '>', 'bar')
@@ -942,7 +942,7 @@ describe('orderBy() interface', () => {
                     .where('foo', '>', 'bar');
       })
           .to.throw(
-              /Cannot specify a where\(\) filter after calling startAt\(\), startAfter\(\), endBefore\(\) or endAt\(\)./);
+              'Cannot specify a where() filter after calling startAt(), startAfter(), endBefore() or endAt().');
     });
   });
 
@@ -995,7 +995,7 @@ describe('limit() interface', () => {
   it('expects number', () => {
     const query = firestore.collection('collectionId');
     expect(() => query.limit(Infinity))
-        .to.throw(/Argument "limit" is not a valid integer./);
+        .to.throw('Argument "limit" is not a valid integer.');
   });
 
   it('uses latest limit', () => {
@@ -1041,7 +1041,7 @@ describe('offset() interface', () => {
   it('expects number', () => {
     const query = firestore.collection('collectionId');
     expect(() => query.offset(Infinity))
-        .to.throw(/Argument "offset" is not a valid integer\./);
+        .to.throw('Argument "offset" is not a valid integer.');
   });
 
   it('uses latest offset', () => {
@@ -1091,11 +1091,11 @@ describe('select() interface', () => {
     const query = firestore.collection('collectionId');
     expect(() => query.select(1))
         .to.throw(
-            /Argument at index 0 is not a valid FieldPath. Invalid use of type "number" as a Firestore argument./);
+            'Argument at index 0 is not a valid FieldPath. Paths can only be specified as strings or via a FieldPath object.');
 
     expect(() => query.select('.'))
         .to.throw(
-            /Argument at index 0 is not a valid FieldPath. Paths must not start or end with '.'./);
+            'Argument at index 0 is not a valid FieldPath. Paths must not start or end with ".".');
   });
 
   it('uses latest field mask', () => {
@@ -1190,42 +1190,42 @@ describe('startAt() interface', () => {
       query.orderBy(Firestore.FieldPath.documentId()).startAt(42);
     })
         .to.throw(
-            /The corresponding value for FieldPath.documentId\(\) must be a string or a DocumentReference./);
+            'The corresponding value for FieldPath.documentId\(\) must be a string or a DocumentReference.');
 
     expect(() => {
       query.orderBy(Firestore.FieldPath.documentId())
           .startAt(firestore.doc('coll/doc/other/doc'));
     })
         .to.throw(
-            /'coll\/doc\/other\/doc' is not part of the query result set and cannot be used as a query boundary./);
+            '"coll/doc/other/doc" is not part of the query result set and cannot be used as a query boundary.');
 
     expect(() => {
       query.orderBy(Firestore.FieldPath.documentId())
           .startAt(firestore.doc('coll/doc/coll_suffix/doc'));
     })
         .to.throw(
-            /'coll\/doc\/coll_suffix\/doc' is not part of the query result set and cannot be used as a query boundary./);
+            '"coll/doc/coll_suffix/doc" is not part of the query result set and cannot be used as a query boundary.');
 
     expect(() => {
       query.orderBy(Firestore.FieldPath.documentId())
           .startAt(firestore.doc('coll/doc'));
     })
         .to.throw(
-            /'coll\/doc' is not part of the query result set and cannot be used as a query boundary./);
+            '"coll/doc" is not part of the query result set and cannot be used as a query boundary.');
 
     expect(() => {
       query.orderBy(Firestore.FieldPath.documentId())
           .startAt(firestore.doc('coll/doc/coll/doc/coll/doc'));
     })
         .to.throw(
-            /Only a direct child can be used as a query boundary. Found: 'coll\/doc\/coll\/doc\/coll\/doc'./);
+            'Only a direct child can be used as a query boundary. Found: "coll/doc/coll/doc/coll/doc".');
 
     // Validate that we can't pass a reference to a collection.
     expect(() => {
       query.orderBy(Firestore.FieldPath.documentId()).startAt('doc/coll');
     })
         .to.throw(
-            /Only a direct child can be used as a query boundary. Found: 'coll\/doc\/coll\/doc\/coll'./);
+            'Only a direct child can be used as a query boundary. Found: "coll/doc/coll/doc/coll".');
   });
 
   it('requires at least one value', () => {
@@ -1233,7 +1233,7 @@ describe('startAt() interface', () => {
 
     expect(() => {
       query.startAt();
-    }).to.throw(/Function 'startAt\(\)' requires at least 1 argument./);
+    }).to.throw('Function "startAt()" requires at least 1 argument.');
   });
 
   it('can specify document snapshot', () => {
@@ -1387,7 +1387,7 @@ describe('startAt() interface', () => {
     return snapshot('collectionId/doc', {}).then(doc => {
       expect(() => query.startAt(doc))
           .to.throw(
-              /Field 'foo' is missing in the provided DocumentSnapshot. Please provide a document that contains values for all specified orderBy\(\) and where\(\) constraints./);
+              'Field "foo" is missing in the provided DocumentSnapshot. Please provide a document that contains values for all specified orderBy() and where() constraints.');
     });
   });
 
@@ -1398,7 +1398,7 @@ describe('startAt() interface', () => {
       query.orderBy('foo').startAt('foo', Firestore.FieldValue.delete());
     })
         .to.throw(
-            /Argument at index 1 is not a valid QueryValue. FieldValue.delete\(\) must appear at the top-level and can only be used in update\(\) or set\(\) with {merge:true}./);
+            'Argument at index 1 is not a valid QueryValue. FieldValue.delete\(\) must appear at the top-level and can only be used in update() or set() with {merge:true}.');
   });
 
   it('requires order by', () => {
@@ -1407,7 +1407,7 @@ describe('startAt() interface', () => {
 
     expect(() => query.startAt('foo', 'bar'))
         .to.throw(
-            /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
+            'Too many cursor values specified. The specified values must match the orderBy() constraints of the query.');
   });
 
   it('can overspecify order by', () => {
@@ -1432,7 +1432,7 @@ describe('startAt() interface', () => {
     const query = firestore.collection('collectionId');
     expect(() => query.startAt(123))
         .to.throw(
-            /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
+            'Too many cursor values specified. The specified values must match the orderBy() constraints of the query.');
   });
 
   it('uses latest value', () => {
@@ -1483,7 +1483,7 @@ describe('startAfter() interface', () => {
     const query = firestore.collection('collectionId');
     expect(() => query.startAfter(123))
         .to.throw(
-            /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
+            'Too many cursor values specified. The specified values must match the orderBy() constraints of the query.');
   });
 
   it('uses latest value', () => {
@@ -1535,7 +1535,7 @@ describe('endAt() interface', () => {
     const query = firestore.collection('collectionId');
     expect(() => query.endAt(123))
         .to.throw(
-            /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
+            'Too many cursor values specified. The specified values must match the orderBy() constraints of the query.');
   });
 
   it('uses latest value', () => {
@@ -1586,7 +1586,7 @@ describe('endBefore() interface', () => {
     const query = firestore.collection('collectionId');
     expect(() => query.endBefore(123))
         .to.throw(
-            /Too many cursor values specified. The specified values must match the orderBy\(\) constraints of the query./);
+            'Too many cursor values specified. The specified values must match the orderBy() constraints of the query.');
   });
 
   it('uses latest value', () => {

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -139,17 +139,17 @@ describe('timestamps', () => {
 
   it('validates nanoseconds', () => {
     expect(() => new Firestore.Timestamp(0.1, 0))
-        .to.throw(/Argument "seconds" is not a valid integer./);
+        .to.throw('Argument "seconds" is not a valid integer.');
 
     expect(() => new Firestore.Timestamp(0, 0.1))
-        .to.throw(/Argument "nanoseconds" is not a valid integer./);
+        .to.throw('Argument "nanoseconds" is not a valid integer.');
 
     expect(() => new Firestore.Timestamp(0, -1))
         .to.throw(
-            /Argument "nanoseconds" is not a valid integer. Value must be within \[0, 999999999] inclusive, but was: -1/);
+            'Argument "nanoseconds" is not a valid integer. Value must be within \[0, 999999999] inclusive, but was: -1');
 
     expect(() => new Firestore.Timestamp(0, 1000000000))
         .to.throw(
-            /Argument "nanoseconds" is not a valid integer. Value must be within \[0, 999999999] inclusive, but was: 1000000000/);
+            'Argument "nanoseconds" is not a valid integer. Value must be within \[0, 999999999] inclusive, but was: 1000000000');
   });
 });

--- a/dev/test/transaction.ts
+++ b/dev/test/transaction.ts
@@ -303,7 +303,7 @@ describe('failed transactions', () => {
 
     return createInstance(overrides).then(firestore => {
       expect(() => (firestore as InvalidApiUsage).runTransaction())
-          .to.throw(/Argument "updateFunction" is not a valid function\./);
+          .to.throw('Argument "updateFunction" is not a valid function.');
     });
   });
 
@@ -319,13 +319,13 @@ describe('failed transactions', () => {
           () => firestore.runTransaction(
               () => Promise.resolve(), {maxAttempts: 'foo' as InvalidApiUsage}))
           .to.throw(
-              /Argument "transactionOptions.maxAttempts" is not a valid integer\./);
+              'Argument "transactionOptions.maxAttempts" is not a valid integer.');
 
       expect(
           () => firestore.runTransaction(
               () => Promise.resolve(), {maxAttempts: 0}))
           .to.throw(
-              /Argument "transactionOptions.maxAttempts" is not a valid integer\./);
+              'Argument "transactionOptions.maxAttempts" is not a valid integer.');
     });
   });
 
@@ -433,10 +433,10 @@ describe('transaction operations', () => {
   it('requires a query or document for get', () => {
     return runTransaction(transaction => {
       expect(() => transaction.get())
-          .to.throw(/Argument "refOrQuery" must be a DocumentRef or a Query\./);
+          .to.throw('Argument "refOrQuery" must be a DocumentRef or a Query.');
 
       expect(() => transaction.get('foo'))
-          .to.throw(/Argument "refOrQuery" must be a DocumentRef or a Query\./);
+          .to.throw('Argument "refOrQuery" must be a DocumentRef or a Query.');
 
       return Promise.resolve();
     }, begin(), commit());

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -643,10 +643,10 @@ describe('Query watch', () => {
 
   it('with invalid callbacks', () => {
     expect(() => colRef.onSnapshot('foo'))
-        .to.throw(/Argument "onNext" is not a valid function./);
+        .to.throw('Argument "onNext" is not a valid function.');
 
     expect(() => colRef.onSnapshot(() => {}, 'foo'))
-        .to.throw(/Argument "onError" is not a valid function./);
+        .to.throw('Argument "onError" is not a valid function.');
   });
 
   it('without error callback', (done) => {
@@ -2133,10 +2133,10 @@ describe('DocumentReference watch', () => {
 
   it('with invalid callbacks', () => {
     expect(() => doc.onSnapshot('foo'))
-        .to.throw(/Argument "onNext" is not a valid function./);
+        .to.throw('Argument "onNext" is not a valid function.');
 
     expect(() => doc.onSnapshot(() => {}, 'foo'))
-        .to.throw(/Argument "onError" is not a valid function./);
+        .to.throw('Argument "onError" is not a valid function.');
   });
 
   it('without error callback', done => {
@@ -2521,6 +2521,6 @@ describe('Query comparator', () => {
 
     const comparator = query.comparator();
     expect(() => input.sort(comparator))
-        .to.throw(/Trying to compare documents on fields that don't exist/);
+        .to.throw('Trying to compare documents on fields that don\'t exist');
   });
 });

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -39,13 +39,13 @@ describe('set() method', () => {
 
   it('requires document name', () => {
     expect(() => writeBatch.set())
-        .to.throw(/Argument "documentRef" is not a valid DocumentReference\./);
+        .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
   it('requires object', () => {
     expect(() => writeBatch.set(firestore.doc('sub/doc')))
         .to.throw(
-            /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "data" is not a valid Document. Input is not a plain JavaScript object.');
   });
 
   it('accepts preconditions', () => {
@@ -66,7 +66,7 @@ describe('delete() method', () => {
 
   it('requires document name', () => {
     expect(() => writeBatch.delete())
-        .to.throw(/Argument "documentRef" is not a valid DocumentReference\./);
+        .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
   it('accepts preconditions', () => {
@@ -89,7 +89,7 @@ describe('update() method', () => {
 
   it('requires document name', () => {
     expect(() => writeBatch.update({}, {}))
-        .to.throw(/Argument "documentRef" is not a valid DocumentReference\./);
+        .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
   it('requires object', () => {
@@ -97,7 +97,7 @@ describe('update() method', () => {
       writeBatch.update(firestore.doc('sub/doc'), firestore.doc('sub/doc'));
     })
         .to.throw(
-            /Argument "dataOrField" is not a valid Document. Input is not a plain JavaScript object./);
+            'Update() requires either a single JavaScript object or an alternating list of field/value pairs that can be followed by an optional precondition. Argument "dataOrField" is not a valid Document. Detected an object of type "DocumentReference" that doesn\'t match the expected instance. Please ensure that the Firestore types you are using are from the same NPM package.');
   });
 
   it('accepts preconditions', () => {
@@ -120,7 +120,7 @@ describe('create() method', () => {
 
   it('requires document name', () => {
     expect(() => writeBatch.create())
-        .to.throw(/Argument "documentRef" is not a valid DocumentReference\./);
+        .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
   it('requires object', () => {
@@ -128,7 +128,7 @@ describe('create() method', () => {
       writeBatch.create(firestore.doc('sub/doc'));
     })
         .to.throw(
-            /Argument "data" is not a valid Document. Input is not a plain JavaScript object./);
+            'Argument "data" is not a valid Document. Input is not a plain JavaScript object.');
   });
 });
 
@@ -305,7 +305,7 @@ describe('batch support', () => {
 
     expect(() => {
       batch.set(documentName, {});
-    }).to.throw(/Cannot modify a WriteBatch that has been committed./);
+    }).to.throw('Cannot modify a WriteBatch that has been committed.');
 
     return promise;
   });


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-firestore/issues/436 and https://b.corp.google.com/issues/78932093

This PR:
- adds the field path to the error message if a field-level validation fails
- uses consistent quotes in all errors (changed single quotes to double)
- enforces that all errors are verified as they are raised by removing the RegExp matching and matching by exact value instead