### PR TITLE
Cleanup: Remove 'any'

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -351,7 +351,8 @@ function runTest(spec) {
   const setTest = spec => {
     const overrides = {commit: commitHandler(spec)};
     return createInstance(overrides).then(() => {
-      const setOption: AnyDuringMigration = {};
+      const setOption: {merge?: boolean,
+                        mergeFields?: Firestore.FieldPath[]} = {};
       if (spec.option && spec.option.all) {
         setOption.merge = true;
       } else if (spec.option && spec.option.fields) {

--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -144,7 +144,7 @@ export class DocumentSnapshot {
    * @param data The field/value map to expand.
    * @return The created DocumentSnapshot.
    */
-  static fromUpdateMap(ref: DocumentReference, data: UpdateData):
+  static fromUpdateMap(ref: DocumentReference, data: UpdateMap):
       DocumentSnapshot {
     const serializer = ref.firestore._serializer;
 
@@ -153,7 +153,7 @@ export class DocumentSnapshot {
      * 'target'.
      */
     function merge(
-        target: ApiMapValue, value: AnyJs, path: string[], pos: number) {
+        target: ApiMapValue, value: unknown, path: string[], pos: number) {
       const key = path[pos];
       const isLast = pos === path.length - 1;
 
@@ -349,7 +349,7 @@ export class DocumentSnapshot {
    *   console.log(`Retrieved data: ${JSON.stringify(data)}`);
    * });
    */
-  data(): DocumentData|undefined {
+  data(): {[field: string]: any}|undefined {  // tslint:disable-line no-any
     const fields = this._fieldsProto;
 
     if (fields === undefined) {
@@ -383,7 +383,7 @@ export class DocumentSnapshot {
    *   console.log(`Retrieved field value: ${field}`);
    * });
    */
-  get(field: string|FieldPath): UserInput {
+  get(field: string|FieldPath): any {  // tslint:disable-line no-any
     this._validator.isFieldPath('field', field);
 
     const protoField = this.protoField(field);
@@ -592,7 +592,7 @@ export class DocumentMask {
    * @param data A map with fields to modify. Only the keys are used to extract
    * the document mask.
    */
-  static fromUpdateMap(data: UpdateData): DocumentMask {
+  static fromUpdateMap(data: UpdateMap): DocumentMask {
     const fieldPaths: FieldPath[] = [];
 
     data.forEach((value, key) => {
@@ -848,7 +848,7 @@ export class DocumentTransform {
    */
   static fromObject(ref: DocumentReference, obj: DocumentData):
       DocumentTransform {
-    const updateMap = new Map<FieldPath, FieldTransform>();
+    const updateMap = new Map<FieldPath, unknown>();
 
     for (const prop in obj) {
       if (obj.hasOwnProperty(prop)) {
@@ -867,7 +867,7 @@ export class DocumentTransform {
    * @param data The update data to extract the transformations from.
    * @returns The Document Transform.
    */
-  static fromUpdateMap(ref: DocumentReference, data: UpdateData):
+  static fromUpdateMap(ref: DocumentReference, data: UpdateMap):
       DocumentTransform {
     const transforms = new Map<FieldPath, FieldTransform>();
 

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -105,7 +105,7 @@ export class FieldValue {
    *   // doc.get('array') contains field 'foo'
    * });
    */
-  static arrayUnion(...elements: AnyJs[]): FieldValue {
+  static arrayUnion(...elements: Array<unknown>): FieldValue {
     validate.minNumberOfArguments('FieldValue.arrayUnion', arguments, 1);
     return new ArrayUnionTransform(elements);
   }
@@ -132,7 +132,7 @@ export class FieldValue {
    *   // doc.get('array') no longer contains field 'foo'
    * });
    */
-  static arrayRemove(...elements: AnyJs[]): FieldValue {
+  static arrayRemove(...elements: Array<unknown>): FieldValue {
     validate.minNumberOfArguments('FieldValue.arrayRemove', arguments, 1);
     return new ArrayRemoveTransform(elements);
   }
@@ -286,7 +286,7 @@ class ServerTimestampTransform extends FieldTransform {
  * @private
  */
 class ArrayUnionTransform extends FieldTransform {
-  constructor(private readonly elements: AnyJs[]) {
+  constructor(private readonly elements: Array<unknown>) {
     super();
   }
 
@@ -340,7 +340,7 @@ class ArrayUnionTransform extends FieldTransform {
  * @private
  */
 class ArrayRemoveTransform extends FieldTransform {
-  constructor(private readonly elements: AnyJs[]) {
+  constructor(private readonly elements: Array<unknown>) {
     super();
   }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -236,7 +236,7 @@ export class Firestore {
    * The serializer to use for the Protobuf transformation.
    * @private
    */
-  private _serializer: Serializer|null = null;
+  _serializer: Serializer|null = null;
 
   private _referencePath: ResourcePath|null = null;
 
@@ -493,7 +493,7 @@ export class Firestore {
    * @returns A QueryDocumentSnapshot for existing documents, otherwise a
    * DocumentSnapshot.
    */
-  private snapshot_(
+  snapshot_(
       documentOrName: api.IDocument|string,
       readTime?: google.protobuf.ITimestamp,
       encoding?: 'json'|'protobufJS'): DocumentSnapshot {
@@ -1094,8 +1094,11 @@ follow these steps, YOUR APP MAY BREAK.`);
         logger(
             'Firestore._initializeStream', requestTag, 'Sending request: %j',
             request);
-        (resultStream as NodeJS.ReadWriteStream)
-            .write(request as AnyDuringMigration, 'utf-8', () => {
+        (resultStream as NodeJS.WritableStream)
+            // The stream returned by the Gapic library accepts Protobuf
+            // messages.
+            // tslint:disable-next-line no-any
+            .write(request as any, 'utf-8', () => {
               logger(
                   'Firestore._initializeStream', requestTag,
                   'Marking stream as healthy');
@@ -1179,14 +1182,14 @@ follow these steps, YOUR APP MAY BREAK.`);
                        'Sending request: %j', decorated.request);
                    const stream = gapicClient[methodName](
                        decorated.request, decorated.gax);
-                   const logStream = through2.obj(function(
-                       this: AnyDuringMigration, chunk, enc, callback) {
-                     logger(
-                         'Firestore.readStream', requestTag,
-                         'Received response: %j', chunk);
-                     this.push(chunk);
-                     callback();
-                   });
+                   const logStream =
+                       through2.obj(function(this, chunk, enc, callback) {
+                         logger(
+                             'Firestore.readStream', requestTag,
+                             'Received response: %j', chunk);
+                         this.push(chunk);
+                         callback();
+                       });
                    resolve(bun([stream, logStream]));
                  } catch (err) {
                    logger(
@@ -1240,8 +1243,7 @@ follow these steps, YOUR APP MAY BREAK.`);
             requestStream.write(decoratedChunk, encoding, callback);
           });
 
-          const logStream = through2.obj(function(
-              this: AnyDuringMigration, chunk, enc, callback) {
+          const logStream = through2.obj(function(this, chunk, enc, callback) {
             logger(
                 'Firestore.readWriteStream', requestTag,
                 'Received response: %j', chunk);

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -448,7 +448,7 @@ export class FieldPath extends Path<FieldPath> {
     validate.minNumberOfArguments('FieldPath', arguments, 1);
 
     const elements: string[] = is.array(segments[0]) ?
-        segments[0] as AnyDuringMigration :
+        (segments[0] as unknown) as string[] :
         segments;
 
     for (let i = 0; i < elements.length; ++i) {

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -82,7 +82,7 @@ export class Serializer {
    * @param val The object to encode
    * @returns The Firestore Proto or null if we are deleting a field.
    */
-  encodeValue(val: AnyJs|AnyJs[]|Serializable): api.IValue|null {
+  encodeValue(val: unknown): api.IValue|null {
     if (val instanceof FieldTransform) {
       return null;
     }
@@ -186,7 +186,7 @@ export class Serializer {
    * @param proto A Firestore 'Value' Protobuf.
    * @returns The converted JS type.
    */
-  decodeValue(proto: api.IValue): AnyJs {
+  decodeValue(proto: api.IValue): unknown {
     const valueType = detectValueType(proto);
 
     switch (valueType) {
@@ -212,7 +212,7 @@ export class Serializer {
         return this.createReference(resourcePath.relativeName);
       }
       case 'arrayValue': {
-        const array: AnyJs[] = [];
+        const array: Array<unknown> = [];
         if (is.array(proto.arrayValue!.values)) {
           for (const value of proto.arrayValue!.values!) {
             array.push(this.decodeValue(value));
@@ -259,7 +259,7 @@ export class Serializer {
  * @param input The argument to verify.
  * @returns 'true' if the input can be a treated as a plain object.
  */
-export function isPlainObject(input: UserInput): boolean {
+export function isPlainObject(input: unknown): input is object {
   return (
       typeof input === 'object' && input !== null &&
       (Object.getPrototypeOf(input) === Object.prototype ||

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -273,7 +273,7 @@ export class Transaction {
    */
   update(
       documentRef: DocumentReference, dataOrField: UpdateData|string|FieldPath,
-      ...preconditionOrValues: Array<Precondition|AnyJs|string|FieldPath>):
+      ...preconditionOrValues: Array<Precondition|unknown|string|FieldPath>):
       Transaction {
     this._validator.minNumberOfArguments('update', arguments, 2);
 

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -21,26 +21,11 @@ import {Timestamp} from './timestamp';
 import api = google.firestore.v1beta1;
 
 /**
- * A union of all of the standard JS types, useful for cases where the type is
- * unknown. Unlike "any" this doesn't lose all type-safety, since the consuming
- * code must still cast to a particular type before using it.
+ * A map in the format of the Proto API
  */
-export type AnyJs = null|undefined|boolean|number|string|object;
-
-// tslint:disable-next-line:no-any
-export type AnyDuringMigration = any;
-
-// A map in the format of the Proto API
 export type ApiMapValue = {
   [k: string]: google.firestore.v1beta1.IValue
 };
-
-/**
- * @private
- * JavaScript input from the API layer.
- */
-// tslint:disable-next-line:no-any
-export type UserInput = any;
 
 // tslint:disable-next-line:no-any
 export type GapicClient = any;
@@ -95,7 +80,7 @@ export interface Settings {
  * mapped to values.
  */
 export type DocumentData = {
-  [field: string]: UserInput
+  [field: string]: unknown
 };
 
 /**
@@ -104,8 +89,13 @@ export type DocumentData = {
  * reference nested fields within the document.
  */
 export type UpdateData = {
-  [fieldPath: string]: UserInput
+  [fieldPath: string]: unknown
 };
+
+/**
+ * Update data that has been resolved to a mapping of FieldPaths to values.
+ */
+export type UpdateMap = Map<FieldPath, unknown>;
 
 /**
  * An options object that configures conditional behavior of `update()` and

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -345,14 +345,14 @@ export class WriteBatch {
   update(
       documentRef: DocumentReference, dataOrField: UpdateData|string|FieldPath,
       ...preconditionOrValues:
-          Array<{lastUpdateTime?: Timestamp}|AnyJs|string|FieldPath>):
+          Array<{lastUpdateTime?: Timestamp}|unknown|string|FieldPath>):
       WriteBatch {
     this._validator.minNumberOfArguments('update', arguments, 2);
     this._validator.isDocumentReference('documentRef', documentRef);
 
     this.verifyNotCommitted();
 
-    const updateMap = new Map();
+    const updateMap = new Map<FieldPath, unknown>();
     let precondition = new Precondition({exists: true});
 
     const argumentError = 'Update() requires either a single JavaScript ' +

--- a/dev/test/backoff.ts
+++ b/dev/test/backoff.ts
@@ -26,9 +26,9 @@ describe('ExponentialBackoff', () => {
 
   before(() => {
     setTimeoutHandler(((callback, timeout) => {
-                        observedDelays.push(timeout);
-                        callback();
-                      }) as AnyDuringMigration);
+      observedDelays.push(timeout);
+      callback();
+    }));
   });
 
   beforeEach(() => {

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -251,7 +251,7 @@ describe('serialize document', () => {
   });
 
   it('resolves infinite nesting', () => {
-    const obj: AnyDuringMigration = {};
+    const obj: {foo?: {}} = {};
     obj.foo = obj;
 
     expect(() => {
@@ -282,7 +282,8 @@ describe('serialize document', () => {
       // instances, even if they have cyclic references (we shouldn't try to
       // validate them beyond the instanceof check).
       const ref = firestore.doc('collectionId/documentId');
-      ref.firestore.firestore = firestore;
+      // tslint:disable-next-line:no-any
+      (ref.firestore as any).firestore = firestore;
       return ref.set({ref});
     });
   });

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -25,7 +25,7 @@ import {AnyDuringMigration, GrpcError} from '../src/types';
 
 import {createInstance, document, DOCUMENT_NAME, found, InvalidApiUsage, missing, stream} from './util/helpers';
 
-const {grpc} = new gax.GrpcClient({} as AnyDuringMigration);
+const {grpc} = new gax.GrpcClient({});
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
@@ -215,7 +215,7 @@ const allSupportedTypesInput = {
   timestampValue: Firestore.Timestamp.fromDate(
       new Date('Mar 18, 1985 08:20:00.123 GMT+0100 (CET)')),
   pathValue: new Firestore.DocumentReference(
-      {formattedName: DATABASE_ROOT} as AnyDuringMigration,
+      {formattedName: DATABASE_ROOT} as any,  // tslint:disable-line no-any
       new ResourcePath(PROJECT_ID, '(default)', 'collection', 'document')),
   arrayValue: ['foo', 42, 'bar'],
   emptyArray: [],
@@ -239,7 +239,7 @@ const allSupportedTypesOutput = {
   timestampValue: Firestore.Timestamp.fromDate(
       new Date('Mar 18, 1985 08:20:00.123 GMT+0100 (CET)')),
   pathValue: new Firestore.DocumentReference(
-      {formattedName: DATABASE_ROOT} as AnyDuringMigration,
+      {formattedName: DATABASE_ROOT} as any,  // tslint:disable-line no-any
       new ResourcePath(PROJECT_ID, '(default)', 'collection', 'document')),
   arrayValue: ['foo', 42, 'bar'],
   emptyArray: [],
@@ -307,8 +307,8 @@ describe('instantiation', () => {
 
     expect(() => {
       new Firestore.Firestore(DEFAULT_SETTINGS).settings({
-        timestampsInSnapshots: 1337
-      } as AnyDuringMigration);
+        timestampsInSnapshots: 1337 as InvalidApiUsage
+      });
     })
         .to.throw(
             'Argument "settings.timestampsInSnapshots" is not a valid boolean.');

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -142,7 +142,8 @@ function orderBy(
 
   for (let i = 0; i < fieldPathAndOrderBys.length; i += 2) {
     const fieldPath = fieldPathAndOrderBys[i] as string;
-    const direction: AnyDuringMigration = fieldPathAndOrderBys[i + 1];
+    const direction =
+        fieldPathAndOrderBys[i + 1] as api.StructuredQuery.Direction;
     orderBy.push({
       field: {
         fieldPath,
@@ -553,15 +554,15 @@ describe('query interface', () => {
 
     return createInstance(overrides).then(firestore => {
       const query = firestore.collection('collectionId');
-      return query.get().then((snapshot: AnyDuringMigration) => {
+      return query.get().then(snapshot => {
         expect(() => {
-          snapshot.docChanges.forEach(() => {});
+          (snapshot.docChanges as InvalidApiUsage).forEach(() => {});
         })
             .to.throw(
                 'QuerySnapshot.docChanges has been changed from a property into a method');
 
         expect(() => {
-          for (const doc of snapshot.docChanges) {
+          for (const doc of (snapshot.docChanges as InvalidApiUsage)) {
           }
         })
             .to.throw(

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -27,7 +27,6 @@ import {Firestore} from '../../src';
 import {ClientPool} from '../../src/pool';
 
 /* tslint:disable:no-any */
-type GapicClient = any;
 const grpc = new GrpcClient({} as any).grpc;
 const SSL_CREDENTIALS = (grpc.credentials as any).createInsecure();
 /* tslint:enable:no-any */

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -118,7 +118,7 @@ function snapshot(
     ref: DocumentReference, data: DocumentData): QueryDocumentSnapshot {
   const snapshot = new DocumentSnapshotBuilder();
   snapshot.ref = ref;
-  snapshot.fieldsProto = ref.firestore._serializer.encodeFields(data);
+  snapshot.fieldsProto = ref.firestore._serializer!.encodeFields(data);
   snapshot.readTime = new Firestore.Timestamp(0, 0);
   snapshot.createTime = new Firestore.Timestamp(0, 0);
   snapshot.updateTime = new Firestore.Timestamp(0, 0);


### PR DESCRIPTION
This is part of #512 but can be reviewed independently.

This PR removes all usages of any (or enables selective ones via tslint directive). `any` remains for APIs to return user data to the user, but for APIs that accept user data, `unknown` is used instead.