### PR TITLE
Don't call stream.end() on Watch ended by server

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -33,7 +33,7 @@ import {Timestamp} from './timestamp';
 import {DocumentData, OrderByDirection, Precondition, SetOptions, UpdateData, WhereFilterOp} from './types';
 import {autoId, requestTag} from './util';
 import {invalidArgumentMessage, validateEnumValue, validateFunction, validateInteger, validateMinNumberOfArguments} from './validate';
-import {Watch} from './watch';
+import {DocumentWatch, QueryWatch} from './watch';
 import {validateDocumentData, WriteBatch, WriteResult} from './write-batch';
 
 import api = proto.google.firestore.v1;
@@ -448,7 +448,7 @@ export class DocumentReference {
     validateFunction('onNext', onNext);
     validateFunction('onError', onError, {optional: true});
 
-    const watch = Watch.forDocument(this);
+    const watch = new DocumentWatch(this.firestore, this);
 
     return watch.onSnapshot((readTime, size, docs) => {
       for (const document of docs()) {
@@ -1685,7 +1685,7 @@ export class Query {
     validateFunction('onNext', onNext);
     validateFunction('onError', onError, {optional: true});
 
-    const watch = Watch.forQuery(this);
+    const watch = new QueryWatch(this.firestore, this);
 
     return watch.onSnapshot((readTime, size, docs, changes) => {
       onNext(new QuerySnapshot(this, readTime, size, docs, changes));

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -209,7 +209,7 @@ class DeferredListener<T> {
  */
 class StreamHelper {
   private readonly deferredListener =
-      new DeferredListener<api.IListenResponse>();
+      new DeferredListener<api.IListenRequest>();
   private backendStream: NodeJS.ReadWriteStream|null = null;
 
   streamCount = 0;  // The number of streams that the client has requested
@@ -242,12 +242,12 @@ class StreamHelper {
   /**
    * Returns a Promise with the next results from the underlying stream.
    */
-  await(type: string): Promise<api.IListenResponse|Error|undefined> {
+  await(type: string): Promise<api.IListenRequest|Error|undefined> {
     return this.deferredListener.await(type);
   }
 
   /** Waits for a destroyed stream to be re-opened. */
-  awaitReopen(): Promise<api.IListenResponse> {
+  awaitReopen(): Promise<api.IListenRequest> {
     return this.await('error')
         .then(() => this.await('close'))
         .then(() => this.awaitOpen());
@@ -257,9 +257,9 @@ class StreamHelper {
    * Waits for the stream to open and to receive its first message (the
    * AddTarget message).
    */
-  awaitOpen(): Promise<api.IListenResponse> {
+  awaitOpen(): Promise<api.IListenRequest> {
     return this.await('open').then(() => {
-      return this.await('data') as api.IListenResponse;
+      return this.await('data') as api.IListenRequest;
     });
   }
 
@@ -733,16 +733,10 @@ describe('Query watch', () => {
       return watchHelper.await('snapshot')
           .then(() => {
             streamHelper.close();
-            return streamHelper.await('end');
-          })
-          .then(() => {
             return streamHelper.awaitOpen();
           })
           .then(() => {
             streamHelper.close();
-            return streamHelper.await('end');
-          })
-          .then(() => {
             return streamHelper.awaitOpen();
           })
           .then(() => {
@@ -769,9 +763,6 @@ describe('Query watch', () => {
         })
         .then(() => {
           streamHelper.close();
-          return streamHelper.await('end');
-        })
-        .then(() => {
           unsubscribe();
           expect(streamHelper.streamCount).to.equal(1);
         });


### PR DESCRIPTION
This is part of https://github.com/googleapis/nodejs-firestore/pull/564

The changes in #564 to make `formattedName()` async changed a lot of the timing in the Watch code and uncovered an issue with the way we close streams. We should only call `stream.end()` if the SDK closes the stream. If the server closes the stream we don't call end() - if we do, we get an exception (that was previously swallowed).

This PR also introduces subclasses for Watch that provide the Target Proto and the Comaprator. This makes it possible to construct these after initialization time and to return a Promise.