### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "proxyquire": "^2.0.1",
     "source-map-support": "^0.5.6",
     "ts-node": "^7.0.0",
-    "typescript": "~3.1.1"
+    "typescript": "~3.1.1",
+    "@types/sinon": "5.0.5"
   }
 }


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.