### PR TITLE
Cleanup: Enum validation

### DIFF
--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -108,6 +108,18 @@ export type UpdateData = {
 };
 
 /**
+ * The direction of a `Query.orderBy()` clause is specified as 'desc' or 'asc'
+ * (descending or ascending).
+ */
+export type OrderByDirection = 'desc'|'asc';
+
+/**
+ * Filter conditions in a `Query.where()` clause are specified using the
+ * strings '<', '<=', '==', '>=', '>', and 'array-contains'.
+ */
+export type WhereFilterOp = '<'|'<='|'=='|'>='|'>'|'array-contains';
+
+/**
  * An options object that configures conditional behavior of `update()` and
  * `delete()` calls in `DocumentReference`, `WriteBatch`, and `Transaction`.
  * Using Preconditions, these calls can be restricted to only apply to

--- a/dev/src/validate.ts
+++ b/dev/src/validate.ts
@@ -205,3 +205,31 @@ export function createValidator(customValidators?: Validators):
   // consumers can call the custom validator functions.
   return new Validator(customValidators);
 }
+
+/**
+ * Validates that the provided named option equals one of the expected values.
+ *
+ * @param arg The argument name or argument index (for varargs methods).).
+ * @param value The input to validate.
+ * @param allowedValues A list of expected values.
+ * @param options Whether the input can be omitted.
+ * @private
+ */
+export function validateEnumValue(
+    arg: string|number, value: unknown, allowedValues: string[],
+    options?: AllowOptional): void {
+  if (!validateOptional(value, options)) {
+    const expectedDescription: string[] = [];
+
+    for (const allowed of allowedValues) {
+      if (allowed === value) {
+        return;
+      }
+      expectedDescription.push(allowed);
+    }
+
+    throw new Error(`Invalid value for argument ${
+        formatArgumentName(
+            arg)}. Acceptable values are: ${expectedDescription.join(', ')}`);
+  }
+}

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -277,14 +277,13 @@ describe('query interface', () => {
     };
 
     queryEquals(
-        [query.where('a', '=', '1'), query.where('a', '=', '1')],
-        [query.where('a', '=', 1)]);
+        [query.where('a', '==', '1'), query.where('a', '==', '1')],
+        [query.where('a', '==', 1)]);
 
     queryEquals(
         [
           query.orderBy('__name__'),
           query.orderBy('__name__', 'asc'),
-          query.orderBy('__name__', 'ASC'),
           query.orderBy(Firestore.FieldPath.documentId()),
         ],
         [
@@ -355,7 +354,7 @@ describe('query interface', () => {
 
     return createInstance(overrides).then(firestore => {
       let query: Query = firestore.collection('collectionId');
-      query = query.where('foo', '=', 'bar');
+      query = query.where('foo', '==', 'bar');
       query = query.orderBy('foo');
       query = query.limit(10);
       return query.get().then(results => {
@@ -603,10 +602,10 @@ describe('where() interface', () => {
             fieldFilters(
                 'fooSmaller', 'LESS_THAN', 'barSmaller', 'fooSmallerOrEquals',
                 'LESS_THAN_OR_EQUAL', 'barSmallerOrEquals', 'fooEquals',
-                'EQUAL', 'barEquals', 'fooEqualsLong', 'EQUAL', 'barEqualsLong',
-                'fooGreaterOrEquals', 'GREATER_THAN_OR_EQUAL',
-                'barGreaterOrEquals', 'fooGreater', 'GREATER_THAN',
-                'barGreater', 'fooContains', 'ARRAY_CONTAINS', 'barContains'));
+                'EQUAL', 'barEquals', 'fooGreaterOrEquals',
+                'GREATER_THAN_OR_EQUAL', 'barGreaterOrEquals', 'fooGreater',
+                'GREATER_THAN', 'barGreater', 'fooContains', 'ARRAY_CONTAINS',
+                'barContains'));
 
         return stream();
       }
@@ -616,8 +615,7 @@ describe('where() interface', () => {
       let query: Query = firestore.collection('collectionId');
       query = query.where('fooSmaller', '<', 'barSmaller');
       query = query.where('fooSmallerOrEquals', '<=', 'barSmallerOrEquals');
-      query = query.where('fooEquals', '=', 'barEquals');
-      query = query.where('fooEqualsLong', '==', 'barEqualsLong');
+      query = query.where('fooEquals', '==', 'barEquals');
       query = query.where('fooGreaterOrEquals', '>=', 'barGreaterOrEquals');
       query = query.where('fooGreater', '>', 'barGreater');
       query = query.where('fooContains', 'array-contains', 'barContains');
@@ -642,7 +640,7 @@ describe('where() interface', () => {
 
     return createInstance(overrides).then(firestore => {
       let query: Query = firestore.collection('collectionId');
-      query = query.where('foo', '=', {foo: 'bar'});
+      query = query.where('foo', '==', {foo: 'bar'});
       return query.get();
     });
   });
@@ -660,8 +658,9 @@ describe('where() interface', () => {
 
     return createInstance(overrides).then(firestore => {
       let query: Query = firestore.collection('collectionId');
-      query = query.where('foo.bar', '=', 'foobar');
-      query = query.where(new Firestore.FieldPath('bar', 'foo'), '=', 'foobar');
+      query = query.where('foo.bar', '==', 'foobar');
+      query =
+          query.where(new Firestore.FieldPath('bar', 'foo'), '==', 'foobar');
       return query.get();
     });
   });
@@ -689,7 +688,7 @@ describe('where() interface', () => {
   it('rejects custom objects for field paths', () => {
     expect(() => {
       let query: Query = firestore.collection('collectionId');
-      query = query.where({} as InvalidApiUsage, '=', 'bar');
+      query = query.where({} as InvalidApiUsage, '==', 'bar');
       return query.get();
     })
         .to.throw(
@@ -698,7 +697,7 @@ describe('where() interface', () => {
     class FieldPath {}
     expect(() => {
       let query: Query = firestore.collection('collectionId');
-      query = query.where(new FieldPath() as InvalidApiUsage, '=', 'bar');
+      query = query.where(new FieldPath() as InvalidApiUsage, '==', 'bar');
       return query.get();
     })
         .to.throw(
@@ -708,7 +707,7 @@ describe('where() interface', () => {
   it('rejects field paths as value', () => {
     expect(() => {
       let query: Query = firestore.collection('collectionId');
-      query = query.where('foo', '=', new Firestore.FieldPath('bar'));
+      query = query.where('foo', '==', new Firestore.FieldPath('bar'));
       return query.get();
     })
         .to.throw(
@@ -718,7 +717,7 @@ describe('where() interface', () => {
   it('rejects field delete as value', () => {
     expect(() => {
       let query = firestore.collection('collectionId');
-      query = query.where('foo', '=', Firestore.FieldValue.delete());
+      query = query.where('foo', '==', Firestore.FieldValue.delete());
       return query.get();
     })
         .to.throw(
@@ -735,31 +734,31 @@ describe('where() interface', () => {
     const query = firestore.collection('collectionId');
 
     expect(() => {
-      query.where('foo', '=', new Foo()).get();
+      query.where('foo', '==', new Foo()).get();
     })
         .to.throw(
             'Argument "value" is not a valid QueryValue. Couldn\'t serialize object of type "Foo". Firestore doesn\'t support JavaScript objects with custom prototypes (i.e. objects that were created via the "new" operator).');
 
     expect(() => {
-      query.where('foo', '=', new FieldPath()).get();
+      query.where('foo', '==', new FieldPath()).get();
     })
         .to.throw(
             'Detected an object of type "FieldPath" that doesn\'t match the expected instance.');
 
     expect(() => {
-      query.where('foo', '=', new FieldValue()).get();
+      query.where('foo', '==', new FieldValue()).get();
     })
         .to.throw(
             'Detected an object of type "FieldValue" that doesn\'t match the expected instance.');
 
     expect(() => {
-      query.where('foo', '=', new DocumentReference()).get();
+      query.where('foo', '==', new DocumentReference()).get();
     })
         .to.throw(
             'Detected an object of type "DocumentReference" that doesn\'t match the expected instance.');
 
     expect(() => {
-      query.where('foo', '=', new GeoPoint()).get();
+      query.where('foo', '==', new GeoPoint()).get();
     })
         .to.throw(
             'Detected an object of type "GeoPoint" that doesn\'t match the expected instance.');
@@ -777,7 +776,7 @@ describe('where() interface', () => {
     return createInstance(overrides).then(firestore => {
       let query: Query = firestore.collection('collectionId');
       query = query.where('foo', '==', NaN);
-      query = query.where('bar', '=', null);
+      query = query.where('bar', '==', null);
       return query.get();
     });
   });
@@ -805,7 +804,7 @@ describe('where() interface', () => {
   it('verifies field path', () => {
     let query: Query = firestore.collection('collectionId');
     expect(() => {
-      query = query.where('foo.', '=', 'foobar');
+      query = query.where('foo.', '==', 'foobar');
     })
         .to.throw(
             'Argument "fieldPath" is not a valid FieldPath. Paths must not start or end with ".".');
@@ -814,10 +813,10 @@ describe('where() interface', () => {
   it('verifies operator', () => {
     let query = firestore.collection('collectionId');
     expect(() => {
-      query = query.where('foo', '@', 'foobar');
+      query = query.where('foo', '@' as InvalidApiUsage, 'foobar');
     })
         .to.throw(
-            'Operator must be one of "<", "<=", "==", ">", ">=" or "array-contains".');
+            'Invalid value for argument "opStr". Acceptable values are: <, <=, ==, >, >=, array-contains');
   });
 });
 
@@ -881,8 +880,10 @@ describe('orderBy() interface', () => {
   it('verifies order', () => {
     let query: Query = firestore.collection('collectionId');
     expect(() => {
-      query = query.orderBy('foo', 'foo');
-    }).to.throw('Order must be one of "asc" or "desc".');
+      query = query.orderBy('foo', 'foo' as InvalidApiUsage);
+    })
+        .to.throw(
+            'Invalid value for argument "directionStr". Acceptable values are: asc, desc');
   });
 
   it('accepts field path', () => {
@@ -1347,10 +1348,10 @@ describe('startAt() interface', () => {
     return createInstance(overrides).then(firestore => {
       return snapshot('collectionId/doc', {c: 'c'}).then(doc => {
         const query = firestore.collection('collectionId')
-                          .where('a', '=', 'a')
+                          .where('a', '==', 'a')
                           .where('b', 'array-contains', 'b')
                           .where('c', '>=', 'c')
-                          .where('d', '=', 'd')
+                          .where('d', '==', 'd')
                           .startAt(doc);
         return query.get();
       });
@@ -1374,7 +1375,7 @@ describe('startAt() interface', () => {
     return createInstance(overrides).then(firestore => {
       return snapshot('collectionId/doc', {foo: 'bar'}).then(doc => {
         const query = firestore.collection('collectionId')
-                          .where('foo', '=', 'bar')
+                          .where('foo', '==', 'bar')
                           .startAt(doc);
         return query.get();
       });


### PR DESCRIPTION
This is part of #512 but can be reviewed independently.

This moves the validation of acceptable "enum" values in the Query API into the shared validation.ts file. To do this, I used the validation code from the Web SDK. As this code prints the acceptable value in the error message, I removed support for non-documented API shorthands such as `=` (instead of `==`).
