### PR TITLE
Add note about Datastore mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The Cloud Firestore Server SDKs are designed to manage the full set of data in y
 
 Applications that use Google&#x27;s Server SDKs should not be used in end-user environments, such as on phones or on publicly hosted websites. If you are developing a Web or Node.js application that accesses Cloud Firestore on behalf of end users, use the firebase Client SDK.
 
+**Note:** This Cloud Firestore Server SDK does not support Firestore databases created in [Datastore mode](https://cloud.google.com/datastore/docs/firestore-or-datastore#in_datastore_mode). To access these databases, use the [Datastore SDK](https://www.npmjs.com/package/@google-cloud/datastore).
+
 
 * [Using the client library](#using-the-client-library)
 * [Versioning](#versioning)


### PR DESCRIPTION
This adds a section to the Readme advising that this client can't be used with Firestore instances in Datastore mode.

Fixes https://github.com/googleapis/nodejs-firestore/issues/459