### PR TITLE
Cleanup: Misc

### DIFF
--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -114,8 +114,7 @@ export class DocumentSnapshot {
       createTime?: Timestamp, updateTime?: Timestamp) {
     this._ref = ref;
     this._fieldsProto = fieldsProto;
-    this._serializer = ref.firestore._serializer;
-    this._validator = ref.firestore._validator;
+    this._serializer = ref.firestore._serializer!;
     this._readTime = readTime;
     this._createTime = createTime;
     this._updateTime = updateTime;
@@ -130,7 +129,7 @@ export class DocumentSnapshot {
    * @return The created DocumentSnapshot.
    */
   static fromObject(ref: DocumentReference, obj: {}): DocumentSnapshot {
-    const serializer = ref.firestore._serializer;
+    const serializer = ref.firestore._serializer!;
     return new DocumentSnapshot(ref, serializer.encodeFields(obj));
   }
   /**
@@ -146,7 +145,7 @@ export class DocumentSnapshot {
    */
   static fromUpdateMap(ref: DocumentReference, data: UpdateData):
       DocumentSnapshot {
-    const serializer = ref.firestore._serializer;
+    const serializer = ref.firestore._serializer!;
 
     /**
      * Merges 'value' at the field path specified by the path array into
@@ -921,7 +920,7 @@ export class DocumentTransform {
 
   /** Validates the user provided field values in this document transform. */
   validate(): void {
-    this._transforms.forEach(transform => transform.validate(this._validator));
+    this._transforms.forEach(transform => transform.validate());
   }
 
   /**

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -103,11 +103,6 @@ const MAX_CONCURRENT_REQUESTS_PER_CLIENT = 100;
  */
 const GRPC_UNAVAILABLE = 14;
 
-/*!
- * The maximum depth of a Firestore object.
- */
-const MAX_DEPTH = 20;
-
 /**
  * Document data (e.g. for use with
  * [set()]{@link DocumentReference#set}) consisting of fields mapped
@@ -1160,8 +1155,8 @@ follow these steps, YOUR APP MAY BREAK.`);
    * takes a request and GAX options.
    * @param request The Protobuf request to send.
    * @param requestTag A unique client-assigned identifier for this request.
-   * @param {boolean} allowRetries Whether this is an idempotent request that
-   * can be retried.
+   * @param allowRetries Whether this is an idempotent request that can be
+   * retried.
    * @returns A Promise with the resulting read-only stream.
    */
   readStream(

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -68,7 +68,7 @@ function typeOrder(val: api.IValue): TypeOrder {
     case 'mapValue':
       return TypeOrder.OBJECT;
     default:
-      throw customObjectError(val);
+      throw new Error('Unexpected value type: ' + valueType);
   }
 }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -196,7 +196,7 @@ export class DocumentReference {
    * }):
    */
   get parent(): CollectionReference {
-    return createCollectionReference(this._firestore, this._path.parent());
+    return new CollectionReference(this._firestore, this._path.parent());
   }
 
   /**
@@ -242,7 +242,7 @@ export class DocumentReference {
           collectionPath}". Your path does not contain an odd number of components.`);
     }
 
-    return createCollectionReference(this._firestore, path);
+    return new CollectionReference(this._firestore, path);
   }
 
   /**
@@ -1941,17 +1941,6 @@ export class CollectionReference extends Query {
         this === other ||
         (other instanceof CollectionReference && super.isEqual(other)));
   }
-}
-/*!
- * Creates a new CollectionReference. Invoked by DocumentReference to avoid
- * invalid declaration order.
- *
- * @param {Firestore} firestore The Firestore Database client.
- * @param {ResourcePath} path The path of this collection.
- * @returns {CollectionReference}
- */
-function createCollectionReference(firestore, path): CollectionReference {
-  return new CollectionReference(firestore, path);
 }
 
 /*!

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -176,7 +176,7 @@ export class Serializer {
       return map;
     }
 
-    throw customObjectError(val);
+    throw new Error(`Cannot encode value: ${val}`);
   }
 
   /**
@@ -261,7 +261,6 @@ export class Serializer {
  */
 export function isPlainObject(input: UserInput): boolean {
   return (
-      typeof input === 'object' && input !== null &&
-      (Object.getPrototypeOf(input) === Object.prototype ||
+      isObject(input) && (Object.getPrototypeOf(input) === Object.prototype ||
        Object.getPrototypeOf(input) === null));
 }

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -277,7 +277,6 @@ export class Transaction {
       Transaction {
     this._validator.minNumberOfArguments('update', arguments, 2);
 
-    preconditionOrValues = Array.prototype.slice.call(arguments, 2);
     this._writeBatch.update.apply(this._writeBatch, [
       documentRef, dataOrField
     ].concat(preconditionOrValues) as [DocumentReference, string]);

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -258,7 +258,7 @@ describe('serialize document', () => {
       firestore.doc('collectionId/documentId').update(obj);
     })
         .to.throw(
-            'Argument "dataOrField" is not a valid Document. Input object is deeper than 20 levels or contains a cycle.');
+            'Argument "dataOrField" is not a valid Firestore document. Input object is deeper than 20 levels or contains a cycle.');
   });
 
   it('is able to write a document reference with cycles', () => {

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -71,7 +71,7 @@ describe('Order', () => {
       order.compare(
           {valueType: 'foo'} as InvalidApiUsage,
           {valueType: 'foo'} as InvalidApiUsage);
-    }).to.throw('Invalid use of type "object" as a Firestore argument.');
+    }).to.throw('Unexpected value type: foo');
   });
 
   it('throws on invalid blob', () => {

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -277,7 +277,7 @@ class StreamHelper {
       err = new Error('Server disconnect');
       err.code = 14;  // Unavailable
     }
-    (this.readStream as AnyDuringMigration).destroy(err);
+    (this.readStream as any).destroy(err);  // tslint:disable-line no-any
   }
 }
 


### PR DESCRIPTION
This is part of #512  but can be reviewed independently.

This is the random cleanup for all unrelated changes. Note: `serializer` is now types as `Serializer|null` since `Firestore` is no longer `any`.