### PR TITLE
Cleanup: Validate primitive types

### DIFF
--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -19,8 +19,6 @@ import api = google.firestore.v1beta1;
 import {createValidator} from './validate';
 import {ProtobufJsValue} from './types';
 
-const validate = createValidator();
-
 /*!
  * @module firestore/convert
  * @private
@@ -71,7 +69,7 @@ export function timestampFromJson(
       nanos: nanos || undefined,
     };
   } else if (timestampValue !== undefined) {
-    validate.isObject('timestampValue', timestampValue);
+    validateObject('timestampValue', timestampValue);
     timestampProto = {
       seconds: timestampValue.seconds || undefined,
       nanos: timestampValue.nanos || undefined,

--- a/dev/src/geo-point.ts
+++ b/dev/src/geo-point.ts
@@ -20,8 +20,6 @@ import api = google.firestore.v1beta1;
 import {createValidator} from './validate';
 import {Serializable} from './serializer';
 
-const validate = createValidator();
-
 /**
  * An immutable object representing a geographic location in Firestore. The
  * location is represented as a latitude/longitude pair.
@@ -49,8 +47,8 @@ export class GeoPoint implements Serializable {
    * });
    */
   constructor(latitude: number, longitude: number) {
-    validate.isNumber('latitude', latitude, -90, 90);
-    validate.isNumber('longitude', longitude, -180, 180);
+    validateNumber('latitude', latitude, {minValue: -90, maxValue: 90});
+    validateNumber('longitude', longitude, {minValue: -180, maxValue: 180});
 
     this._latitude = latitude;
     this._longitude = longitude;

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -349,10 +349,11 @@ export class Firestore {
    * @param {object} settings The settings to use for all Firestore operations.
    */
   settings(settings: Settings): void {
-    this._validator.isObject('settings', settings);
-    this._validator.isOptionalString('settings.projectId', settings.projectId);
-    this._validator.isOptionalBoolean(
-        'settings.timestampsInSnapshots', settings.timestampsInSnapshots);
+    validateObject('settings', settings);
+    validateString('settings.projectId', settings.projectId, {optional: true});
+    validateBoolean(
+        'settings.timestampsInSnapshots', settings.timestampsInSnapshots,
+        {optional: true});
 
     if (this._clientInitialized) {
       throw new Error(
@@ -374,11 +375,12 @@ export class Firestore {
   }
 
   private validateAndApplySettings(settings: Settings): void {
-    this._validator.isOptionalBoolean(
-        'settings.timestampsInSnapshots', settings.timestampsInSnapshots);
+    validateBoolean(
+        'settings.timestampsInSnapshots', settings.timestampsInSnapshots,
+        {optional: true});
 
     if (settings && settings.projectId) {
-      this._validator.isString('settings.projectId', settings.projectId);
+      validateString('settings.projectId', settings.projectId);
       this._referencePath = new ResourcePath(settings.projectId, '(default)');
     } else {
       // Initialize a temporary reference path that will be overwritten during
@@ -584,12 +586,13 @@ export class Firestore {
   runTransaction<T>(
       updateFunction: (transaction: Transaction) => Promise<T>,
       transactionOptions?: {maxAttempts?: number}): Promise<T> {
-    this._validator.isFunction('updateFunction', updateFunction);
+    validateFunction('updateFunction', updateFunction);
 
     if (transactionOptions) {
-      this._validator.isObject('transactionOptions', transactionOptions);
-      this._validator.isOptionalInteger(
-          'transactionOptions.maxAttempts', transactionOptions.maxAttempts, 1);
+      validateObject('transactionOptions', transactionOptions);
+      validateInteger(
+          'transactionOptions.maxAttempts', transactionOptions.maxAttempts,
+          {optional: true, minValue: 1});
     }
 
     return this._runTransaction(updateFunction, transactionOptions);

--- a/dev/src/logger.ts
+++ b/dev/src/logger.ts
@@ -18,8 +18,6 @@ import * as util from 'util';
 
 import {createValidator} from './validate';
 
-const validate = createValidator();
-
 /*! The Firestore library version */
 let libVersion: string;
 
@@ -50,7 +48,7 @@ export function logger(
  * @private
  */
 export function setLogFunction(logger: (msg: string) => void): void {
-  validate.isFunction('logger', logger);
+  validateFunction('logger', logger);
   logFunction = logger;
 }
 

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -452,7 +452,7 @@ export class FieldPath extends Path<FieldPath> {
         segments;
 
     for (let i = 0; i < elements.length; ++i) {
-      validate.isString(i, elements[i]);
+      validateString(i, elements[i]);
       if (elements[i].length === 0) {
         throw new Error(`Element at index ${i} should not be an empty string.`);
       }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -453,8 +453,8 @@ export class DocumentReference {
   onSnapshot(
       onNext: (snapshot: DocumentSnapshot) => void,
       onError?: (error: Error) => void): () => void {
-    this._validator.isFunction('onNext', onNext);
-    this._validator.isOptionalFunction('onError', onError);
+    validateFunction('onNext', onNext);
+    validateFunction('onError', onError, {optional: true});
 
     const watch = Watch.forDocument(this);
 
@@ -798,7 +798,7 @@ export class QuerySnapshot {
   // tslint:disable-next-line:no-any
   forEach(callback: (result: QueryDocumentSnapshot) => void, thisArg?: any):
       void {
-    this._validator.isFunction('callback', callback);
+    validateFunction('callback', callback);
 
     for (const doc of this.docs) {
       callback.call(thisArg, doc);
@@ -1146,7 +1146,7 @@ export class Query {
    * });
    */
   limit(limit: number): Query {
-    this._validator.isInteger('limit', limit);
+    validateInteger('limit', limit);
 
     const options = extend(true, {}, this._queryOptions);
     options.limit = limit;
@@ -1175,7 +1175,7 @@ export class Query {
    * });
    */
   offset(offset: number): Query {
-    this._validator.isInteger('offset', offset);
+    validateInteger('offset', offset);
 
     const options = extend(true, {}, this._queryOptions);
     options.offset = offset;
@@ -1700,8 +1700,8 @@ export class Query {
   onSnapshot(
       onNext: (snapshot: QuerySnapshot) => void,
       onError?: (error: Error) => void): () => void {
-    this._validator.isFunction('onNext', onNext);
-    this._validator.isOptionalFunction('onError', onError);
+    validateFunction('onNext', onNext);
+    validateFunction('onError', onError, {optional: true});
 
     const watch = Watch.forQuery(this);
 

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -17,8 +17,6 @@
 import {google} from '../protos/firestore_proto_api';
 import {createValidator} from './validate';
 
-const validate = createValidator();
-
 /*!
  * Number of nanoseconds in a millisecond.
  *
@@ -119,8 +117,9 @@ export class Timestamp {
    * from 0 to 999,999,999 inclusive.
    */
   constructor(seconds, nanoseconds) {
-    validate.isInteger('seconds', seconds);
-    validate.isInteger('nanoseconds', nanoseconds, 0, 999999999);
+    validateInteger('seconds', seconds);
+    validateInteger(
+        'nanoseconds', nanoseconds, {minValue: 0, maxValue: 999999999});
 
     this._seconds = seconds;
     this._nanoseconds = nanoseconds;

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -98,3 +98,30 @@ export function parseGetAllArguments(
       null;
   return {fieldMask, documents};
 }
+
+/**
+ * Determines whether `value` is a JavaScript object.
+ *
+ * @private
+ */
+export function isObject(value: unknown): value is object {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+/**
+ * Returns whether `value` has no custom properties.
+ *
+ * @private
+ */
+export function isEmpty(value: {}): boolean {
+  return Object.keys(value).length === 0;
+}
+
+/**
+ * Determines whether `value` is a JavaScript function.
+ *
+ * @private
+ */
+export function isFunction(value: unknown): boolean {
+  return value && {}.toString.call(value) === '[object Function]';
+}


### PR DESCRIPTION
This is part of #512 but can be reviewed independently.

This PR adds free-standing methods for the validation of simple types, such as boolean and strings. It uses an function argument to allow for optional values, instead of encoding this behavior in the method name (`isOptionalString` becomes `validateString(..., { optional: true )`.

The unused methods are removed in a follow-up PR.