### PR TITLE
Adding array-contains to error message

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1986,7 +1986,8 @@ export function validateComparisonOperator(
     return true;
   }
 
-  throw new Error('Operator must be one of "<", "<=", "==", ">", or ">=".');
+  throw new Error(
+      'Operator must be one of "<", "<=", "==", ">", ">=" or "array-contains".');
 }
 
 /*!

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -815,7 +815,9 @@ describe('where() interface', () => {
     let query = firestore.collection('collectionId');
     expect(() => {
       query = query.where('foo', '@', 'foobar');
-    }).to.throw('Operator must be one of "<", "<=", "==", ">", or ">="\.');
+    })
+        .to.throw(
+            'Operator must be one of "<", "<=", "==", ">", ">=" or "array-contains".');
   });
 });
 


### PR DESCRIPTION
This adds the 'array-contains' operator the an error message that validates query operators.