### PR TITLE
Cleanup: Argument count validation

### DIFF
--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -25,8 +25,6 @@ import api = proto.google.firestore.v1beta1;
 import {Serializer} from './serializer';
 import {FieldPath} from './path';
 
-const validate = createValidator();
-
 /**
  * Sentinel values that can be used when writing documents with set(), create()
  * or update().
@@ -106,7 +104,7 @@ export class FieldValue {
    * });
    */
   static arrayUnion(...elements: AnyJs[]): FieldValue {
-    validate.minNumberOfArguments('FieldValue.arrayUnion', arguments, 1);
+    validateMinNumberOfArguments('FieldValue.arrayUnion', arguments, 1);
     return new ArrayUnionTransform(elements);
   }
 
@@ -133,7 +131,7 @@ export class FieldValue {
    * });
    */
   static arrayRemove(...elements: AnyJs[]): FieldValue {
-    validate.minNumberOfArguments('FieldValue.arrayRemove', arguments, 1);
+    validateMinNumberOfArguments('FieldValue.arrayRemove', arguments, 1);
     return new ArrayRemoveTransform(elements);
   }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -707,7 +707,7 @@ export class Firestore {
       documentRef: DocumentReference,
       ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
       Promise<DocumentSnapshot[]> {
-    this._validator.minNumberOfArguments('Firestore.getAll', arguments, 1);
+    validateMinNumberOfArguments('Firestore.getAll', arguments, 1);
 
     const {documents, fieldMask} = parseGetAllArguments(
         this._validator, [documentRef, ...moreDocumentRefsOrReadOptions]);

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -445,7 +445,7 @@ export class FieldPath extends Path<FieldPath> {
    * });
    */
   constructor(...segments: string[]) {
-    validate.minNumberOfArguments('FieldPath', arguments, 1);
+    validateMinNumberOfArguments('FieldPath', arguments, 1);
 
     const elements: string[] = is.array(segments[0]) ?
         segments[0] as AnyDuringMigration :

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -410,12 +410,11 @@ export class DocumentReference {
       dataOrField: (UpdateData|string|FieldPath),
       ...preconditionOrValues: Array<UserInput|string|FieldPath|Precondition>):
       Promise<WriteResult> {
-    this._validator.minNumberOfArguments('update', arguments, 1);
+    validateMinNumberOfArguments('DocumentReference.update', arguments, 1);
 
     const writeBatch = new WriteBatch(this._firestore);
     return writeBatch
         .update
-        // tslint:disable-next-line no-any
         .apply(
             writeBatch,
             [this, dataOrField].concat(
@@ -1364,7 +1363,7 @@ export class Query {
    */
   startAt(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot|UserInput>):
       Query {
-    this._validator.minNumberOfArguments('startAt', arguments, 1);
+    validateMinNumberOfArguments('Query.startAt', arguments, 1);
 
     const options = extend(true, {}, this._queryOptions);
 
@@ -1399,7 +1398,7 @@ export class Query {
    */
   startAfter(...fieldValuesOrDocumentSnapshot:
                  Array<DocumentSnapshot|UserInput>): Query {
-    this._validator.minNumberOfArguments('startAfter', arguments, 1);
+    validateMinNumberOfArguments('Query.startAfter', arguments, 1);
 
     const options = extend(true, {}, this._queryOptions);
 
@@ -1433,7 +1432,7 @@ export class Query {
    */
   endBefore(...fieldValuesOrDocumentSnapshot:
                 Array<DocumentSnapshot|UserInput>): Query {
-    this._validator.minNumberOfArguments('endBefore', arguments, 1);
+    validateMinNumberOfArguments('Query.endBefore', arguments, 1);
 
     const options = extend(true, {}, this._queryOptions);
 
@@ -1467,7 +1466,7 @@ export class Query {
    */
   endAt(...fieldValuesOrDocumentSnapshot: Array<DocumentSnapshot|UserInput>):
       Query {
-    this._validator.minNumberOfArguments('endAt', arguments, 1);
+    validateMinNumberOfArguments('Query.endAt', arguments, 1);
 
     const options = extend(true, {}, this._queryOptions);
 

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -165,7 +165,7 @@ export class Transaction {
       throw new Error(READ_AFTER_WRITE_ERROR_MSG);
     }
 
-    this._validator.minNumberOfArguments('Transaction.getAll', arguments, 1);
+    validateMinNumberOfArguments('Transaction.getAll', arguments, 1);
 
     const {documents, fieldMask} = parseGetAllArguments(
         this._validator, [documentRef, ...moreDocumentRefsOrReadOptions]);
@@ -275,7 +275,7 @@ export class Transaction {
       documentRef: DocumentReference, dataOrField: UpdateData|string|FieldPath,
       ...preconditionOrValues: Array<Precondition|AnyJs|string|FieldPath>):
       Transaction {
-    this._validator.minNumberOfArguments('update', arguments, 2);
+    validateMinNumberOfArguments('Transaction.update', arguments, 2);
 
     preconditionOrValues = Array.prototype.slice.call(arguments, 2);
     this._writeBatch.update.apply(this._writeBatch, [

--- a/dev/src/validate.ts
+++ b/dev/src/validate.ts
@@ -205,3 +205,39 @@ export function createValidator(customValidators?: Validators):
   // consumers can call the custom validator functions.
   return new Validator(customValidators);
 }
+
+/**
+ * Verifies that 'args' has at least 'minSize' elements.
+ *
+ * @private
+ * @param funcName The function name to use in the error message.
+ * @param args The array (or array-like structure) to verify.
+ * @param minSize The minimum number of elements to enforce.
+ * @throws if the expectation is not met.
+ */
+export function validateMinNumberOfArguments(
+    funcName: string, args: IArguments, minSize: number): void {
+  if (args.length < minSize) {
+    throw new Error(
+        `Function "${funcName}()" requires at least ` +
+        `${formatPlural(minSize, 'argument')}.`);
+  }
+}
+
+/**
+ * Verifies that 'args' has at most 'maxSize' elements.
+ *
+ * @private
+ * @param funcName The function name to use in the error message.
+ * @param args The array (or array-like structure) to verify.
+ * @param maxSize The maximum number of elements to enforce.
+ * @throws if the expectation is not met.
+ */
+export function validateMaxNumberOfArguments(
+    funcName: string, args: IArguments, maxSize: number): void {
+  if (args.length > maxSize) {
+    throw new Error(
+        `Function "${funcName}()" accepts at most ` +
+        `${formatPlural(maxSize, 'argument')}.`);
+  }
+}

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -347,7 +347,7 @@ export class WriteBatch {
       ...preconditionOrValues:
           Array<{lastUpdateTime?: Timestamp}|AnyJs|string|FieldPath>):
       WriteBatch {
-    this._validator.minNumberOfArguments('update', arguments, 2);
+    validateMinNumberOfArguments('WriteBatch.update', arguments, 2);
     this._validator.isDocumentReference('documentRef', documentRef);
 
     this.verifyNotCommitted();
@@ -370,7 +370,11 @@ export class WriteBatch {
             precondition = new Precondition(arguments[i]);
           } else {
             this._validator.isFieldPath(i, arguments[i]);
-            this._validator.minNumberOfArguments('update', arguments, i + 1);
+            // Unlike the `validateMinNumberOfArguments` invocation above, this
+            // validation can be triggered both from `WriteBatch.update()` and
+            // `DocumentReference.update()`. Hence, we don't use the fully
+            // qualified API name in the error message.
+            validateMinNumberOfArguments('update', arguments, i + 1);
 
             const fieldPath = FieldPath.fromArgument(arguments[i]);
             this._validator.isFieldValue(
@@ -395,7 +399,7 @@ export class WriteBatch {
           allowDeletes: 'root',
           allowTransforms: true,
         });
-        this._validator.maxNumberOfArguments('update', arguments, 3);
+        validateMaxNumberOfArguments('update', arguments, 3);
 
         Object.keys(dataOrField).forEach(key => {
           this._validator.isFieldPath(key, key);

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -1313,7 +1313,7 @@ describe('update document', () => {
 
     expect(() => {
       firestore.doc('collectionId/documentId').update();
-    }).to.throw('Function "update()" requires at least 1 argument.');
+    }).to.throw('Function "DocumentReference.update()" requires at least 1 argument.');
   });
 
   it('rejects nested deletes', () => {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -1233,7 +1233,7 @@ describe('startAt() interface', () => {
 
     expect(() => {
       query.startAt();
-    }).to.throw('Function "startAt()" requires at least 1 argument.');
+    }).to.throw('Function "Query.startAt()" requires at least 1 argument.');
   });
 
   it('can specify document snapshot', () => {


### PR DESCRIPTION
This is part of https://github.com/googleapis/nodejs-firestore/pull/512 but can be reviewed independently.

This PR adds free-standing methods for argument count validation. The existing methods are removed in a follow-up PR that will remove the entire Validator class.