### PR TITLE
Cleanup: Enforce Import ordering

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -14,25 +14,22 @@
  * limitations under the License.
  */
 
-import {expect} from 'chai';
 const duplexify = require('duplexify');
 
-import * as is from 'is';
+import {expect} from 'chai';
 import * as path from 'path';
 import * as protobufjs from 'protobufjs';
 import * as through2 from 'through2';
 
-import * as proto from '../protos/firestore_proto_api';
-import api = proto.google.firestore.v1beta1;
-
+import {google} from '../protos/firestore_proto_api';
 import * as Firestore from '../src';
-
-import {ResourcePath} from '../src/path';
-import * as convert from '../src/convert';
-
-import {createInstance as createInstanceHelper} from '../test/util/helpers';
-import {AnyDuringMigration} from '../src/types';
+import {documentFromJson} from '../src/convert';
 import {DocumentChangeType} from '../src/document-change';
+import {ResourcePath} from '../src/path';
+import {isObject} from '../src/util';
+import {createInstance as createInstanceHelper} from '../test/util/helpers';
+
+import api = google.firestore.v1beta1;
 
 const REQUEST_TIME = 'REQUEST_TIME';
 
@@ -175,7 +172,7 @@ const convertInput = {
 
     for (const doc of snapshot.docs) {
       const deepCopy = JSON.parse(JSON.stringify(doc));
-      deepCopy.fields = convert.documentFromJson(deepCopy.fields);
+      deepCopy.fields = documentFromJson(deepCopy.fields);
       docs.push(
           firestore.snapshot_(deepCopy, readTime, 'json') as
           Firestore.QueryDocumentSnapshot);
@@ -183,7 +180,7 @@ const convertInput = {
 
     for (const change of snapshot.changes) {
       const deepCopy = JSON.parse(JSON.stringify(change.doc));
-      deepCopy.fields = convert.documentFromJson(deepCopy.fields);
+      deepCopy.fields = documentFromJson(deepCopy.fields);
       const doc = firestore.snapshot_(deepCopy, readTime, 'json');
       const type =
           (['unspecified', 'added', 'removed', 'modified'][change.kind] as
@@ -208,7 +205,7 @@ const convertProto = {
     }
     if (deepCopy.documentChange) {
       deepCopy.documentChange.document.fields =
-          convert.documentFromJson(deepCopy.documentChange.document.fields);
+          documentFromJson(deepCopy.documentChange.document.fields);
     }
     return deepCopy;
   },

--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -15,11 +15,10 @@
  */
 
 import {google} from '../protos/firestore_proto_api';
-import api = google.firestore.v1beta1;
-import {createValidator} from './validate';
 import {ProtobufJsValue} from './types';
+import {validateObject} from './validate';
 
-const validate = createValidator();
+import api = google.firestore.v1beta1;
 
 /*!
  * @module firestore/convert

--- a/dev/src/document-change.ts
+++ b/dev/src/document-change.ts
@@ -15,6 +15,7 @@
  */
 
 import {QueryDocumentSnapshot} from './document';
+
 export type DocumentChangeType = 'added'|'removed'|'modified';
 
 /**

--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
 const deepEqual = require('deep-equal');
-import * as is from 'is';
+
+import * as assert from 'assert';
 
 import {google} from '../protos/firestore_proto_api';
-import {FieldTransform} from './field-value';
-import {FieldPath} from './path';
+import {DeleteTransform, FieldTransform} from './field-value';
+import {GeoPoint} from './geo-point';
+import {FieldPath, validateFieldPath} from './path';
 import {DocumentReference} from './reference';
 import {isPlainObject, Serializer} from './serializer';
 import {Timestamp} from './timestamp';
-import {AnyDuringMigration, AnyJs, ApiMapValue, DocumentData, UpdateData, UserInput} from './types';
+import {ApiMapValue, DocumentData, UpdateMap, ValidationOptions} from './types';
+import {isEmpty, isObject} from './util';
+import {customObjectMessage, invalidArgumentMessage} from './validate';
 
 import api = google.firestore.v1beta1;
 

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -16,16 +16,13 @@
 
 const deepEqual = require('deep-equal');
 
-import * as proto from '../protos/firestore_proto_api';
-
-import {AnyDuringMigration, AnyJs} from './types';
-import {createValidator} from './validate';
-
-import api = proto.google.firestore.v1beta1;
-import {Serializer} from './serializer';
+import {google} from '../protos/firestore_proto_api';
+import {validateUserInput} from './document';
 import {FieldPath} from './path';
+import {Serializer} from './serializer';
+import {validateMinNumberOfArguments} from './validate';
 
-const validate = createValidator();
+import api = google.firestore.v1beta1;
 
 /**
  * Sentinel values that can be used when writing documents with set(), create()

--- a/dev/src/geo-point.ts
+++ b/dev/src/geo-point.ts
@@ -15,12 +15,10 @@
  */
 
 import {google} from '../protos/firestore_proto_api';
-import api = google.firestore.v1beta1;
-
-import {createValidator} from './validate';
 import {Serializable} from './serializer';
+import {validateNumber} from './validate';
 
-const validate = createValidator();
+import api = google.firestore.v1beta1;
 
 /**
  * An immutable object representing a geographic location in Firestore. The

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -18,28 +18,25 @@ import {replaceProjectIdToken} from '@google-cloud/projectify';
 import * as assert from 'assert';
 import * as bun from 'bun';
 import * as extend from 'extend';
-import * as is from 'is';
 import * as through2 from 'through2';
+
 import {google} from '../protos/firestore_proto_api';
-import * as convert from './convert';
-import {DocumentSnapshot, DocumentSnapshotBuilder, validatePrecondition, validateSetOptions} from './document';
-import {DeleteTransform, FieldTransform} from './field-value';
+import {documentFromJson, timestampFromJson} from './convert';
+import {DocumentSnapshot, DocumentSnapshotBuilder} from './document';
 import {GeoPoint} from './geo-point';
 import {logger, setLibVersion} from './logger';
-import {FieldPath} from './path';
+import {FieldPath, validateResourcePath} from './path';
 import {ResourcePath} from './path';
 import {ClientPool} from './pool';
-import {CollectionReference, validateComparisonOperator, validateDocumentReference, validateFieldOrder} from './reference';
+import {CollectionReference} from './reference';
 import {DocumentReference} from './reference';
-import {isPlainObject, Serializer} from './serializer';
+import {Serializer} from './serializer';
 import {Timestamp} from './timestamp';
-import {Transaction} from './transaction';
-import {DocumentData, GapicClient, ReadOptions, Settings, ValidationOptions} from './types';
-import {AnyDuringMigration, AnyJs} from './types';
-import {parseGetAllArguments, requestTag} from './util';
-import {customObjectError, Validator} from './validate';
+import {parseGetAllArguments, Transaction} from './transaction';
+import {DocumentData, GapicClient, ReadOptions, Settings} from './types';
+import {requestTag} from './util';
+import {validateBoolean, validateFunction, validateInteger, validateMinNumberOfArguments, validateObject, validateString,} from './validate';
 import {WriteBatch} from './write-batch';
-import {validateUpdateMap} from './write-batch';
 
 import api = google.firestore.v1beta1;
 
@@ -508,8 +505,8 @@ export class Firestore {
     } else if (encoding === 'json') {
       // Google Cloud Functions calls us with Proto3 JSON format data, which we
       // must convert to Protobuf JS.
-      convertTimestamp = convert.timestampFromJson;
-      convertDocument = convert.documentFromJson;
+      convertTimestamp = timestampFromJson;
+      convertDocument = documentFromJson;
     } else {
       throw new Error(
           `Unsupported encoding format. Expected "json" or "protobufJS", ` +

--- a/dev/src/logger.ts
+++ b/dev/src/logger.ts
@@ -16,9 +16,7 @@
 
 import * as util from 'util';
 
-import {createValidator} from './validate';
-
-const validate = createValidator();
+import {validateFunction} from './validate';
 
 /*! The Firestore library version */
 let libVersion: string;

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -15,12 +15,11 @@
  */
 
 import {google} from '../protos/firestore_proto_api';
-import api = google.firestore.v1beta1;
-
 import {detectValueType} from './convert';
 import {ResourcePath} from './path';
-import {customObjectError} from './validate';
 import {ApiMapValue} from './types';
+
+import api = google.firestore.v1beta1;
 
 /*!
  * The type order as defined by the backend.

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import * as is from 'is';
 import {google} from '../protos/firestore_proto_api';
+import {customObjectMessage, invalidArgumentMessage, validateMinNumberOfArguments, validateString} from './validate';
+
 import api = google.firestore.v1beta1;
-
-import {createValidator, customObjectError} from './validate';
-import {AnyDuringMigration} from './types';
-
-const validate = createValidator();
 
 /*!
  * A regular expression to verify an absolute Resource Path in Firestore. It

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 
-import * as bun from 'bun';
 const deepEqual = require('deep-equal');
+
+import * as bun from 'bun';
 import * as extend from 'extend';
-import * as is from 'is';
 import * as through2 from 'through2';
 
-import * as proto from '../protos/firestore_proto_api';
-import api = proto.google.firestore.v1beta1;
-
-import {compare} from './order';
-import {logger} from './logger';
-import {DocumentSnapshot, DocumentSnapshotBuilder, QueryDocumentSnapshot} from './document';
+import {google} from '../protos/firestore_proto_api';
+import {DocumentSnapshot, DocumentSnapshotBuilder, QueryDocumentSnapshot, validateUserInput} from './document';
 import {DocumentChange} from './document-change';
-import {Watch} from './watch';
-import {WriteBatch, WriteResult} from './write-batch';
-import {Timestamp} from './timestamp';
-import {FieldPath, ResourcePath} from './path';
-import {autoId, requestTag} from './util';
-import {customObjectError} from './validate';
-import {AnyDuringMigration, DocumentData, UpdateData, Precondition, SetOptions, UserInput} from './types';
-import {Serializer} from './serializer';
 import {Firestore} from './index';
+import {logger} from './logger';
+import {compare} from './order';
+import {FieldPath, ResourcePath, validateFieldPath, validateResourcePath} from './path';
+import {Serializer} from './serializer';
+import {Timestamp} from './timestamp';
+import {DocumentData, OrderByDirection, Precondition, SetOptions, UpdateData, WhereFilterOp} from './types';
+import {autoId, requestTag} from './util';
+import {invalidArgumentMessage, validateEnumValue, validateFunction, validateInteger, validateMinNumberOfArguments} from './validate';
+import {Watch} from './watch';
+import {validateDocumentData, WriteBatch, WriteResult} from './write-batch';
+
+import api = google.firestore.v1beta1;
 
 /*!
  * The direction of a `Query.orderBy()` clause is specified as 'desc' or 'asc'

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-import * as is from 'is';
-
-import * as proto from '../protos/firestore_proto_api';
-import api = proto.google.firestore.v1beta1;
-
-import {Timestamp} from './timestamp';
-import {FieldTransform} from './field-value';
-
-import {customObjectError} from './validate';
-import {ResourcePath} from './path';
+import {google} from '../protos/firestore_proto_api';
 import {detectValueType} from './convert';
-import {AnyDuringMigration, AnyJs, UserInput} from './types';
+import {FieldTransform} from './field-value';
 import {GeoPoint} from './geo-point';
 import {DocumentReference, Firestore} from './index';
+import {ResourcePath} from './path';
+import {Timestamp} from './timestamp';
+
+import api = google.firestore.v1beta1;
 
 /** An interface for Firestore types that can be serialized to Protobuf. */
 export interface Serializable {

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -15,7 +15,7 @@
  */
 
 import {google} from '../protos/firestore_proto_api';
-import {createValidator} from './validate';
+import {validateInteger} from './validate';
 
 const validate = createValidator();
 

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import * as proto from '../protos/firestore_proto_api';
-
+import {google} from '../protos/firestore_proto_api';
 import {DocumentSnapshot, Precondition} from './document';
 import {Firestore, WriteBatch} from './index';
-import {FieldPath} from './path';
-import {DocumentReference, Query, QuerySnapshot} from './reference';
-import {AnyDuringMigration, AnyJs, DocumentData, Precondition as PublicPrecondition, ReadOptions, SetOptions, UpdateData} from './types';
-import {parseGetAllArguments} from './util';
+import {FieldPath, validateFieldPath} from './path';
+import {DocumentReference, Query, QuerySnapshot, validateDocumentReference} from './reference';
+import {isPlainObject} from './serializer';
+import {DocumentData, Precondition as PublicPrecondition, ReadOptions, SetOptions, UpdateData} from './types';
 import {requestTag} from './util';
+import {invalidArgumentMessage, validateMinNumberOfArguments} from './validate';
 
-import api = proto.google.firestore.v1beta1;
+import api = google.firestore.v1beta1;
 
 /*!
  * Error message for transactional reads that were executed after performing

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-import {FieldPath} from './path';
-import {DocumentReference} from './reference';
-import {isPlainObject} from './serializer';
-import {AnyDuringMigration, ReadOptions} from './types';
-
 /**
  * Generate a unique client-side identifier.
  *

--- a/dev/src/validate.ts
+++ b/dev/src/validate.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import * as is from 'is';
-
 import {FieldPath} from './path';
-import {AnyDuringMigration} from './types';
+import {isFunction, isObject} from './util';
 
 /**
  * Formats the given word as plural conditionally given the preceding number.

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -19,7 +19,6 @@ import * as rbtree from 'functional-red-black-tree';
 import * as through2 from 'through2';
 
 import {google} from '../protos/firestore_proto_api';
-
 import {ExponentialBackoff} from './backoff';
 import {DocumentSnapshotBuilder, QueryDocumentSnapshot} from './document';
 import {DocumentChange, DocumentChangeType} from './document-change';
@@ -27,10 +26,10 @@ import Firestore, {DocumentReference, Query} from './index';
 import {logger} from './logger';
 import {ResourcePath} from './path';
 import {Timestamp} from './timestamp';
+import {GrpcError} from './types';
 import {requestTag} from './util';
 
 import api = google.firestore.v1beta1;
-import {GrpcError} from './types';
 
 /*!
  * Target ID used by watch. Watch uses a fixed target id since we only support

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -17,17 +17,17 @@
 import * as assert from 'assert';
 
 import {google} from '../protos/firestore_proto_api';
-
-import {DocumentMask, DocumentSnapshot, DocumentTransform, Precondition} from './document';
+import {DocumentMask, DocumentSnapshot, DocumentTransform, Precondition, validateFieldValue, validateUserInput} from './document';
 import {Firestore} from './index';
 import {logger} from './logger';
-import {FieldPath} from './path';
-import {DocumentReference} from './reference';
-import {Serializer} from './serializer';
+import {FieldPath, validateFieldPath} from './path';
+import {DocumentReference, validateDocumentReference} from './reference';
+import {isPlainObject, Serializer} from './serializer';
 import {Timestamp} from './timestamp';
-import {AnyDuringMigration, AnyJs, Precondition as PublicPrecondition, SetOptions, UpdateData, UserInput} from './types';
+import {Precondition as PublicPrecondition, SetOptions, UpdateData, UpdateMap} from './types';
 import {DocumentData} from './types';
-import {requestTag} from './util';
+import {isObject, requestTag} from './util';
+import {AllowOptional, customObjectMessage, invalidArgumentMessage, validateMaxNumberOfArguments, validateMinNumberOfArguments, validateOptional} from './validate';
 
 import api = google.firestore.v1beta1;
 

--- a/dev/test/backoff.ts
+++ b/dev/test/backoff.ts
@@ -17,7 +17,6 @@
 import {expect} from 'chai';
 
 import {ExponentialBackoff, setTimeoutHandler} from '../src/backoff';
-import {AnyDuringMigration} from '../src/types';
 
 const nop = () => {};
 

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import {expect} from 'chai';
 
 import * as Firestore from '../src/index';

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -17,8 +17,6 @@
 import {expect} from 'chai';
 
 import * as Firestore from '../src';
-import {AnyDuringMigration} from '../src/types';
-
 import {create, createInstance, document, found, InvalidApiUsage, missing, remove, requestEquals, retrieve, serverTimestamp, set, stream, update, updateMask, writeResult} from './util/helpers';
 
 const PROJECT_ID = 'test-project';

--- a/dev/test/field-value.ts
+++ b/dev/test/field-value.ts
@@ -17,7 +17,6 @@
 import {expect} from 'chai';
 
 import {FieldValue} from '../src';
-
 import {ApiOverride, arrayTransform, createInstance, document, requestEquals, serverTimestamp, set, writeResult} from './util/helpers';
 
 function genericFieldValueTests(methodName: string, sentinel: FieldValue) {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -21,8 +21,7 @@ import * as gax from 'google-gax';
 import * as Firestore from '../src';
 import {FieldPath} from '../src';
 import {ResourcePath} from '../src/path';
-import {AnyDuringMigration, GrpcError} from '../src/types';
-
+import {GrpcError} from '../src/types';
 import {createInstance, document, DOCUMENT_NAME, found, InvalidApiUsage, missing, stream} from './util/helpers';
 
 const {grpc} = new gax.GrpcClient({} as AnyDuringMigration);

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -17,12 +17,12 @@
 import {expect} from 'chai';
 
 import * as Firestore from '../src';
-import {DocumentSnapshot} from '../src/document';
-import {GeoPoint} from '../src/geo-point';
+import {DocumentSnapshot} from '../src';
+import {GeoPoint} from '../src';
+import {DocumentReference} from '../src';
 import * as order from '../src/order';
 import {ResourcePath} from '../src/path';
-import {DocumentReference} from '../src/reference';
-import {createInstance, InvalidApiUsage} from '../test/util/helpers';
+import {createInstance, InvalidApiUsage} from './util/helpers';
 
 // Change the argument to 'console.log' to enable debug output.
 Firestore.setLogFunction(() => {});

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -16,15 +16,15 @@
 
 import {expect} from 'chai';
 import * as extend from 'extend';
-import * as proto from '../protos/firestore_proto_api';
+
+import {google} from '../protos/firestore_proto_api';
 import * as Firestore from '../src';
 import {DocumentData, DocumentReference, Query, Timestamp} from '../src';
 import {DocumentSnapshot, DocumentSnapshotBuilder} from '../src/document';
 import {ResourcePath} from '../src/path';
-import {AnyDuringMigration} from '../src/types';
 import {createInstance, document, InvalidApiUsage, stream} from './util/helpers';
 
-import api = proto.google.firestore.v1beta1;
+import api = google.firestore.v1beta1;
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -15,7 +15,6 @@
  */
 
 import {expect} from 'chai';
-import * as is from 'is';
 import * as through2 from 'through2';
 
 import * as Firestore from '../src/index';

--- a/dev/test/transaction.ts
+++ b/dev/test/transaction.ts
@@ -18,14 +18,12 @@ import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as through2 from 'through2';
 
-import * as proto from '../protos/firestore_proto_api';
+import {google} from '../protos/firestore_proto_api';
 import * as Firestore from '../src';
-
+import {DocumentReference, FieldPath, Transaction} from '../src';
 import {createInstance, InvalidApiUsage} from './util/helpers';
 
-import api = proto.google.firestore.v1beta1;
-import {AnyDuringMigration} from '../src/types';
-import {FieldPath} from '../src';
+import api = google.firestore.v1beta1;
 
 use(chaiAsPromised);
 

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -35,7 +35,6 @@ import Precondition = FirebaseFirestore.Precondition;
 import SetOptions = FirebaseFirestore.SetOptions;
 import Timestamp = FirebaseFirestore.Timestamp;
 import Settings = FirebaseFirestore.Settings;
-import {AnyDuringMigration} from '../src/types';
 
 // This test verifies the Typescript typings and is not meant for execution.
 xdescribe('firestore.d.ts', () => {

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
+const v1beta1 = require('../../src/v1beta1');
+
 import {expect} from 'chai';
 import {GrpcClient} from 'google-gax';
 import * as through2 from 'through2';
 
-import * as proto from '../../protos/firestore_proto_api';
-import api = proto.google.firestore.v1beta1;
-
-const v1beta1 = require('../../src/v1beta1');
-
+import {google} from '../../protos/firestore_proto_api';
 import {Firestore} from '../../src';
 import {ClientPool} from '../../src/pool';
+
+import api = google.firestore.v1beta1;
 
 /* tslint:disable:no-any */
 type GapicClient = any;

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {expect} from 'chai';
 const duplexify = require('duplexify');
+
+import {expect} from 'chai';
 import * as through2 from 'through2';
 
 import * as proto from '../protos/firestore_proto_api';
@@ -25,8 +26,7 @@ import {setTimeoutHandler} from '../src/backoff';
 import {DocumentSnapshotBuilder} from '../src/document';
 import {DocumentChangeType} from '../src/document-change';
 import {Serializer} from '../src/serializer';
-import {AnyDuringMigration, GrpcError} from '../src/types';
-
+import {GrpcError} from '../src/types';
 import {createInstance} from './util/helpers';
 
 import api = proto.google.firestore.v1beta1;

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
     "no-bitwise": true
   },
   "rules": {
-    "no-unused-expression": false
+    "no-unused-expression": false,
+    "ordered-imports": true
   }
 }


### PR DESCRIPTION
This is part of #512 but can be reviewed independently.

This PR cleans up all the imports for #510 and uses `tslint` to enforce ordering. I manually moved the imports around to group them into cohesive blocks before invoking the linter.