### PR TITLE
Overload getAll function to allow array destructuring

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -703,6 +703,8 @@ export class Firestore {
    *   console.log(`Second document: ${JSON.stringify(docs[1])}`);
    * });
    */
+  getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
+      Promise<DocumentSnapshot[]>;
   getAll(
       documentRef: DocumentReference,
       ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -703,16 +703,13 @@ export class Firestore {
    *   console.log(`Second document: ${JSON.stringify(docs[1])}`);
    * });
    */
-  getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
-      Promise<DocumentSnapshot[]>;
-  getAll(
-      documentRef: DocumentReference,
-      ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
-      Promise<DocumentSnapshot[]> {
+  getAll(...documentRefsOrReadOptions: [
+    DocumentReference, ...Array<DocumentReference|ReadOptions>
+  ]): Promise<DocumentSnapshot[]> {
     this._validator.minNumberOfArguments('Firestore.getAll', arguments, 1);
 
-    const {documents, fieldMask} = parseGetAllArguments(
-        this._validator, [documentRef, ...moreDocumentRefsOrReadOptions]);
+    const {documents, fieldMask} =
+        parseGetAllArguments(this._validator, [...documentRefsOrReadOptions]);
     return this.getAll_(documents, fieldMask, requestTag());
   }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -703,13 +703,12 @@ export class Firestore {
    *   console.log(`Second document: ${JSON.stringify(docs[1])}`);
    * });
    */
-  getAll(...documentRefsOrReadOptions: [
-    DocumentReference, ...Array<DocumentReference|ReadOptions>
-  ]): Promise<DocumentSnapshot[]> {
+  getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
+      Promise<DocumentSnapshot[]> {
     this._validator.minNumberOfArguments('Firestore.getAll', arguments, 1);
 
     const {documents, fieldMask} =
-        parseGetAllArguments(this._validator, [...documentRefsOrReadOptions]);
+        parseGetAllArguments(this._validator, documentRefsOrReadOptions);
     return this.getAll_(documents, fieldMask, requestTag());
   }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -687,9 +687,12 @@ export class Firestore {
   /**
    * Retrieves multiple documents from Firestore.
    *
-   * @param {DocumentReference} documentRef A `DocumentReference` to receive.
-   * @param {Array.<DocumentReference|ReadOptions>} moreDocumentRefsOrReadOptions
-   * Additional `DocumentReferences` to receive, followed by an optional field
+   * The first argument is required and must be of type `DocumentReference`
+   * followed by any additional `DocumentReference` documents. If used, the
+   * optional `ReadOptions` must be the last argument.
+   *
+   * @param {Array.<DocumentReference|ReadOptions>} documentRefsOrReadOptions
+   * The `DocumentReferences` to receive, followed by an optional field
    * mask.
    * @returns {Promise<Array.<DocumentSnapshot>>} A Promise that
    * contains an array with the resulting document snapshots.

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -157,6 +157,8 @@ export class Transaction {
    *   });
    * });
    */
+  getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
+      Promise<DocumentSnapshot[]>;
   getAll(
       documentRef: DocumentReference,
       ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -157,20 +157,17 @@ export class Transaction {
    *   });
    * });
    */
-  getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
-      Promise<DocumentSnapshot[]>;
-  getAll(
-      documentRef: DocumentReference,
-      ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
-      Promise<DocumentSnapshot[]> {
+  getAll(...documentRefsOrReadOptions: [
+    DocumentReference, ...Array<DocumentReference|ReadOptions>
+  ]): Promise<DocumentSnapshot[]> {
     if (!this._writeBatch.isEmpty) {
       throw new Error(READ_AFTER_WRITE_ERROR_MSG);
     }
 
     this._validator.minNumberOfArguments('Transaction.getAll', arguments, 1);
 
-    const {documents, fieldMask} = parseGetAllArguments(
-        this._validator, [documentRef, ...moreDocumentRefsOrReadOptions]);
+    const {documents, fieldMask} =
+        parseGetAllArguments(this._validator, [...documentRefsOrReadOptions]);
 
     return this._firestore.getAll_(
         documents, fieldMask, this._requestTag, this._transactionId);

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -157,9 +157,8 @@ export class Transaction {
    *   });
    * });
    */
-  getAll(...documentRefsOrReadOptions: [
-    DocumentReference, ...Array<DocumentReference|ReadOptions>
-  ]): Promise<DocumentSnapshot[]> {
+  getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>):
+      Promise<DocumentSnapshot[]> {
     if (!this._writeBatch.isEmpty) {
       throw new Error(READ_AFTER_WRITE_ERROR_MSG);
     }
@@ -167,7 +166,7 @@ export class Transaction {
     this._validator.minNumberOfArguments('Transaction.getAll', arguments, 1);
 
     const {documents, fieldMask} =
-        parseGetAllArguments(this._validator, [...documentRefsOrReadOptions]);
+        parseGetAllArguments(this._validator, documentRefsOrReadOptions);
 
     return this._firestore.getAll_(
         documents, fieldMask, this._requestTag, this._transactionId);

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -137,9 +137,12 @@ export class Transaction {
    * Retrieves multiple documents from Firestore. Holds a pessimistic lock on
    * all returned documents.
    *
-   * @param {DocumentReference} documentRef A `DocumentReference` to receive.
-   * @param {Array.<DocumentReference|ReadOptions>} moreDocumentRefsOrReadOptions
-   * Additional `DocumentReferences` to receive, followed by an optional field
+   * The first argument is required and must be of type `DocumentReference`
+   * followed by any additional `DocumentReference` documents. If used, the
+   * optional `ReadOptions` must be the last argument.
+   *
+   * @param {Array.<DocumentReference|ReadOptions>} documentRefsOrReadOptions
+   * The `DocumentReferences` to receive, followed by an optional field
    * mask.
    * @returns {Promise<Array.<DocumentSnapshot>>} A Promise that
    * contains an array with the resulting document snapshots.

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -77,6 +77,18 @@ describe('Firestore class', () => {
         });
   });
 
+  it('getAll() supports array destructuring', () => {
+    const ref1 = randomCol.doc('doc1');
+    const ref2 = randomCol.doc('doc2');
+    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'a'})])
+        .then(() => {
+          return firestore.getAll(...[ref1, ref2]);
+        })
+        .then(docs => {
+          expect(docs.length).to.equal(2);
+        });
+  });
+
   it('getAll() supports field mask', () => {
     const ref1 = randomCol.doc('doc1');
     return ref1.set({foo: 'a', bar: 'b'})
@@ -85,6 +97,19 @@ describe('Firestore class', () => {
         })
         .then(docs => {
           expect(docs[0].data()).to.deep.equal({foo: 'a'});
+        });
+  });
+
+  it('getAll() supports array destructuring with field mask', () => {
+    const ref1 = randomCol.doc('doc1');
+    const ref2 = randomCol.doc('doc2');
+    return Promise.all([ref1.set({f: 'a', b: 'b'}), ref2.set({f: 'a', b: 'b'})])
+        .then(() => {
+          return firestore.getAll(...[ref1, ref2], {fieldMask: ['f']});
+        })
+        .then(docs => {
+          expect(docs[0].data()).to.deep.equal({f: 'a'});
+          expect(docs[1].data()).to.deep.equal({f: 'a'});
         });
   });
 });
@@ -1383,6 +1408,22 @@ describe('Transaction class', () => {
         });
   });
 
+  it('getAll() supports array destructuring', () => {
+    const ref1 = randomCol.doc('doc1');
+    const ref2 = randomCol.doc('doc2');
+    return Promise.all([ref1.set({}), ref2.set({})])
+        .then(() => {
+          return firestore.runTransaction(updateFunction => {
+            return updateFunction.getAll(...[ref1, ref2]).then(docs => {
+              return Promise.resolve(docs.length);
+            });
+          });
+        })
+        .then(res => {
+          expect(res).to.equal(2);
+        });
+  });
+
   it('getAll() supports field mask', () => {
     const ref1 = randomCol.doc('doc1');
     return ref1.set({foo: 'a', bar: 'b'}).then(() => {
@@ -1395,6 +1436,24 @@ describe('Transaction class', () => {
             expect(doc.data()).to.deep.equal({foo: 'a'});
           });
     });
+  });
+
+  it('getAll() supports array destructuring with field mask', () => {
+    const ref1 = randomCol.doc('doc1');
+    const ref2 = randomCol.doc('doc2');
+    return Promise.all([ref1.set({f: 'a', b: 'b'}), ref2.set({f: 'a', b: 'b'})])
+        .then(() => {
+          return firestore.runTransaction(updateFunction => {
+            return updateFunction.getAll(...[ref1, ref2], {fieldMask: ['f']})
+                .then(docs => {
+                  expect(docs[0].data()).to.deep.equal({f: 'a'});
+                  expect(docs[1].data()).to.deep.equal({f: 'a'});
+                });
+          });
+        })
+        .then(res => {
+          expect(res).to.equal(2);
+        });
   });
 
   it('has get() with query', () => {

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -1443,16 +1443,16 @@ describe('Transaction class', () => {
     const ref2 = randomCol.doc('doc2');
     return Promise.all([ref1.set({f: 'a', b: 'b'}), ref2.set({f: 'a', b: 'b'})])
         .then(() => {
-          return firestore.runTransaction(updateFunction => {
-            return updateFunction.getAll(...[ref1, ref2], {fieldMask: ['f']})
-                .then(docs => {
-                  expect(docs[0].data()).to.deep.equal({f: 'a'});
-                  expect(docs[1].data()).to.deep.equal({f: 'a'});
-                });
-          });
-        })
-        .then(res => {
-          expect(res).to.equal(2);
+          return firestore
+              .runTransaction(updateFunction => {
+                return updateFunction
+                    .getAll(...[ref1, ref2], {fieldMask: ['f']})
+                    .then((docs) => docs);
+              })
+              .then(docs => {
+                expect(docs[0].data()).to.deep.equal({f: 'a'});
+                expect(docs[1].data()).to.deep.equal({f: 'a'});
+              });
         });
   });
 

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -146,10 +146,8 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll(
-      ...documentRefsOrReadOptions: [
-        DocumentReference, ...Array<DocumentReference|ReadOptions>
-    ]): Promise<DocumentSnapshot[]>;
+    getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>): 
+        Promise<DocumentSnapshot[]>;
 
     /**
      * Fetches the root collections that are associated with this Firestore
@@ -266,10 +264,8 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll(
-      ...documentRefsOrReadOptions: [
-        DocumentReference, ...Array<DocumentReference|ReadOptions>
-    ]): Promise<DocumentSnapshot[]>;
+    getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>): 
+        Promise<DocumentSnapshot[]>;
 
     /**
      * Create the document referred to by the provided `DocumentReference`.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -139,10 +139,14 @@ declare namespace FirebaseFirestore {
 
     /**
      * Retrieves multiple documents from Firestore.
-     *
-     * @param documentRef A `DocumentReference` to receive.
-     * @param moreDocumentRefsOrReadOptions Additional `DocumentReferences` to
-     * receive, followed by an optional field mask.
+    *
+    * The first argument is required and must be of type `DocumentReference`
+    * followed by any additional `DocumentReference` documents. If used, the 
+    * optional `ReadOptions` must be the last argument.
+    * 
+    * @param {Array.<DocumentReference|ReadOptions>} documentRefsOrReadOptions
+    * The `DocumentReferences` to receive, followed by an optional field
+    * mask.
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
@@ -258,9 +262,13 @@ declare namespace FirebaseFirestore {
      * Retrieves multiple documents from Firestore. Holds a pessimistic lock on
      * all returned documents.
      *
-     * @param documentRef A `DocumentReference` to receive.
-     * @param moreDocumentRefsOrReadOptions Additional `DocumentReferences` to
-     * receive, followed by an optional field mask.
+     * The first argument is required and must be of type `DocumentReference`
+     * followed by any additional `DocumentReference` documents. If used, the 
+     * optional `ReadOptions` must be the last argument.
+     * 
+     * @param {Array.<DocumentReference|ReadOptions>} documentRefsOrReadOptions
+     * The `DocumentReferences` to receive, followed by an optional field
+     * mask.
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -146,12 +146,10 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>): 
-        Promise<DocumentSnapshot[]>;
     getAll(
-        documentRef: DocumentReference,
-        ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>
-    ): Promise<DocumentSnapshot[]>;
+      ...documentRefsOrReadOptions: [
+        DocumentReference, ...Array<DocumentReference|ReadOptions>
+    ]): Promise<DocumentSnapshot[]>;
 
     /**
      * Fetches the root collections that are associated with this Firestore
@@ -268,12 +266,10 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>): 
-        Promise<DocumentSnapshot[]>;
     getAll(
-        documentRef: DocumentReference,
-        ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>
-    ): Promise<DocumentSnapshot[]>;
+      ...documentRefsOrReadOptions: [
+        DocumentReference, ...Array<DocumentReference|ReadOptions>
+    ]): Promise<DocumentSnapshot[]>;
 
     /**
      * Create the document referred to by the provided `DocumentReference`.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -139,14 +139,14 @@ declare namespace FirebaseFirestore {
 
     /**
      * Retrieves multiple documents from Firestore.
-    *
-    * The first argument is required and must be of type `DocumentReference`
-    * followed by any additional `DocumentReference` documents. If used, the 
-    * optional `ReadOptions` must be the last argument.
-    * 
-    * @param {Array.<DocumentReference|ReadOptions>} documentRefsOrReadOptions
-    * The `DocumentReferences` to receive, followed by an optional field
-    * mask.
+     *
+     * The first argument is required and must be of type `DocumentReference`
+     * followed by any additional `DocumentReference` documents. If used, the 
+     * optional `ReadOptions` must be the last argument.
+     * 
+     * @param {Array.<DocumentReference|ReadOptions>} documentRefsOrReadOptions
+     * The `DocumentReferences` to receive, followed by an optional field
+     * mask.
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -146,6 +146,8 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
+    getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>): 
+        Promise<DocumentSnapshot[]>;
     getAll(
         documentRef: DocumentReference,
         ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>
@@ -266,6 +268,8 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
+    getAll(...documentRefsOrReadOptions: Array<DocumentReference|ReadOptions>): 
+        Promise<DocumentSnapshot[]>;
     getAll(
         documentRef: DocumentReference,
         ...moreDocumentRefsOrReadOptions: Array<DocumentReference|ReadOptions>


### PR DESCRIPTION
Fixes #501

This PR overloads the getAll function in Firestore and Transaction class to allow passing in a destructured array of documents.

- [x] Tests and linter pass
- [x] Code coverage does not decrease
- [x] Appropriate docs were updated
