### PR TITLE
Remove unhandled Promise rejection warning

### DIFF
--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -24,7 +24,7 @@ const version = require('../../package.json').version;
 class DeferredPromise<T> {
   resolve: Function;
   reject: Function;
-  promise: Promise<T>;
+  promise: Promise<T>|null;
 
   constructor() {
     this.resolve = () => {
@@ -33,8 +33,7 @@ class DeferredPromise<T> {
     this.reject = () => {
       throw new Error('DeferredPromise.reject has not been initialized');
     };
-    this.promise =
-        Promise.reject('DeferredPromise.promise has not been initialized');
+    this.promise = null;
   }
 }
 
@@ -666,8 +665,7 @@ describe('DocumentReference class', () => {
   });
 
   describe('watch', () => {
-    const currentDeferred = new DeferredPromise();
-
+    const currentDeferred = new DeferredPromise<DocumentSnapshot>();
 
     function resetPromise() {
       currentDeferred.promise = new Promise((resolve, reject) => {
@@ -677,7 +675,7 @@ describe('DocumentReference class', () => {
     }
 
     function waitForSnapshot(): Promise<DocumentSnapshot> {
-      return currentDeferred.promise.then(snapshot => {
+      return currentDeferred.promise!.then(snapshot => {
         resetPromise();
         return snapshot as DocumentSnapshot;
       });
@@ -1187,7 +1185,7 @@ describe('Query class', () => {
     }
 
     function waitForSnapshot(): Promise<QuerySnapshot> {
-      return currentDeferred.promise.then(snapshot => {
+      return currentDeferred.promise!.then(snapshot => {
         resetPromise();
         return snapshot;
       });


### PR DESCRIPTION
In #553, I added type information to `DeferredPromise`. As part of this, I changed the initialization in the constructor to `Promise.reject()` since I no longer know the value type. Turns out that that logs a bunch of "unhandled promise rejection" warnings. This PR makes the Promise nullable and defers the initialization. It's not the cleanest solution, but it's test-only code that isn't reused... 