### PR TITLE
Cleanup: Remove `is`

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -93,9 +93,9 @@ const convertInput = {
   argument: json => {
     const obj = JSON.parse(json);
     function convertValue(value) {
-      if (is.object(value)) {
+      if (isObject(value)) {
         return convertObject(value);
-      } else if (is.array(value)) {
+      } else if (Array.isArray(value)) {
         return convertArray(value);
       } else if (value === 'NaN') {
         return NaN;

--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -162,7 +162,7 @@ export class DocumentSnapshot {
           if (value instanceof FieldTransform) {
             // If there is already data at this path, we need to retain it.
             // Otherwise, we don't include it in the DocumentSnapshot.
-            return !is.empty(target) ? target : null;
+            return !isEmpty(target) ? target : null;
           }
           // The merge is done.
           const leafNode = serializer.encodeValue(value);
@@ -186,7 +186,7 @@ export class DocumentSnapshot {
             target[key] = childNode;
             return target;
           } else {
-            return !is.empty(target) ? target : null;
+            return !isEmpty(target) ? target : null;
           }
         }
       } else {
@@ -432,7 +432,7 @@ export class DocumentSnapshot {
    * @return {boolean}
    */
   get isEmpty(): boolean {
-    return is.undefined(this._fieldsProto) || is.empty(this._fieldsProto);
+    return this._fieldsProto === undefined || isEmpty(this._fieldsProto);
   }
 
   /**
@@ -760,7 +760,7 @@ export class DocumentMask {
             DocumentMask.removeFromSortedArray(remainingPaths, [childPath]);
             result = result || {};
             result[key] = currentData[key];
-          } else if (is.object(currentData[key])) {
+          } else if (isObject(currentData[key])) {
             const childObject = processObject(currentData[key], childPath);
             if (childObject) {
               result = result || {};
@@ -879,7 +879,7 @@ export class DocumentTransform {
           throw new Error(
               `${val.methodName}() is not supported inside of array values.`);
         }
-      } else if (is.array(val)) {
+      } else if (Array.isArray(val)) {
         for (let i = 0; i < val.length; ++i) {
           // We need to verify that no array value contains a document transform
           encode_(val[i], path.append(String(i)), false);

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -328,7 +328,7 @@ export class Firestore {
     //
     // The environment variable FUNCTION_TRIGGER_TYPE is used to detect the GCF
     // environment.
-    this._preferTransactions = is.defined(process.env.FUNCTION_TRIGGER_TYPE);
+    this._preferTransactions = process.env.FUNCTION_TRIGGER_TYPE !== undefined;
     this._lastSuccessfulRequest = 0;
 
     if (this._preferTransactions) {
@@ -502,7 +502,7 @@ export class Firestore {
     let convertTimestamp;
     let convertDocument;
 
-    if (!is.defined(encoding) || encoding === 'protobufJS') {
+    if (encoding === undefined || encoding === 'protobufJS') {
       convertTimestamp = data => data;
       convertDocument = data => data;
     } else if (encoding === 'json') {
@@ -798,7 +798,7 @@ export class Firestore {
                   const orderedDocuments: DocumentSnapshot[] = [];
                   for (const docRef of docRefs) {
                     const document = retrievedDocuments.get(docRef.path);
-                    if (!is.defined(document)) {
+                    if (document === undefined) {
                       reject(new Error(
                           `Did not receive document for "${docRef.path}".`));
                     }
@@ -969,7 +969,7 @@ follow these steps, YOUR APP MAY BREAK.`);
           return result;
         })
         .catch(err => {
-          if (is.defined(err.code) && err.code !== GRPC_UNAVAILABLE) {
+          if (err.code !== undefined && err.code !== GRPC_UNAVAILABLE) {
             logger(
                 'Firestore._retry', requestTag,
                 'Request failed with unrecoverable error:', err);

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -447,8 +447,8 @@ export class FieldPath extends Path<FieldPath> {
   constructor(...segments: string[]) {
     validate.minNumberOfArguments('FieldPath', arguments, 1);
 
-    const elements: string[] = is.array(segments[0]) ?
-        segments[0] as AnyDuringMigration :
+    const elements: string[] = Array.isArray(segments[0]) ?
+        (segments[0] as unknown) as string[] :
         segments;
 
     for (let i = 0; i < elements.length; ++i) {

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -87,7 +87,7 @@ export class Serializer {
       return null;
     }
 
-    if (is.string(val)) {
+    if (typeof val === 'string') {
       return {
         stringValue: val as string,
       };
@@ -99,20 +99,20 @@ export class Serializer {
       };
     }
 
-    if (typeof val === 'number' && is.integer(val)) {
+    if (typeof val === 'number' && !isNaN(val) && val % 1 === 0) {
       return {
         integerValue: val as number,
       };
     }
 
     // Integers are handled above, the remaining numbers are treated as doubles
-    if (is.number(val)) {
+    if (typeof val === 'number') {
       return {
         doubleValue: val as number,
       };
     }
 
-    if (is.date(val)) {
+    if (val instanceof Date) {
       const timestamp = Timestamp.fromDate(val as Date);
       return {
         timestampValue: {
@@ -136,9 +136,9 @@ export class Serializer {
     }
 
 
-    if (typeof val === 'object' && 'toProto' in val &&
-        typeof val.toProto === 'function') {
-      return val.toProto();
+    if (isObject(val) && 'toProto' in val &&
+        typeof (val as Serializable).toProto === 'function') {
+      return (val as Serializable).toProto();
     }
 
     if (val instanceof Array) {
@@ -166,9 +166,9 @@ export class Serializer {
 
       // If we encounter an empty object, we always need to send it to make sure
       // the server creates a map entry.
-      if (!is.empty(val)) {
+      if (!isEmpty(val)) {
         map.mapValue!.fields = this.encodeFields(val);
-        if (is.empty(map.mapValue!.fields)) {
+        if (isEmpty(map.mapValue!.fields)) {
           return null;
         }
       }
@@ -212,8 +212,8 @@ export class Serializer {
         return this.createReference(resourcePath.relativeName);
       }
       case 'arrayValue': {
-        const array: AnyJs[] = [];
-        if (is.array(proto.arrayValue!.values)) {
+        const array: unknown[] = [];
+        if (Array.isArray(proto.arrayValue!.values)) {
           for (const value of proto.arrayValue!.values!) {
             array.push(this.decodeValue(value));
           }

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -71,8 +71,8 @@ describe('timestamps', () => {
                {timestampsInSnapshots: false}, DOCUMENT_WITH_TIMESTAMP)
         .then(firestore => {
           return firestore.doc('collectionId/documentId').get().then(res => {
-            expect(is.date(res.data()!['moonLanding'])).to.be.true;
-            expect(is.date(res.get('moonLanding'))).to.be.true;
+            expect(res.data()!['moonLanding']).to.be.instanceOf(Date);
+            expect(res.get('moonLanding')).to.be.instanceOf(Date);
             console.error = oldErrorLog;
           });
         });

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "extend": "^3.0.1",
     "functional-red-black-tree": "^1.0.1",
     "google-gax": "^0.22.0",
-    "is": "^3.2.1",
     "lodash.merge": "^4.6.1",
     "protobufjs": "^6.8.6",
     "through2": "^3.0.0"
@@ -64,7 +63,6 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/duplexify": "^3.5.0",
     "@types/extend": "^3.0.0",
-    "@types/is": "0.0.21",
     "@types/mocha": "^5.2.3",
     "@types/node": "^10.3.5",
     "@types/through2": "^2.0.34",


### PR DESCRIPTION
This is part of #512 but can be reviewed independently.

This PR removes the dependency on `is` and moves all checks into the SDK itself. While `is` is nice library, it doesn't quite work with TypeScript type inference.