### PR TITLE
Bumping version to 0.19

### DIFF
--- a/dev/protos/update.sh
+++ b/dev/protos/update.sh
@@ -59,7 +59,12 @@ cp protobuf/src/google/protobuf/{any,empty,struct,timestamp,wrappers}.proto \
    "${PROTOS_DIR}/google/protobuf/"
 
 # Generate the Protobuf typings
-pbjs --proto_path=. --js_out=import_style=commonjs,binary:library --target=static --no-create --no-encode --no-decode --no-verify --no-convert --no-delimited --force-enum-string --force-number -o firestore_proto_api.js  "${PROTOS_DIR}/google/firestore/v1beta1/*.proto" "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto";
+pbjs --proto_path=. --js_out=import_style=commonjs,binary:library \
+  --target=static --no-create --no-encode --no-decode --no-verify \
+  --no-convert --no-delimited --force-enum-string --force-number -o \
+  firestore_proto_api.js  "${PROTOS_DIR}/google/firestore/v1beta1/*.proto" \
+  "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" \
+  "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto"
 pbts -o firestore_proto_api.d.ts firestore_proto_api.js
 
 # Copy typings into source repo

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/firestore",
   "description": "Firestore Client Library for Node.js",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "mocha system-test/*.js --timeout 600000"
   },
   "dependencies": {
-    "@google-cloud/firestore": "^0.18.0"
+    "@google-cloud/firestore": "^0.19.0"
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",


### PR DESCRIPTION
This prepares the next Node release and also reformats the `update.sh` file. We don't want to send out a PR with unrelated changes after all.