### PR TITLE
refactor(typescript): enable noImplicitAny

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -109,13 +109,13 @@ const convertInput = {
 
       return value;
     }
-    function convertArray(arr: Array<unknown>): Array<unknown>|FieldValue {
+    function convertArray(arr: unknown[]): unknown[]|FieldValue {
       if (arr.length > 0 && arr[0] === 'ArrayUnion') {
         return FieldValue.arrayUnion(
-            ...(convertArray(arr.slice(1)) as Array<unknown>));
+            ...(convertArray(arr.slice(1)) as unknown[]));
       } else if (arr.length > 0 && arr[0] === 'ArrayRemove') {
         return FieldValue.arrayRemove(
-            ...(convertArray(arr.slice(1)) as Array<unknown>));
+            ...(convertArray(arr.slice(1)) as unknown[]));
       } else {
         for (let i = 0; i < arr.length; ++i) {
           arr[i] = convertValue(arr[i]);
@@ -159,7 +159,7 @@ const convertInput = {
     return convertedPaths;
   },
   cursor: (cursor: ConformanceProto) => {
-    const args: Array<unknown> = [];
+    const args: unknown[] = [];
     if (cursor.docSnapshot) {
       args.push(DocumentSnapshot.fromObject(
           docRef(cursor.docSnapshot.path),
@@ -281,7 +281,7 @@ function runTest(spec: ConformanceProto) {
   const updateTest = (spec: ConformanceProto) => {
     const overrides = {commit: commitHandler(spec)};
     return createInstance(overrides).then(() => {
-      const varargs: Array<unknown> = [];
+      const varargs: unknown[] = [];
 
       if (spec.jsonData) {
         varargs[0] = convertInput.argument(spec.jsonData);

--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -16,7 +16,7 @@
 
 import {google} from '../protos/firestore_proto_api';
 
-import {ProtobufJsValue} from './types';
+import {ApiMapValue, ProtobufJsValue} from './types';
 import {validateObject} from './validate';
 
 import api = google.firestore.v1;
@@ -160,7 +160,7 @@ export function detectValueType(proto: ProtobufJsValue): string {
  * @param fieldValue The `firestore.v1.Value` in Proto3 JSON format.
  * @return The `firestore.v1.Value` in Protobuf JS format.
  */
-export function valueFromJson(fieldValue: ProtobufJsValue): api.IValue {
+export function valueFromJson(fieldValue: api.IValue): api.IValue {
   const valueType = detectValueType(fieldValue);
 
   switch (valueType) {
@@ -194,7 +194,7 @@ export function valueFromJson(fieldValue: ProtobufJsValue): api.IValue {
       };
     }
     case 'mapValue': {
-      const mapValue = {};
+      const mapValue: ApiMapValue = {};
       for (const prop in fieldValue.mapValue!.fields!) {
         if (fieldValue.mapValue!.fields!.hasOwnProperty(prop)) {
           mapValue[prop] = valueFromJson(fieldValue.mapValue!.fields![prop]);
@@ -212,17 +212,16 @@ export function valueFromJson(fieldValue: ProtobufJsValue): api.IValue {
 }
 
 /**
- * Converts a `firestore.v1.Document` in Proto3 JSON encoding into the
- * Protobuf JS format expected by this client. This conversion creates a copy of
- * the underlying document.
+ * Converts a map of IValues in Proto3 JSON encoding into the Protobuf JS format
+ * expected by this client. This conversion creates a copy of the underlying
+ * fields.
  *
  * @private
- * @param document The `firestore.v1.Document` in Proto3 JSON
- * format.
- * @return The `firestore.v1.Document` in Protobuf JS format.
+ * @param document An object with IValues in Proto3 JSON format.
+ * @return The object in Protobuf JS format.
  */
-export function documentFromJson(document: api.IDocument): api.IDocument {
-  const result = {};
+export function fieldsFromJson(document: ApiMapValue): ApiMapValue {
+  const result: ApiMapValue = {};
 
   for (const prop in document) {
     if (document.hasOwnProperty(prop)) {

--- a/dev/src/document-change.ts
+++ b/dev/src/document-change.ts
@@ -166,7 +166,7 @@ export class DocumentChange {
    * @param {*} other The value to compare against.
    * @return true if this `DocumentChange` is equal to the provided value.
    */
-  isEqual(other): boolean {
+  isEqual(other: DocumentChange): boolean {
     if (this === other) {
       return true;
     }

--- a/dev/src/external-modules.d.ts
+++ b/dev/src/external-modules.d.ts
@@ -1,0 +1,4 @@
+// TODO(mrschmidt): Come up with actual definitions for these modules.
+
+declare module 'bun';
+declare module 'functional-red-black-tree'

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -365,7 +365,7 @@ class ArrayRemoveTransform extends FieldTransform {
     }
   }
 
-  toProto(serializer: Serializer, fieldPath):
+  toProto(serializer: Serializer, fieldPath: FieldPath):
       api.DocumentTransform.IFieldTransform {
     const encodedElements = serializer.encodeValue(this.elements)!.arrayValue!;
     return {

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -102,7 +102,7 @@ export class FieldValue {
    *   // doc.get('array') contains field 'foo'
    * });
    */
-  static arrayUnion(...elements: Array<unknown>): FieldValue {
+  static arrayUnion(...elements: unknown[]): FieldValue {
     validateMinNumberOfArguments('FieldValue.arrayUnion', arguments, 1);
     return new ArrayUnionTransform(elements);
   }
@@ -129,7 +129,7 @@ export class FieldValue {
    *   // doc.get('array') no longer contains field 'foo'
    * });
    */
-  static arrayRemove(...elements: Array<unknown>): FieldValue {
+  static arrayRemove(...elements: unknown[]): FieldValue {
     validateMinNumberOfArguments('FieldValue.arrayRemove', arguments, 1);
     return new ArrayRemoveTransform(elements);
   }
@@ -282,7 +282,7 @@ class ServerTimestampTransform extends FieldTransform {
  * @private
  */
 class ArrayUnionTransform extends FieldTransform {
-  constructor(private readonly elements: Array<unknown>) {
+  constructor(private readonly elements: unknown[]) {
     super();
   }
 
@@ -335,7 +335,7 @@ class ArrayUnionTransform extends FieldTransform {
  * @private
  */
 class ArrayRemoveTransform extends FieldTransform {
-  constructor(private readonly elements: Array<unknown>) {
+  constructor(private readonly elements: unknown[]) {
     super();
   }
 

--- a/dev/src/geo-point.ts
+++ b/dev/src/geo-point.ts
@@ -82,7 +82,7 @@ export class GeoPoint implements Serializable {
    * @param {*} other The value to compare against.
    * @return {boolean} true if this `GeoPoint` is equal to the provided value.
    */
-  isEqual(other): boolean {
+  isEqual(other: GeoPoint): boolean {
     return (
         this === other ||
         (other instanceof GeoPoint && this.latitude === other.latitude &&

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -21,9 +21,8 @@ import * as extend from 'extend';
 import * as through2 from 'through2';
 
 import {google} from '../protos/firestore_proto_api';
-import {documentFromJson, timestampFromJson} from './convert';
-import {DocumentSnapshot, DocumentSnapshotBuilder} from './document';
-import {GeoPoint} from './geo-point';
+import {fieldsFromJson, timestampFromJson} from './convert';
+import {DocumentSnapshot, DocumentSnapshotBuilder, QueryDocumentSnapshot} from './document';
 import {logger, setLibVersion} from './logger';
 import {FieldPath, validateResourcePath} from './path';
 import {ResourcePath} from './path';
@@ -33,7 +32,7 @@ import {DocumentReference} from './reference';
 import {Serializer} from './serializer';
 import {Timestamp} from './timestamp';
 import {parseGetAllArguments, Transaction} from './transaction';
-import {DocumentData, GapicClient, ReadOptions, Settings} from './types';
+import {ApiMapValue, GapicClient, GrpcError, ReadOptions, Settings} from './types';
 import {requestTag} from './util';
 import {validateBoolean, validateFunction, validateInteger, validateMinNumberOfArguments, validateObject, validateString,} from './validate';
 import {WriteBatch} from './write-batch';
@@ -78,12 +77,12 @@ setLibVersion(libVersion);
 /*!
  * @see v1
  */
-let v1;  // Lazy-loaded in `_runRequest()`
+let v1: unknown;  // Lazy-loaded in `_runRequest()`
 
 /*!
  * @see v1beta1
  */
-let v1beta1;  // Lazy-loaded in `_runRequest()`
+let v1beta1: unknown;  // Lazy-loaded upon access.
 
 /*!
  * HTTP header for the resource prefix to improve routing and project isolation
@@ -203,9 +202,6 @@ const GRPC_UNAVAILABLE = 14;
  * Full quickstart example:
  */
 export class Firestore {
-  /** @private */
-  readonly _validator;
-
   /**
    * A client pool to distribute requests over multiple GAPIC clients in order
    * to work around a connection limit of 100 concurrent requests per client.
@@ -461,41 +457,84 @@ export class Firestore {
   }
 
   /**
-   * Creates a [DocumentSnapshot]{@link DocumentSnapshot} or a
-   * [QueryDocumentSnapshot]{@link QueryDocumentSnapshot} from a
-   * `firestore.v1.Document` proto (or from a resource name for missing
-   * documents).
-   *
-   * This API is used by Google Cloud Functions and can be called with both
-   * 'Proto3 JSON' and 'Protobuf JS' encoded data.
+   * Creates a [DocumentSnapshot]{@link DocumentSnapshot} for a missing
+   * document.
    *
    * @private
-   * @param documentOrName The Firestore 'Document' proto or the resource name
-   * of a missing document.
+   * @param documentName The absolute resource name of the missing document.
    * @param readTime A 'Timestamp' proto indicating the time this document was
    * read.
-   * @param encoding One of 'json' or 'protobufJS'. Applies to both the
-   * 'document' Proto and 'readTime'. Defaults to 'protobufJS'.
-   * @returns A QueryDocumentSnapshot for existing documents, otherwise a
-   * DocumentSnapshot.
+   * @param encoding If set, 'protobufJS' to indicate the format of `readTime`.
+   * @returns The DocumentSnapshot for the missing document.
    */
   snapshot_(
-      documentOrName: api.IDocument|string,
-      readTime?: google.protobuf.ITimestamp,
+      documentName: string, readTime?: google.protobuf.ITimestamp,
+      encoding?: 'protobufJS'): DocumentSnapshot;
+  /**
+   * Creates a [DocumentSnapshot]{@link DocumentSnapshot} for a missing
+   * document.
+   *
+   * This API is used by Google Cloud Functions.
+   *
+   * @private
+   * @param documentName The absolute resource name of the missing document.
+   * @param readTime An ISO-8601 formatted string indicating the time this
+   * document was read.
+   * @param encoding 'json' to indicate the format of `readTime`.
+   * @returns The DocumentSnapshot for the missing document.
+   */
+  snapshot_(documentName: string, readTime: string, encoding: 'json'):
+      DocumentSnapshot;
+  /**
+   * Creates a [QueryDocumentSnapshot]{@link QueryDocumentSnapshot} from a
+   * `firestore.v1.Document` proto.
+   *
+   * @private
+   * @param document The Firestore 'Document' proto in Protobuf JS format.
+   * @param readTime A 'Timestamp' proto indicating the time this document was
+   * read.
+   * @param encoding  If set, 'protobufJS' to indicate the format of `document`
+   * and `readTime`.
+   * @returns The QueryDocumentSnapshot with the document's data.
+   */
+  snapshot_(
+      document: api.IDocument, readTime: google.protobuf.ITimestamp,
+      encoding?: 'protobufJS'): QueryDocumentSnapshot;
+  /**
+   * Creates a [QueryDocumentSnapshot]{@link QueryDocumentSnapshot} from a
+   * `firestore.v1.Document` proto.
+   *
+   * This API is used by Google Cloud Functions.
+   *
+   * @private
+   * @param document The Firestore 'Document' proto in JSON format.
+   * @param readTime An ISO-8601 formatted string indicating the time this
+   * document was read.
+   * @param encoding 'json' to indicate the format of `document` and `readTime`.
+   * @returns The QueryDocumentSnapshot with the document's data.
+   */
+  snapshot_(
+      document: {[k: string]: unknown}, readTime: string,
+      encoding: 'json'): QueryDocumentSnapshot;
+  snapshot_(
+      documentOrName: api.IDocument|{[k: string]: unknown}|string,
+      readTime?: google.protobuf.ITimestamp|string,
       encoding?: 'json'|'protobufJS'): DocumentSnapshot {
     // TODO: Assert that Firestore Project ID is valid.
 
-    let convertTimestamp;
-    let convertDocument;
+    let convertTimestamp: (
+        timestampValue?: string|google.protobuf.ITimestamp,
+        argumentName?: string) => google.protobuf.ITimestamp | undefined;
+    let convertFields: (data: ApiMapValue) => ApiMapValue;
 
     if (encoding === undefined || encoding === 'protobufJS') {
-      convertTimestamp = data => data;
-      convertDocument = data => data;
+      convertTimestamp = data => data as google.protobuf.ITimestamp;
+      convertFields = data => data;
     } else if (encoding === 'json') {
       // Google Cloud Functions calls us with Proto3 JSON format data, which we
       // must convert to Protobuf JS.
       convertTimestamp = timestampFromJson;
-      convertDocument = documentFromJson;
+      convertFields = fieldsFromJson;
     } else {
       throw new Error(
           `Unsupported encoding format. Expected "json" or "protobufJS", ` +
@@ -509,18 +548,22 @@ export class Firestore {
           this, ResourcePath.fromSlashSeparatedString(documentOrName));
     } else {
       document.ref = new DocumentReference(
-          this, ResourcePath.fromSlashSeparatedString(documentOrName.name!));
-      document.fieldsProto =
-          documentOrName.fields ? convertDocument(documentOrName.fields) : {};
+          this,
+          ResourcePath.fromSlashSeparatedString(documentOrName.name as string));
+      document.fieldsProto = documentOrName.fields ?
+          convertFields(documentOrName.fields as ApiMapValue) :
+          {};
       document.createTime = Timestamp.fromProto(convertTimestamp(
-          documentOrName.createTime, 'documentOrName.createTime'));
+          documentOrName.createTime as string | google.protobuf.ITimestamp,
+          'documentOrName.createTime')!);
       document.updateTime = Timestamp.fromProto(convertTimestamp(
-          documentOrName.updateTime, 'documentOrName.updateTime'));
+          documentOrName.updateTime as string | google.protobuf.ITimestamp,
+          'documentOrName.updateTime')!);
     }
 
     if (readTime) {
       document.readTime =
-          Timestamp.fromProto(convertTimestamp(readTime, 'readTime'));
+          Timestamp.fromProto(convertTimestamp(readTime, 'readTime')!);
     }
 
     return document.build();
@@ -599,7 +642,7 @@ export class Firestore {
 
     const transaction = new Transaction(this, previousTransaction);
     const requestTag = transaction.requestTag;
-    let result;
+    let result: Promise<T>;
 
     --attemptsRemaining;
 
@@ -885,7 +928,7 @@ export class Firestore {
    */
   private _detectProjectId(gapicClient: GapicClient): Promise<string> {
     return new Promise((resolve, reject) => {
-      gapicClient.getProjectId((err, projectId) => {
+      gapicClient.getProjectId((err: Error, projectId: string) => {
         if (err) {
           logger(
               'Firestore._detectProjectId', null,
@@ -912,7 +955,9 @@ export class Firestore {
     let decoratedRequest = extend(true, {}, request);
     decoratedRequest =
         replaceProjectIdToken(decoratedRequest, this._referencePath!.projectId);
-    const decoratedGax = {otherArgs: {headers: {}}};
+    const decoratedGax: {
+      otherArgs: {headers: {[k: string]: string}}
+    } = {otherArgs: {headers: {}}};
     decoratedGax.otherArgs.headers[CLOUD_RESOURCE_HEADER] = this.formattedName;
 
     return {request: decoratedRequest, gax: decoratedGax};
@@ -1126,7 +1171,7 @@ export class Firestore {
               'Firestore.request', requestTag, 'Sending request: %j',
               decorated.request);
           gapicClient[methodName](
-              decorated.request, decorated.gax, (err, result) => {
+              decorated.request, decorated.gax, (err: GrpcError, result: T) => {
                 if (err) {
                   logger(
                       'Firestore.request', requestTag, 'Received error:', err);

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -457,62 +457,32 @@ export class Firestore {
   }
 
   /**
-   * Creates a [DocumentSnapshot]{@link DocumentSnapshot} for a missing
-   * document.
+   * Creates a [DocumentSnapshot]{@link DocumentSnapshot} or a
+   * [QueryDocumentSnapshot]{@link QueryDocumentSnapshot} from a
+   * `firestore.v1.Document` proto (or from a resource name for missing
+   * documents).
+   *
+   * This API is used by Google Cloud Functions and can be called with both
+   * 'Proto3 JSON' and 'Protobuf JS' encoded data.
    *
    * @private
-   * @param documentName The absolute resource name of the missing document.
+   * @param documentOrName The Firestore 'Document' proto or the resource name
+   * of a missing document.
    * @param readTime A 'Timestamp' proto indicating the time this document was
    * read.
-   * @param encoding If set, 'protobufJS' to indicate the format of `readTime`.
-   * @returns The DocumentSnapshot for the missing document.
+   * @param encoding One of 'json' or 'protobufJS'. Applies to both the
+   * 'document' Proto and 'readTime'. Defaults to 'protobufJS'.
+   * @returns A QueryDocumentSnapshot for existing documents, otherwise a
+   * DocumentSnapshot.
    */
   snapshot_(
       documentName: string, readTime?: google.protobuf.ITimestamp,
       encoding?: 'protobufJS'): DocumentSnapshot;
-  /**
-   * Creates a [DocumentSnapshot]{@link DocumentSnapshot} for a missing
-   * document.
-   *
-   * This API is used by Google Cloud Functions.
-   *
-   * @private
-   * @param documentName The absolute resource name of the missing document.
-   * @param readTime An ISO-8601 formatted string indicating the time this
-   * document was read.
-   * @param encoding 'json' to indicate the format of `readTime`.
-   * @returns The DocumentSnapshot for the missing document.
-   */
   snapshot_(documentName: string, readTime: string, encoding: 'json'):
       DocumentSnapshot;
-  /**
-   * Creates a [QueryDocumentSnapshot]{@link QueryDocumentSnapshot} from a
-   * `firestore.v1.Document` proto.
-   *
-   * @private
-   * @param document The Firestore 'Document' proto in Protobuf JS format.
-   * @param readTime A 'Timestamp' proto indicating the time this document was
-   * read.
-   * @param encoding  If set, 'protobufJS' to indicate the format of `document`
-   * and `readTime`.
-   * @returns The QueryDocumentSnapshot with the document's data.
-   */
   snapshot_(
       document: api.IDocument, readTime: google.protobuf.ITimestamp,
       encoding?: 'protobufJS'): QueryDocumentSnapshot;
-  /**
-   * Creates a [QueryDocumentSnapshot]{@link QueryDocumentSnapshot} from a
-   * `firestore.v1.Document` proto.
-   *
-   * This API is used by Google Cloud Functions.
-   *
-   * @private
-   * @param document The Firestore 'Document' proto in JSON format.
-   * @param readTime An ISO-8601 formatted string indicating the time this
-   * document was read.
-   * @param encoding 'json' to indicate the format of `document` and `readTime`.
-   * @returns The QueryDocumentSnapshot with the document's data.
-   */
   snapshot_(
       document: {[k: string]: unknown}, readTime: string,
       encoding: 'json'): QueryDocumentSnapshot;

--- a/dev/src/logger.ts
+++ b/dev/src/logger.ts
@@ -32,7 +32,7 @@ let logFunction = (msg: string) => {};
  */
 export function logger(
     methodName: string, requestTag: string|null, logMessage: string,
-    ...additionalArgs: Array<string|number|object>): void {
+    ...additionalArgs: Array<unknown>): void {
   requestTag = requestTag || '#####';
 
   const formattedMessage = util.format(logMessage, ...additionalArgs);

--- a/dev/src/logger.ts
+++ b/dev/src/logger.ts
@@ -32,7 +32,7 @@ let logFunction = (msg: string) => {};
  */
 export function logger(
     methodName: string, requestTag: string|null, logMessage: string,
-    ...additionalArgs: Array<unknown>): void {
+    ...additionalArgs: unknown[]): void {
   requestTag = requestTag || '#####';
 
   const formattedMessage = util.format(logMessage, ...additionalArgs);

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -208,15 +208,13 @@ abstract class Path<T> {
 export class ResourcePath extends Path<ResourcePath> {
   /**
    * The project ID of this path.
-   * @type {string}
    */
-  readonly projectId;
+  readonly projectId: string;
 
   /**
    * The database ID of this path.
-   * @type {string}
    */
-  readonly databaseId;
+  readonly databaseId: string;
 
   /**
    * Constructs a Firestore Resource Path.

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -190,7 +190,7 @@ export class DocumentReference {
    * }):
    */
   get parent(): CollectionReference {
-    return new CollectionReference(this._firestore, this._path.parent());
+    return new CollectionReference(this._firestore, this._path.parent()!);
   }
 
   /**
@@ -1495,7 +1495,7 @@ export class Query {
     const docs: QueryDocumentSnapshot[] = [];
 
     return new Promise((resolve, reject) => {
-      let readTime;
+      let readTime: Timestamp;
 
       self._stream(transactionId)
           .on('error',
@@ -1749,10 +1749,10 @@ export class CollectionReference extends Query {
    * @private
    * @hideconstructor
    *
-   * @param {Firestore} firestore The Firestore Database client.
-   * @param {ResourcePath} path The Path of this collection.
+   * @param firestore The Firestore Database client.
+   * @param path The Path of this collection.
    */
-  constructor(firestore, path) {
+  constructor(firestore: Firestore, path: ResourcePath) {
     super(firestore, path);
   }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -926,7 +926,7 @@ export class Query {
    */
   static _extractFieldValues(
       documentSnapshot: DocumentSnapshot, fieldOrders: FieldOrder[]) {
-    const fieldValues: Array<unknown> = [];
+    const fieldValues: unknown[] = [];
 
     for (const fieldOrder of fieldOrders) {
       if (FieldPath.documentId().isEqual(fieldOrder.field)) {

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -228,7 +228,7 @@ export class Serializer {
         return this.createReference(resourcePath.relativeName);
       }
       case 'arrayValue': {
-        const array: Array<unknown> = [];
+        const array: unknown[] = [];
         if (Array.isArray(proto.arrayValue!.values)) {
           for (const value of proto.arrayValue!.values!) {
             array.push(this.decodeValue(value));

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -15,7 +15,7 @@
  */
 
 
-import * as proto from '../protos/firestore_proto_api';
+import {google} from '../protos/firestore_proto_api';
 import {validateInteger} from './validate';
 
 /*!
@@ -67,7 +67,7 @@ export class Timestamp {
    * @return {Timestamp} A new `Timestamp` representing the same point in time
    * as the given date.
    */
-  static fromDate(date) {
+  static fromDate(date: Date) {
     return Timestamp.fromMillis(date.getTime());
   }
 
@@ -84,7 +84,7 @@ export class Timestamp {
    * @return {Timestamp}  A new `Timestamp` representing the same point in time
    * as the given number of milliseconds.
    */
-  static fromMillis(milliseconds) {
+  static fromMillis(milliseconds: number) {
     const seconds = Math.floor(milliseconds / 1000);
     const nanos = (milliseconds - seconds * 1000) * MS_TO_NANOS;
     return new Timestamp(seconds, nanos);
@@ -96,7 +96,7 @@ export class Timestamp {
    * @private
    * @param {Object} timestamp The `Timestamp` Protobuf object.
    */
-  static fromProto(timestamp) {
+  static fromProto(timestamp: google.protobuf.ITimestamp) {
     return new Timestamp(
         Number(timestamp.seconds || 0), Number(timestamp.nanos || 0));
   }
@@ -117,7 +117,7 @@ export class Timestamp {
    * have non-negative nanoseconds values that count forward in time. Must be
    * from 0 to 999,999,999 inclusive.
    */
-  constructor(seconds, nanoseconds) {
+  constructor(seconds: number, nanoseconds: number) {
     validateInteger('seconds', seconds);
     validateInteger(
         'nanoseconds', nanoseconds, {minValue: 0, maxValue: 999999999});
@@ -214,7 +214,7 @@ export class Timestamp {
    * @param {any} other The `Timestamp` to compare against.
    * @return {boolean} 'true' if this `Timestamp` is equal to the provided one.
    */
-  isEqual(other) {
+  isEqual(other: Timestamp): boolean {
     return (
         this === other ||
         (other instanceof Timestamp && this._seconds === other.seconds &&
@@ -228,7 +228,7 @@ export class Timestamp {
    * @returns {Object} The `Timestamp` Protobuf object.
    */
   toProto() {
-    const timestamp: proto.google.protobuf.ITimestamp = {};
+    const timestamp: google.protobuf.ITimestamp = {};
 
     if (this.seconds) {
       timestamp.seconds = this.seconds;

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -31,6 +31,11 @@ export type ApiMapValue = {
 // tslint:disable-next-line:no-any
 export type GapicClient = any;
 
+// We don't have type information for the npm package
+// `functional-red-black-tree`.
+// tslint:disable-next-line:no-any
+export type RBTree = any;
+
 export class GrpcError extends Error {
   code?: number;
 }

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -26,7 +26,7 @@ import Firestore, {DocumentReference, Query} from './index';
 import {logger} from './logger';
 import {ResourcePath} from './path';
 import {Timestamp} from './timestamp';
-import {GrpcError} from './types';
+import {GrpcError, RBTree} from './types';
 import {requestTag} from './util';
 
 import api = google.firestore.v1;
@@ -384,7 +384,7 @@ export class Watch {
       changeMap.clear();
       resumeToken = null;
 
-      docTree.forEach(snapshot => {
+      docTree.forEach((snapshot: QueryDocumentSnapshot) => {
         // Mark each document as deleted. If documents are not deleted, they
         // will be send again by the server.
         changeMap.set(snapshot.ref.formattedName, REMOVED);
@@ -394,7 +394,7 @@ export class Watch {
     };
 
     /** Closes the stream and calls onError() if the stream is still active. */
-    const closeStream = (err) => {
+    const closeStream = (err: GrpcError) => {
       if (currentStream) {
         currentStream.unpipe(stream);
         currentStream.end();
@@ -535,7 +535,7 @@ export class Watch {
      * @private
      */
     const computeSnapshot =
-        (docTree: rbtree, docMap: Map<string, QueryDocumentSnapshot>,
+        (docTree: RBTree, docMap: Map<string, QueryDocumentSnapshot>,
          changes: DocumentChangeSet) => {
           let updatedTree = docTree;
           const updatedMap = docMap;
@@ -751,9 +751,9 @@ export class Watch {
                       ResourcePath.fromSlashSeparatedString(name).relativeName);
                   snapshot.fieldsProto = document.fields || {};
                   snapshot.createTime =
-                      Timestamp.fromProto(document.createTime);
+                      Timestamp.fromProto(document.createTime!);
                   snapshot.updateTime =
-                      Timestamp.fromProto(document.updateTime);
+                      Timestamp.fromProto(document.updateTime!);
                   changeMap.set(name, snapshot);
                 } else if (removed) {
                   logger(

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -110,9 +110,9 @@ export class WriteBatch {
    * @private
    * @hideconstructor
    *
-   * @param {Firestore} firestore The Firestore Database client.
+   * @param firestore The Firestore Database client.
    */
-  constructor(firestore) {
+  constructor(firestore: Firestore) {
     this._firestore = firestore;
     this._serializer = new Serializer(firestore);
   }
@@ -261,7 +261,7 @@ export class WriteBatch {
 
     this.verifyNotCommitted();
 
-    let documentMask;
+    let documentMask: DocumentMask;
 
     if (mergePaths) {
       documentMask = DocumentMask.fromFieldMask(options!.mergeFields!);
@@ -273,20 +273,20 @@ export class WriteBatch {
 
     const document = DocumentSnapshot.fromObject(documentRef, data);
     if (mergePaths) {
-      documentMask.removeFields(transform.fields);
+      documentMask!.removeFields(transform.fields);
     } else {
       documentMask = DocumentMask.fromObject(data);
     }
 
-    const hasDocumentData = !document.isEmpty || !documentMask.isEmpty;
+    const hasDocumentData = !document.isEmpty || !documentMask!.isEmpty;
 
     let write;
 
     if (!mergePaths && !mergeLeaves) {
       write = document.toProto();
     } else if (hasDocumentData || transform.isEmpty) {
-      write = document.toProto();
-      write.updateMask = documentMask.toProto(this._serializer);
+      write = document.toProto()!;
+      write.updateMask = documentMask!.toProto();
     }
 
     this._writes.push({
@@ -383,9 +383,10 @@ export class WriteBatch {
         validateUpdateMap('dataOrField', dataOrField);
         validateMaxNumberOfArguments('update', arguments, 3);
 
-        Object.keys(dataOrField).forEach(key => {
+        const data = dataOrField as UpdateData;
+        Object.keys(data).forEach(key => {
           validateFieldPath(key, key);
-          updateMap.set(FieldPath.fromArgument(key), dataOrField[key]);
+          updateMap.set(FieldPath.fromArgument(key), data[key]);
         });
 
         if (preconditionOrValues.length > 0) {
@@ -524,7 +525,7 @@ export class WriteBatch {
                     resp.writeResults.length} results for ${
                     request.writes!.length} operations.`);
 
-            const commitTime = Timestamp.fromProto(resp.commitTime);
+            const commitTime = Timestamp.fromProto(resp.commitTime!);
 
             let offset = 0;
 

--- a/dev/test/backoff.ts
+++ b/dev/test/backoff.ts
@@ -38,11 +38,11 @@ describe('ExponentialBackoff', () => {
     setTimeoutHandler(setTimeout);
   });
 
-  function assertDelayEquals(expected) {
+  function assertDelayEquals(expected: number) {
     expect(observedDelays.shift()).to.equal(expected);
   }
 
-  function assertDelayBetween(low, high) {
+  function assertDelayBetween(low: number, high: number) {
     const actual = observedDelays.shift()!;
     expect(actual).to.be.at.least(low);
     expect(actual).to.be.at.most(high);

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -16,19 +16,22 @@
 
 import {expect} from 'chai';
 
-import * as Firestore from '../src';
-import {DocumentSnapshot} from '../src';
+import {google} from '../protos/firestore_proto_api';
+
+import {Firestore, QueryDocumentSnapshot, setLogFunction, Timestamp} from '../src';
 import {GeoPoint} from '../src';
 import {DocumentReference} from '../src';
 import * as order from '../src/order';
 import {ResourcePath} from '../src/path';
 import {createInstance, InvalidApiUsage} from './util/helpers';
 
+import api = google.firestore.v1;
+
 // Change the argument to 'console.log' to enable debug output.
-Firestore.setLogFunction(() => {});
+setLogFunction(() => {});
 
 describe('Order', () => {
-  let firestore;
+  let firestore: Firestore;
 
   beforeEach(() => {
     return createInstance().then(firestoreInstance => {
@@ -37,32 +40,34 @@ describe('Order', () => {
   });
 
   /** Converts a value into its proto representation. */
-  function wrap(value) {
-    return firestore['_serializer']!.encodeValue(value);
+  function wrap(value: unknown): api.IValue {
+    const val = firestore._serializer!.encodeValue(value);
+    expect(val).to.not.be.null;
+    return val!;
   }
 
-  function blob(data) {
+  function blob(data: number[]): api.IValue {
     return wrap(Buffer.from(data));
   }
 
-  function resource(pathString) {
+  function resource(pathString: string): api.IValue {
     return wrap(new DocumentReference(
         firestore, ResourcePath.fromSlashSeparatedString(pathString)));
   }
 
-  function geopoint(lat, lng) {
+  function geopoint(lat: number, lng: number): api.IValue {
     return wrap(new GeoPoint(lat, lng));
   }
 
-  function int(n: number) {
+  function int(n: number): api.IValue {
     return {
-      integerValue: '' + n,
+      integerValue: n,
     };
   }
 
-  function double(n: number) {
+  function double(n: number): api.IValue {
     return {
-      doubleValue: '' + n,
+      doubleValue: n,
     };
   }
 
@@ -88,10 +93,18 @@ describe('Order', () => {
 
   it('compares document snapshots by name', () => {
     const docs = [
-      new DocumentSnapshot(firestore.doc('col/doc3')),
-      new DocumentSnapshot(firestore.doc('col/doc2')),
-      new DocumentSnapshot(firestore.doc('col/doc2')),
-      new DocumentSnapshot(firestore.doc('col/doc1')),
+      new QueryDocumentSnapshot(
+          firestore.doc('col/doc3'), {}, Timestamp.now(), Timestamp.now(),
+          Timestamp.now()),
+      new QueryDocumentSnapshot(
+          firestore.doc('col/doc2'), {}, Timestamp.now(), Timestamp.now(),
+          Timestamp.now()),
+      new QueryDocumentSnapshot(
+          firestore.doc('col/doc2'), {}, Timestamp.now(), Timestamp.now(),
+          Timestamp.now()),
+      new QueryDocumentSnapshot(
+          firestore.doc('col/doc1'), {}, Timestamp.now(), Timestamp.now(),
+          Timestamp.now()),
     ];
 
     docs.sort(firestore.collection('col').comparator());

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -17,11 +17,15 @@
 import {expect} from 'chai';
 import * as through2 from 'through2';
 
-import * as Firestore from '../src/index';
-import {createInstance as createInstanceHelper, document} from '../test/util/helpers';
+import {google} from '../protos/firestore_proto_api';
 
-function createInstance(opts, document) {
-  const overrides = {
+import * as Firestore from '../src/index';
+import {ApiOverride, createInstance as createInstanceHelper, document} from '../test/util/helpers';
+
+import api = google.firestore.v1;
+
+function createInstance(opts: {}, document: api.IDocument) {
+  const overrides: ApiOverride = {
     batchGetDocuments: () => {
       const stream = through2.obj();
       setImmediate(() => {

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -17,22 +17,24 @@
 const duplexify = require('duplexify');
 
 import {expect} from 'chai';
+import {Transform} from 'stream';
 import * as through2 from 'through2';
 
-import * as proto from '../protos/firestore_proto_api';
-import * as Firestore from '../src';
-import {DocumentData, DocumentReference, QueryDocumentSnapshot, QuerySnapshot} from '../src';
+import {google} from '../protos/firestore_proto_api';
+
+import {CollectionReference, FieldPath, Firestore, GeoPoint, setLogFunction, Timestamp} from '../src';
+import {DocumentData, DocumentReference, DocumentSnapshot, Query, QueryDocumentSnapshot, QuerySnapshot} from '../src';
 import {setTimeoutHandler} from '../src/backoff';
 import {DocumentSnapshotBuilder} from '../src/document';
 import {DocumentChangeType} from '../src/document-change';
 import {Serializer} from '../src/serializer';
 import {GrpcError} from '../src/types';
-import {createInstance} from './util/helpers';
+import {createInstance, InvalidApiUsage} from './util/helpers';
 
-import api = proto.google.firestore.v1;
+import api = google.firestore.v1;
 
 // Change the argument to 'console.log' to enable debug output.
-Firestore.setLogFunction(() => {});
+setLogFunction(() => {});
 
 
 let PROJECT_ID = process.env.PROJECT_ID;
@@ -50,8 +52,8 @@ function docsEqual(
   for (let i = 0; i < actual.length; i++) {
     expect(actual[i].ref.id).to.equal(expected[i].ref.id);
     expect(actual[i].data()).to.deep.eq(expected[i].data());
-    expect(expected[i].createTime).to.be.an.instanceOf(Firestore.Timestamp);
-    expect(expected[i].updateTime).to.be.an.instanceOf(Firestore.Timestamp);
+    expect(expected[i].createTime).to.be.an.instanceOf(Timestamp);
+    expect(expected[i].updateTime).to.be.an.instanceOf(Timestamp);
   }
 }
 
@@ -73,11 +75,15 @@ type TestSnapshot = {
  * @param expected Array of DocumentSnapshot.
  */
 function snapshotsEqual(
-    lastSnapshot: TestSnapshot, version: number, actual: QuerySnapshot,
+    lastSnapshot: TestSnapshot, version: number,
+    actual: Error|QuerySnapshot|undefined,
     expected: TestSnapshot): TestSnapshot {
   const localDocs = ([] as QueryDocumentSnapshot[]).concat(lastSnapshot.docs);
 
-  const actualDocChanges = actual.docChanges();
+  expect(actual).to.be.an.instanceof(QuerySnapshot);
+
+  const actualSnapshot = actual as QuerySnapshot;
+  const actualDocChanges = actualSnapshot.docChanges();
 
   expect(actualDocChanges.length).to.equal(expected.docChanges.length);
   for (let i = 0; i < expected.docChanges.length; i++) {
@@ -88,8 +94,8 @@ function snapshotsEqual(
         .to.deep.eq(expected.docChanges[i].doc.data());
     const readVersion =
         actualDocChanges[i].type === 'removed' ? version - 1 : version;
-    expect(actualDocChanges[i].doc.readTime.isEqual(
-               new Firestore.Timestamp(0, readVersion)))
+    expect(
+        actualDocChanges[i].doc.readTime.isEqual(new Timestamp(0, readVersion)))
         .to.be.true;
 
     if (actualDocChanges[i].oldIndex !== -1) {
@@ -102,13 +108,12 @@ function snapshotsEqual(
     }
   }
 
-  docsEqual(actual.docs, expected.docs);
+  docsEqual(actualSnapshot.docs, expected.docs);
   docsEqual(localDocs, expected.docs);
-  expect(actual.readTime.isEqual(new Firestore.Timestamp(0, version)))
-      .to.be.true;
-  expect(actual.size).to.equal(expected.docs.length);
+  expect(actualSnapshot.readTime.isEqual(new Timestamp(0, version))).to.be.true;
+  expect(actualSnapshot.size).to.equal(expected.docs.length);
 
-  return {docs: actual.docs, docChanges: actualDocChanges};
+  return {docs: actualSnapshot.docs, docChanges: actualDocChanges};
 }
 
 /*
@@ -119,9 +124,9 @@ function snapshot(
   const snapshot = new DocumentSnapshotBuilder();
   snapshot.ref = ref;
   snapshot.fieldsProto = ref.firestore._serializer!.encodeFields(data);
-  snapshot.readTime = new Firestore.Timestamp(0, 0);
-  snapshot.createTime = new Firestore.Timestamp(0, 0);
-  snapshot.updateTime = new Firestore.Timestamp(0, 0);
+  snapshot.readTime = new Timestamp(0, 0);
+  snapshot.createTime = new Timestamp(0, 0);
+  snapshot.updateTime = new Timestamp(0, 0);
   return snapshot.build() as QueryDocumentSnapshot;
 }
 
@@ -134,9 +139,12 @@ function docChange(
   return {type, doc: snapshot(ref, data)};
 }
 
-const added = (ref, data) => docChange('added', ref, data);
-const modified = (ref, data) => docChange('modified', ref, data);
-const removed = (ref, data) => docChange('removed', ref, data);
+const added = (ref: DocumentReference, data: DocumentData) =>
+    docChange('added', ref, data);
+const modified = (ref: DocumentReference, data: DocumentData) =>
+    docChange('modified', ref, data);
+const removed = (ref: DocumentReference, data: DocumentData) =>
+    docChange('removed', ref, data);
 
 const EMPTY = {
   docs: [],
@@ -153,7 +161,7 @@ class DeferredListener<T> {
    * Makes stream data available via the Promises set in the 'await' call. If no
    * Promise has been set, the data will be cached.
    */
-  on(type: string, data?: T): void {
+  on(type: string, data?: T|Error): void {
     const listener = this.pendingListeners.shift();
 
     if (listener) {
@@ -200,15 +208,16 @@ class DeferredListener<T> {
  * sequential invocations of the Listen API.
  */
 class StreamHelper {
-  private streamCount = 0;
   private readonly deferredListener =
       new DeferredListener<api.IListenResponse>();
-  private readStream: NodeJS.ReadableStream|null = null;
-  private writeStream: NodeJS.WritableStream|null = null;
   private backendStream: NodeJS.ReadWriteStream|null = null;
 
+  streamCount = 0;  // The number of streams that the client has requested
+  readStream: Transform|null = null;
+  writeStream: Transform|null = null;
+
   /** Returns the GAPIC callback to use with this stream helper. */
-  getListenCallback() {
+  getListenCallback(): () => NodeJS.ReadWriteStream {
     return () => {
       // Create a mock backend whose stream we can return.
       ++this.streamCount;
@@ -226,7 +235,7 @@ class StreamHelper {
       this.deferredListener.on('open', {});
 
       this.backendStream = duplexify.obj(this.readStream, this.writeStream);
-      return this.backendStream;
+      return this.backendStream!;
     };
   }
 
@@ -257,8 +266,11 @@ class StreamHelper {
   /**
    * Sends a message to the currently active stream.
    */
-  write(data): void {
-    this.writeStream!.write(data);
+  write(data: string|object): void {
+    // The stream returned by the Gapic library accepts Protobuf
+    // messages, but the type information does not expose this.
+    // tslint:disable-next-line no-any
+    this.writeStream!.write(data as any);
   }
 
   /**
@@ -272,24 +284,25 @@ class StreamHelper {
    * Destroys the currently active stream with the optionally provided error.
    * If omitted, the stream is closed with a GRPC Status of UNAVAILABLE.
    */
-  destroyStream(err): void {
+  destroyStream(err?: GrpcError): void {
     if (!err) {
-      err = new Error('Server disconnect');
+      err = new GrpcError('Server disconnect');
       err.code = 14;  // Unavailable
     }
-    (this.readStream as any).destroy(err);  // tslint:disable-line no-any
+    this.readStream!.destroy(err);
   }
 }
 
 /**
  * Encapsulates the stream logic for the Watch API.
  */
-class WatchHelper<T> {
-  private readonly serializer: Serializer;
+class WatchHelper<T = QuerySnapshot | DocumentSnapshot> {
   private readonly streamHelper: StreamHelper;
-  private snapshotVersion = 0;
   private readonly deferredListener = new DeferredListener<T>();
   private unsubscribe: (() => void)|null = null;
+
+  snapshotVersion = 0;
+  serializer: Serializer;
 
   /**
    * @param streamHelper The StreamHelper base class for this Watch operation.
@@ -297,7 +310,9 @@ class WatchHelper<T> {
    * watched.
    * @param targetId The target ID of the watch stream.
    */
-  constructor(streamHelper, private reference, private targetId) {
+  constructor(
+      streamHelper: StreamHelper, private reference: DocumentReference|Query,
+      private targetId: number) {
     this.serializer = new Serializer(reference.firestore);
     this.streamHelper = streamHelper;
     this.snapshotVersion = 0;
@@ -307,6 +322,8 @@ class WatchHelper<T> {
   /**
    * Returns a Promise with the next result from the underlying stream.
    */
+  await(type: 'snapshot'): Promise<T>;
+  await(type: 'error'): Promise<Error>;
   await(type: string): Promise<T|Error|undefined> {
     return this.deferredListener.await(type);
   }
@@ -319,10 +336,10 @@ class WatchHelper<T> {
    */
   startWatch(): () => void {
     this.unsubscribe = this.reference.onSnapshot(
-        snapshot => {
-          this.deferredListener.on('snapshot', snapshot);
+        (snapshot: unknown) => {
+          this.deferredListener.on('snapshot', snapshot as T);
         },
-        error => {
+        (error: Error) => {
           this.deferredListener.on('error', error);
         });
     return this.unsubscribe!;
@@ -378,7 +395,7 @@ class WatchHelper<T> {
    * Sends a target change from the backend of type 'NO_CHANGE'. If specified,
    * includes a resume token.
    */
-  sendSnapshot(version: number, resumeToken: Uint8Array): void {
+  sendSnapshot(version: number, resumeToken?: Uint8Array): void {
     this.snapshotVersion = version;
 
     const proto: api.IListenResponse = {
@@ -399,7 +416,7 @@ class WatchHelper<T> {
   /**
    * Sends a target change from the backend of type 'CURRENT'.
    */
-  sendCurrent(resumeToken: Uint8Array): void {
+  sendCurrent(resumeToken?: Uint8Array): void {
     const proto: api.IListenResponse = {
       targetChange: {
         targetChangeType: 'CURRENT',
@@ -469,7 +486,7 @@ class WatchHelper<T> {
   /**
    * A wrapper for writing tests that successfully run a watch.
    */
-  runTest(expectedRequest: api.IListenRequest, func: () => Promise<void>):
+  runTest(expectedRequest: api.IListenRequest, func: () => Promise<unknown>):
       Promise<void> {
     this.startWatch();
 
@@ -485,8 +502,8 @@ class WatchHelper<T> {
    * A wrapper for writing tests that fail to run a watch.
    */
   runFailedTest(
-      expectedRequest: api.IListenRequest, func: () => Promise<void>,
-      expectedError: Error): Promise<void> {
+      expectedRequest: api.IListenRequest, func: () => void|Promise<unknown>,
+      expectedError: string): Promise<void> {
     this.startWatch();
 
     return this.streamHelper.awaitOpen()
@@ -508,17 +525,21 @@ class WatchHelper<T> {
 
 describe('Query watch', () => {
   // The collection to query.
-  let colRef;
+  let colRef: CollectionReference;
 
   // The documents used in this query.
-  let doc1, doc2, doc3, doc4;
+  let doc1: DocumentReference;
+  let doc2: DocumentReference;
+  let doc3: DocumentReference;
+  let doc4: DocumentReference;
 
-  let firestore;
-  let targetId;
-  let watchHelper;
-  let streamHelper;
+  let firestore: Firestore;
+  let targetId: number;
+  let watchHelper: WatchHelper<QuerySnapshot>;
+  let streamHelper: StreamHelper;
 
-  let lastSnapshot;
+  let lastSnapshot:
+      {docs: QueryDocumentSnapshot[], docChanges: DocumentChange[]} = EMPTY;
 
   // The proto JSON that should be sent for the query.
   const collQueryJSON = () => {
@@ -541,7 +562,7 @@ describe('Query watch', () => {
   };
 
   // The proto JSON that should be sent for the query.
-  const includeQueryJSON = () => {
+  const includeQueryJSON: () => api.IListenRequest = () => {
     return {
       database: `projects/${PROJECT_ID}/databases/(default)`,
       addTarget: {
@@ -568,28 +589,29 @@ describe('Query watch', () => {
   };
 
   // The proto JSON that should be sent for a resumed query.
-  const resumeTokenQuery = resumeToken => {
-    return {
-      database: `projects/${PROJECT_ID}/databases/(default)`,
-      addTarget: {
-        query: {
-          parent: `projects/${PROJECT_ID}/databases/(default)/documents`,
-          structuredQuery: {
-            from: [{collectionId: 'col'}],
+  const resumeTokenQuery: (resumeToken: Buffer) => api.IListenRequest =
+      (resumeToken: Buffer) => {
+        return {
+          database: `projects/${PROJECT_ID}/databases/(default)`,
+          addTarget: {
+            query: {
+              parent: `projects/${PROJECT_ID}/databases/(default)/documents`,
+              structuredQuery: {
+                from: [{collectionId: 'col'}],
+              },
+            },
+            targetId,
+            resumeToken,
           },
-        },
-        targetId,
-        resumeToken,
-      },
-    };
-  };
+        };
+      };
 
   const sortedQuery = () => {
     return colRef.orderBy('foo', 'desc');
   };
 
   // The proto JSON that should be sent for the query.
-  const sortedQueryJSON = () => {
+  const sortedQueryJSON: () => api.IListenRequest = () => {
     return {
       database: `projects/${PROJECT_ID}/databases/(default)`,
       addTarget: {
@@ -606,7 +628,7 @@ describe('Query watch', () => {
   };
 
   /** The GAPIC callback that executes the listen. */
-  let listenCallback;
+  let listenCallback: () => NodeJS.ReadWriteStream;
 
   beforeEach(() => {
     // We are intentionally skipping the delays to ensure fast test execution.
@@ -642,10 +664,10 @@ describe('Query watch', () => {
   });
 
   it('with invalid callbacks', () => {
-    expect(() => colRef.onSnapshot('foo'))
+    expect(() => colRef.onSnapshot('foo' as InvalidApiUsage))
         .to.throw('Argument "onNext" is not a valid function.');
 
-    expect(() => colRef.onSnapshot(() => {}, 'foo'))
+    expect(() => colRef.onSnapshot(() => {}, 'foo' as InvalidApiUsage))
         .to.throw('Argument "onError" is not a valid function.');
   });
 
@@ -707,7 +729,7 @@ describe('Query watch', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       watchHelper.sendAddTarget();
       watchHelper.sendCurrent();
-      watchHelper.sendSnapshot(1, [0xabcd]);
+      watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
       return watchHelper.await('snapshot')
           .then(() => {
             streamHelper.close();
@@ -742,7 +764,7 @@ describe('Query watch', () => {
           expect(request).to.deep.eq(collQueryJSON());
           watchHelper.sendAddTarget();
           watchHelper.sendCurrent();
-          watchHelper.sendSnapshot(1, [0xabcd]);
+          watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
           return watchHelper.await('snapshot');
         })
         .then(() => {
@@ -756,7 +778,7 @@ describe('Query watch', () => {
   });
 
   it('retries based on error code', () => {
-    const expectRetry = {
+    const expectRetry: {[k: number]: boolean} = {
       /* Cancelled */ 1: true,
       /* Unknown */ 2: true,
       /* InvalidArgument */ 3: false,
@@ -787,7 +809,7 @@ describe('Query watch', () => {
             return watchHelper.runTest(collQueryJSON(), () => {
               watchHelper.sendAddTarget();
               watchHelper.sendCurrent();
-              watchHelper.sendSnapshot(1, [0xabcd]);
+              watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
               return watchHelper.await('snapshot').then(() => {
                 streamHelper.destroyStream(err);
                 return streamHelper.awaitReopen();
@@ -797,7 +819,7 @@ describe('Query watch', () => {
             return watchHelper.runFailedTest(collQueryJSON(), () => {
               watchHelper.sendAddTarget();
               watchHelper.sendCurrent();
-              watchHelper.sendSnapshot(1, [0xabcd]);
+              watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
               return watchHelper.await('snapshot')
                   .then(() => {
                     streamHelper.destroyStream(err);
@@ -821,7 +843,7 @@ describe('Query watch', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       watchHelper.sendAddTarget();
       watchHelper.sendCurrent();
-      watchHelper.sendSnapshot(1, [0xabcd]);
+      watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
       return watchHelper.await('snapshot').then(() => {
         streamHelper.destroyStream(new Error('Unknown'));
         return streamHelper.awaitReopen();
@@ -876,7 +898,7 @@ describe('Query watch', () => {
   });
 
   it('reconnects after error', () => {
-    let resumeToken = [0xabcd];
+    let resumeToken = Buffer.from([0xabcd]);
 
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
@@ -906,7 +928,7 @@ describe('Query watch', () => {
             watchHelper.sendAddTarget();
             watchHelper.sendDoc(doc2, {foo: 'b'});
 
-            resumeToken = [0xbcde];
+            resumeToken = Buffer.from([0xbcde]);
             watchHelper.sendSnapshot(3, resumeToken);
             return watchHelper.await('snapshot');
           })
@@ -943,7 +965,7 @@ describe('Query watch', () => {
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
       watchHelper.sendAddTarget();
-      watchHelper.sendCurrent([0x0]);
+      watchHelper.sendCurrent(Buffer.from([0x0]));
       watchHelper.sendSnapshot(1);
       return watchHelper.await('snapshot')
           .then(results => {
@@ -952,7 +974,7 @@ describe('Query watch', () => {
             // Add a result.
             watchHelper.sendDoc(doc1, {foo: 'a'});
             watchHelper.sendDoc(doc2, {foo: 'b'});
-            watchHelper.sendSnapshot(2, [0x1]);
+            watchHelper.sendSnapshot(2, Buffer.from([0x1]));
             return watchHelper.await('snapshot');
           })
           .then(results => {
@@ -968,7 +990,7 @@ describe('Query watch', () => {
           })
           .then(() => {
             watchHelper.sendDocDelete(doc2);
-            watchHelper.sendSnapshot(3, [0x2]);
+            watchHelper.sendSnapshot(3, Buffer.from([0x2]));
             return watchHelper.await('snapshot');
           })
           .then(results => {
@@ -986,7 +1008,7 @@ describe('Query watch', () => {
       watchHelper.sendAddTarget();
 
       watchHelper.sendCurrent();
-      let resumeToken = [0x1];
+      let resumeToken = Buffer.from([0x1]);
       watchHelper.sendSnapshot(1, resumeToken);
       return watchHelper.await('snapshot')
           .then(results => {
@@ -1002,11 +1024,11 @@ describe('Query watch', () => {
                 targetChangeType: 'NO_CHANGE',
                 targetIds: [0xfeed],
                 readTime: {seconds: 0, nanos: 0},
-                resumeToken: [0x2],
+                resumeToken: Buffer.from([0x2]),
               },
             });
 
-            resumeToken = [0x3];
+            resumeToken = Buffer.from([0x3]);
             // Send snapshot with matching target id but no resume token.
             // The old token continues to be used.
             streamHelper.write({
@@ -1043,7 +1065,7 @@ describe('Query watch', () => {
               // Mock the server responding to the query.
               watchHelper.sendAddTarget();
               watchHelper.sendCurrent();
-              const resumeToken = [0xabcd];
+              const resumeToken = Buffer.from([0xabcd]);
               watchHelper.sendSnapshot(1, resumeToken);
               return watchHelper.await('snapshot')
                   .then(results => {
@@ -1066,7 +1088,7 @@ describe('Query watch', () => {
                     return streamHelper.await('close');
                   })
                   .then(() => {
-                    streamHelper.writeStream.destroy();
+                    streamHelper.writeStream!.destroy();
                   });
             },
             'Stream Error (6)')
@@ -1171,8 +1193,8 @@ describe('Query watch', () => {
     const expectedJson = sortedQueryJSON();
 
     // Add FieldPath.documentId() sorting
-    query = query.orderBy(Firestore.FieldPath.documentId(), 'desc');
-    expectedJson.addTarget.query.structuredQuery.orderBy.push({
+    query = query.orderBy(FieldPath.documentId(), 'desc');
+    expectedJson.addTarget!.query!.structuredQuery!.orderBy!.push({
       direction: 'DESCENDING',
       field: {fieldPath: '__name__'},
     });
@@ -1375,7 +1397,7 @@ describe('Query watch', () => {
             });
 
             // Delete a result.
-            watchHelper.sendDocRemove(doc2);
+            watchHelper.sendDocRemove(doc2, {foo: 'c'});
             watchHelper.sendSnapshot(4);
             return watchHelper.await('snapshot');
           })
@@ -1565,7 +1587,7 @@ describe('Query watch', () => {
   });
 
   it('handles filter mismatch', () => {
-    let oldRequestStream;
+    let oldRequestStream: NodeJS.WritableStream;
 
     return watchHelper.runTest(collQueryJSON(), () => {
       // Mock the server responding to the query.
@@ -1589,7 +1611,7 @@ describe('Query watch', () => {
 
             // Send a filter that doesn't match. Make sure the stream gets
             // reopened.
-            oldRequestStream = streamHelper.writeStream;
+            oldRequestStream = streamHelper.writeStream!;
             streamHelper.write({filter: {count: 0}});
             return streamHelper.await('end');
           })
@@ -1797,32 +1819,36 @@ describe('Query watch', () => {
   });
 
   describe('supports isEqual', () => {
-    let snapshotVersion;
+    let snapshotVersion: number;
 
     beforeEach(() => {
       snapshotVersion = 0;
     });
 
-    function initialSnapshot(watchTest) {
+    function initialSnapshot(
+        watchTest: (initialSnapshot: QuerySnapshot) => Promise<void>| void) {
       return watchHelper.runTest(collQueryJSON(), () => {
         watchHelper.sendAddTarget();
         watchHelper.sendCurrent();
         watchHelper.sendSnapshot(++snapshotVersion);
         return watchHelper.await('snapshot')
-            .then(snapshot => watchTest(snapshot));
+            .then(snapshot => watchTest(snapshot as QuerySnapshot));
       });
     }
 
-    function nextSnapshot(baseSnapshot, watchStep) {
+    function nextSnapshot(
+        baseSnapshot: QuerySnapshot,
+        watchStep: (currentSnapshot: QuerySnapshot) =>
+            Promise<void>| void): Promise<QuerySnapshot> {
       watchStep(baseSnapshot);
       watchHelper.sendSnapshot(++snapshotVersion);
-      return watchHelper.await('snapshot');
+      return watchHelper.await('snapshot') as Promise<QuerySnapshot>;
     }
 
     it('for equal snapshots', () => {
-      let firstSnapshot;
-      let secondSnapshot;
-      let thirdSnapshot;
+      let firstSnapshot: QuerySnapshot;
+      let secondSnapshot: QuerySnapshot;
+      let thirdSnapshot: QuerySnapshot;
 
       return initialSnapshot(snapshot => {
                return nextSnapshot(
@@ -1878,7 +1904,7 @@ describe('Query watch', () => {
     });
 
     it('for equal snapshots with materialized changes', () => {
-      let firstSnapshot;
+      let firstSnapshot: QuerySnapshot;
 
       return initialSnapshot(snapshot => {
                return nextSnapshot(snapshot, () => {
@@ -1903,7 +1929,7 @@ describe('Query watch', () => {
     });
 
     it('for snapshots of different size', () => {
-      let firstSnapshot;
+      let firstSnapshot: QuerySnapshot;
 
       return initialSnapshot(snapshot => {
                return nextSnapshot(snapshot, () => {
@@ -1923,7 +1949,7 @@ describe('Query watch', () => {
     });
 
     it('for snapshots with different kind of changes', () => {
-      let firstSnapshot;
+      let firstSnapshot: QuerySnapshot;
 
       return initialSnapshot(snapshot => {
                return nextSnapshot(snapshot, () => {
@@ -1948,7 +1974,7 @@ describe('Query watch', () => {
     });
 
     it('for snapshots with different number of changes', () => {
-      let firstSnapshot;
+      let firstSnapshot: QuerySnapshot;
 
       return initialSnapshot(snapshot => {
                return nextSnapshot(
@@ -1987,7 +2013,7 @@ describe('Query watch', () => {
     });
 
     it('for snapshots with different data types', () => {
-      let originalSnapshot;
+      let originalSnapshot: QuerySnapshot;
 
       return initialSnapshot(snapshot => {
                return nextSnapshot(snapshot, () => {
@@ -2006,7 +2032,7 @@ describe('Query watch', () => {
     });
 
     it('for snapshots with different queries', () => {
-      let firstSnapshot;
+      let firstSnapshot: QuerySnapshot;
 
       return initialSnapshot(snapshot => {
                firstSnapshot = snapshot;
@@ -2019,7 +2045,7 @@ describe('Query watch', () => {
               watchHelper.sendCurrent();
               watchHelper.sendSnapshot(1);
               return watchHelper.await('snapshot').then(snapshot => {
-                expect(snapshot.isEqual(firstSnapshot)).to.be.false;
+                expect((snapshot).isEqual(firstSnapshot)).to.be.false;
               });
             });
           });
@@ -2027,9 +2053,10 @@ describe('Query watch', () => {
 
     it('for objects with different type', () => {
       return initialSnapshot(snapshot => {
-        expect(snapshot.isEqual('foo')).to.be.false;
-        expect(snapshot.isEqual({})).to.be.false;
-        expect(snapshot.isEqual(new Firestore.GeoPoint(0, 0))).to.be.false;
+        expect(snapshot.isEqual('foo' as InvalidApiUsage)).to.be.false;
+        expect(snapshot.isEqual({} as InvalidApiUsage)).to.be.false;
+        expect(snapshot.isEqual(new GeoPoint(0, 0) as InvalidApiUsage))
+            .to.be.false;
       });
     });
   });
@@ -2076,12 +2103,12 @@ describe('Query watch', () => {
 
 describe('DocumentReference watch', () => {
   // The document to query.
-  let doc;
+  let doc: DocumentReference;
 
-  let firestore;
-  let targetId;
-  let watchHelper;
-  let streamHelper;
+  let firestore: Firestore;
+  let targetId: number;
+  let watchHelper: WatchHelper<DocumentSnapshot>;
+  let streamHelper: StreamHelper;
 
   // The proto JSON that should be sent for the watch.
   const watchJSON = () => {
@@ -2097,7 +2124,7 @@ describe('DocumentReference watch', () => {
   };
 
   // The proto JSON that should be sent for a resumed query.
-  const resumeTokenJSON = resumeToken => {
+  const resumeTokenJSON = (resumeToken: Uint8Array) => {
     return {
       database: `projects/${PROJECT_ID}/databases/(default)`,
       addTarget: {
@@ -2132,10 +2159,10 @@ describe('DocumentReference watch', () => {
   });
 
   it('with invalid callbacks', () => {
-    expect(() => doc.onSnapshot('foo'))
+    expect(() => doc.onSnapshot('foo' as InvalidApiUsage))
         .to.throw('Argument "onNext" is not a valid function.');
 
-    expect(() => doc.onSnapshot(() => {}, 'foo'))
+    expect(() => doc.onSnapshot(() => {}, 'foo' as InvalidApiUsage))
         .to.throw('Argument "onError" is not a valid function.');
   });
 
@@ -2204,9 +2231,9 @@ describe('DocumentReference watch', () => {
           })
           .then(snapshot => {
             expect(snapshot.exists).to.be.true;
-            expect(snapshot.createTime.isEqual(new Firestore.Timestamp(1, 2)))
+            expect(snapshot.createTime!.isEqual(new Timestamp(1, 2)))
                 .to.be.true;
-            expect(snapshot.updateTime.isEqual(new Firestore.Timestamp(3, 1)))
+            expect(snapshot.updateTime!.isEqual(new Timestamp(3, 1)))
                 .to.be.true;
             expect(snapshot.get('foo')).to.equal('a');
 
@@ -2254,7 +2281,7 @@ describe('DocumentReference watch', () => {
   });
 
   it('reconnects after error', () => {
-    const resumeToken = [0xabcd];
+    const resumeToken = Buffer.from([0xabcd]);
 
     return watchHelper.runTest(watchJSON(), () => {
       // Mock the server responding to the watch.
@@ -2385,7 +2412,7 @@ describe('DocumentReference watch', () => {
             expect(snapshot.exists).to.be.true;
 
             // Remove the document.
-            watchHelper.sendDocRemove(doc);
+            watchHelper.sendDocRemove(doc, {foo: 'c'});
             watchHelper.sendSnapshot(3);
             return watchHelper.await('snapshot');
           })
@@ -2433,9 +2460,12 @@ describe('DocumentReference watch', () => {
 });
 
 describe('Query comparator', () => {
-  let firestore;
-  let colRef;
-  let doc1, doc2, doc3, doc4;
+  let firestore: Firestore;
+  let colRef: Query;
+  let doc1: DocumentReference;
+  let doc2: DocumentReference;
+  let doc3: DocumentReference;
+  let doc4: DocumentReference;
 
   beforeEach(() => {
     return createInstance().then(firestoreClient => {
@@ -2450,7 +2480,9 @@ describe('Query comparator', () => {
     });
   });
 
-  function testSort(query, input, expected) {
+  function testSort(
+      query: Query, input: QueryDocumentSnapshot[],
+      expected: QueryDocumentSnapshot[]) {
     const comparator = query.comparator();
     input.sort(comparator);
     docsEqual(input, expected);

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -16,19 +16,19 @@
 
 import {expect} from 'chai';
 
-import * as Firestore from '../src';
-import {createInstance} from './util/helpers';
+import {FieldValue, Firestore, setLogFunction, Timestamp, WriteBatch, WriteResult} from '../src';
+import {ApiOverride, createInstance, InvalidApiUsage} from './util/helpers';
 
 const REQUEST_TIME = 'REQUEST_TIME';
 
 // Change the argument to 'console.log' to enable debug output.
-Firestore.setLogFunction(() => {});
+setLogFunction(() => {});
 
 const PROJECT_ID = 'test-project';
 
 describe('set() method', () => {
-  let firestore;
-  let writeBatch;
+  let firestore: Firestore;
+  let writeBatch: WriteBatch;
 
   beforeEach(() => {
     return createInstance().then(firestoreClient => {
@@ -38,12 +38,12 @@ describe('set() method', () => {
   });
 
   it('requires document name', () => {
-    expect(() => writeBatch.set())
+    expect(() => (writeBatch as InvalidApiUsage).set())
         .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
   it('requires object', () => {
-    expect(() => writeBatch.set(firestore.doc('sub/doc')))
+    expect(() => (writeBatch as InvalidApiUsage).set(firestore.doc('sub/doc')))
         .to.throw(
             'Argument "data" is not a valid Firestore document. Input is not a plain JavaScript object.');
   });
@@ -54,8 +54,8 @@ describe('set() method', () => {
 });
 
 describe('delete() method', () => {
-  let firestore;
-  let writeBatch;
+  let firestore: Firestore;
+  let writeBatch: WriteBatch;
 
   beforeEach(() => {
     return createInstance().then(firestoreInstance => {
@@ -65,20 +65,20 @@ describe('delete() method', () => {
   });
 
   it('requires document name', () => {
-    expect(() => writeBatch.delete())
+    expect(() => (writeBatch as InvalidApiUsage).delete())
         .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
   it('accepts preconditions', () => {
     writeBatch.delete(firestore.doc('sub/doc'), {
-      lastUpdateTime: new Firestore.Timestamp(479978400, 123000000),
+      lastUpdateTime: new Timestamp(479978400, 123000000),
     });
   });
 });
 
 describe('update() method', () => {
-  let firestore;
-  let writeBatch;
+  let firestore: Firestore;
+  let writeBatch: WriteBatch;
 
   beforeEach(() => {
     return createInstance().then(firestoreInstance => {
@@ -88,7 +88,7 @@ describe('update() method', () => {
   });
 
   it('requires document name', () => {
-    expect(() => writeBatch.update({}, {}))
+    expect(() => writeBatch.update({} as InvalidApiUsage, {}))
         .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
@@ -103,13 +103,13 @@ describe('update() method', () => {
   it('accepts preconditions', () => {
     writeBatch.update(
         firestore.doc('sub/doc'), {foo: 'bar'},
-        {lastUpdateTime: new Firestore.Timestamp(479978400, 123000000)});
+        {lastUpdateTime: new Timestamp(479978400, 123000000)});
   });
 });
 
 describe('create() method', () => {
-  let firestore;
-  let writeBatch;
+  let firestore: Firestore;
+  let writeBatch: WriteBatch;
 
   beforeEach(() => {
     return createInstance().then(firestoreClient => {
@@ -119,13 +119,13 @@ describe('create() method', () => {
   });
 
   it('requires document name', () => {
-    expect(() => writeBatch.create())
+    expect(() => (writeBatch as InvalidApiUsage).create())
         .to.throw('Argument "documentRef" is not a valid DocumentReference.');
   });
 
   it('requires object', () => {
     expect(() => {
-      writeBatch.create(firestore.doc('sub/doc'));
+      (writeBatch as InvalidApiUsage).create(firestore.doc('sub/doc'));
     })
         .to.throw(
             'Argument "data" is not a valid Firestore document. Input is not a plain JavaScript object.');
@@ -136,11 +136,11 @@ describe('batch support', () => {
   const documentName =
       `projects/${PROJECT_ID}/databases/(default)/documents/col/doc`;
 
-  let firestore;
-  let writeBatch;
+  let firestore: Firestore;
+  let writeBatch: WriteBatch;
 
   beforeEach(() => {
-    const overrides = {
+    const overrides: ApiOverride = {
       commit: (request, options, callback) => {
         expect(request).to.deep.eq({
           database: `projects/${PROJECT_ID}/databases/(default)`,
@@ -240,21 +240,17 @@ describe('batch support', () => {
     });
   });
 
-  function verifyResponse(writeResults) {
-    expect(writeResults[0].writeTime.isEqual(new Firestore.Timestamp(0, 0)))
-        .to.be.true;
-    expect(writeResults[1].writeTime.isEqual(new Firestore.Timestamp(1, 1)))
-        .to.be.true;
-    expect(writeResults[2].writeTime.isEqual(new Firestore.Timestamp(2, 2)))
-        .to.be.true;
-    expect(writeResults[3].writeTime.isEqual(new Firestore.Timestamp(3, 3)))
-        .to.be.true;
+  function verifyResponse(writeResults: WriteResult[]) {
+    expect(writeResults[0].writeTime.isEqual(new Timestamp(0, 0))).to.be.true;
+    expect(writeResults[1].writeTime.isEqual(new Timestamp(1, 1))).to.be.true;
+    expect(writeResults[2].writeTime.isEqual(new Timestamp(2, 2))).to.be.true;
+    expect(writeResults[3].writeTime.isEqual(new Timestamp(3, 3))).to.be.true;
   }
 
   it('accepts multiple operations', () => {
     const documentName = firestore.doc('col/doc');
 
-    writeBatch.set(documentName, {foo: Firestore.FieldValue.serverTimestamp()});
+    writeBatch.set(documentName, {foo: FieldValue.serverTimestamp()});
     writeBatch.update(documentName, {foo: 'bar'});
     writeBatch.create(documentName, {});
     writeBatch.delete(documentName);
@@ -267,8 +263,7 @@ describe('batch support', () => {
   it('chains multiple operations', () => {
     const documentName = firestore.doc('col/doc');
 
-    return writeBatch
-        .set(documentName, {foo: Firestore.FieldValue.serverTimestamp()})
+    return writeBatch.set(documentName, {foo: FieldValue.serverTimestamp()})
         .update(documentName, {foo: 'bar'})
         .create(documentName, {})
         .delete(documentName)
@@ -297,7 +292,7 @@ describe('batch support', () => {
     const documentName = firestore.doc('col/doc');
 
     const batch = firestore.batch();
-    batch.set(documentName, {foo: Firestore.FieldValue.serverTimestamp()});
+    batch.set(documentName, {foo: FieldValue.serverTimestamp()});
     batch.update(documentName, {foo: 'bar'});
     batch.create(documentName, {});
     batch.delete(documentName);
@@ -314,7 +309,7 @@ describe('batch support', () => {
     const documentName = firestore.doc('col/doc');
 
     const batch = firestore.batch();
-    batch.set(documentName, {foo: Firestore.FieldValue.serverTimestamp()});
+    batch.set(documentName, {foo: FieldValue.serverTimestamp()});
     batch.update(documentName, {foo: 'bar'});
     batch.create(documentName, {});
     batch.delete(documentName);
@@ -322,7 +317,7 @@ describe('batch support', () => {
   });
 
   it('can return same write result', () => {
-    const overrides = {
+    const overrides: ApiOverride = {
       commit: (request, options, callback) => {
         callback(null, {
           commitTime: {
@@ -365,12 +360,12 @@ describe('batch support', () => {
     let beginCalled = 0;
     let commitCalled = 0;
 
-    const overrides = {
+    const overrides: ApiOverride = {
       beginTransaction: (actual, options, callback) => {
         ++beginCalled;
-        callback(null, {transaction: 'foo'});
+        callback(null, {transaction: Buffer.from('foo')});
       },
-      commit: (actual, options, callback) => {
+      commit: (request, options, callback) => {
         ++commitCalled;
         callback(null, {
           commitTime: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": false, // TODO: Remove when all source are migrated to TS
-    "outDir": "build",
-    "noImplicitAny": false, // TODO: Remove when all source are migrated to TS
+    "outDir": "build"
   },
   "include": [
+    "dev/src/*.d.ts",
     "dev/src/*.ts",
     "dev/src/**/*.js",
     "dev/test/*.js",


### PR DESCRIPTION
This removes `no-implicit-any` from the SDK.

Fixes: https://github.com/googleapis/nodejs-firestore/issues/525