### PR TITLE
Fix destructuring for getAll

### DIFF
--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -147,8 +147,7 @@ declare namespace FirebaseFirestore {
      * snapshots.
      */
     getAll(
-        documentRef: DocumentReference,
-        ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>
+        ...documentRefs: Array<DocumentReference|ReadOptions>
     ): Promise<DocumentSnapshot[]>;
 
     /**


### PR DESCRIPTION
This is a proposal to fix #501 : it literally restores the previous array-based signature, while keeping support for `ReadOptions`-typed arguments.