### PR TITLE
Make formattedName a method

### DIFF
--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -448,7 +448,7 @@ export class DocumentSnapshot {
   toProto(): api.IWrite|null {
     return {
       update: {
-        name: this._ref.formattedName,
+        name: this._ref.formattedName(),
         fields: this._fieldsProto,
       },
     };
@@ -810,7 +810,7 @@ export class DocumentMask {
 
     const encodedPaths: string[] = [];
     for (const fieldPath of this._sortedPaths) {
-      encodedPaths.push(fieldPath.formattedName);
+      encodedPaths.push(fieldPath.formattedName());
     }
 
     return {
@@ -947,9 +947,10 @@ export class DocumentTransform {
       protoTransforms.push(transform.toProto(serializer, path));
     });
 
+    const document = this.ref.formattedName();
     return {
       transform: {
-        document: this.ref.formattedName,
+        document,
         fieldTransforms: protoTransforms,
       },
     };

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -270,7 +270,7 @@ class ServerTimestampTransform extends FieldTransform {
   toProto(serializer: Serializer, fieldPath: FieldPath):
       api.DocumentTransform.IFieldTransform {
     return {
-      fieldPath: fieldPath.formattedName,
+      fieldPath: fieldPath.formattedName(),
       setToServerValue: 'REQUEST_TIME',
     };
   }
@@ -316,7 +316,7 @@ class ArrayUnionTransform extends FieldTransform {
       api.DocumentTransform.IFieldTransform {
     const encodedElements = serializer.encodeValue(this.elements)!.arrayValue!;
     return {
-      fieldPath: fieldPath.formattedName,
+      fieldPath: fieldPath.formattedName(),
       appendMissingElements: encodedElements
     };
   }
@@ -369,7 +369,7 @@ class ArrayRemoveTransform extends FieldTransform {
       api.DocumentTransform.IFieldTransform {
     const encodedElements = serializer.encodeValue(this.elements)!.arrayValue!;
     return {
-      fieldPath: fieldPath.formattedName,
+      fieldPath: fieldPath.formattedName(),
       removeAllFromArray: encodedElements
     };
   }

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -68,15 +68,6 @@ abstract class Path<T> {
   constructor(protected readonly segments: string[]) {}
 
   /**
-   * String representation as expected by the proto API.
-   *
-   * @private
-   */
-  get formattedName(): string {
-    return this.canonicalString()!;
-  }
-
-  /**
    * Returns the number of segments of this field path.
    *
    * @private
@@ -86,7 +77,6 @@ abstract class Path<T> {
   }
 
   abstract construct(segments: string[]|string): T;
-  abstract canonicalString(): string;
   abstract split(relativePath: string): string[];
 
   /**
@@ -136,16 +126,6 @@ abstract class Path<T> {
     }
 
     return true;
-  }
-
-  /**
-   * Returns a string representation of this path.
-   *
-   * @private
-   * @returns A string representing this path.
-   */
-  toString(): string {
-    return this.formattedName;
   }
 
   /**
@@ -203,7 +183,6 @@ abstract class Path<T> {
  * within Firestore.
  *
  * @private
- * @class
  */
 export class ResourcePath extends Path<ResourcePath> {
   /**
@@ -219,9 +198,6 @@ export class ResourcePath extends Path<ResourcePath> {
   /**
    * Constructs a Firestore Resource Path.
    *
-   * @private
-   * @hideconstructor
-   *
    * @param projectId The Firestore project id.
    * @param databaseId The Firestore database id.
    * @param segments Sequence of names of the parts of the path.
@@ -235,9 +211,6 @@ export class ResourcePath extends Path<ResourcePath> {
 
   /**
    * String representation of the path relative to the database root.
-   *
-   * @private
-   * @type {string}
    */
   get relativeName(): string {
     return this.segments.join('/');
@@ -279,9 +252,8 @@ export class ResourcePath extends Path<ResourcePath> {
   /**
    * Creates a resource path from an absolute Firestore path.
    *
-   * @private
-   * @param {string} absolutePath A string representation of a Resource Path.
-   * @returns {ResourcePath} The new ResourcePath.
+   * @param absolutePath A string representation of a Resource Path.
+   * @returns The new ResourcePath.
    */
   static fromSlashSeparatedString(absolutePath: string): ResourcePath {
     const elements = RESOURCE_PATH_RE.exec(absolutePath);
@@ -313,11 +285,9 @@ export class ResourcePath extends Path<ResourcePath> {
   /**
    * String representation of a ResourcePath as expected by the API.
    *
-   * @private
-   * @override
-   * @returns {string} The representation as expected by the API.
+   * @returns The representation as expected by the API.
    */
-  canonicalString(): string {
+  formattedName(): string {
     const components = [
       'projects', this.projectId, 'databases', this.databaseId, 'documents',
       ...this.segments
@@ -330,10 +300,7 @@ export class ResourcePath extends Path<ResourcePath> {
    * the normal constructor because polymorphic 'this' doesn't work on static
    * methods.
    *
-   * @private
-   * @override
-   * @param {Array.<string>} segments Sequence of names of the parts of the
-   * path.
+   * @param segments Sequence of names of the parts of the path.
    * @returns {ResourcePath} The newly created ResourcePath.
    */
   construct(segments: string[]): ResourcePath {
@@ -375,12 +342,10 @@ export class ResourcePath extends Path<ResourcePath> {
 
   /**
    * Converts this ResourcePath to the Firestore Proto representation.
-   *
-   * @private
    */
   toProto(): api.IValue {
     return {
-      referenceValue: this.formattedName,
+      referenceValue: this.formattedName(),
     };
   }
 }
@@ -489,7 +454,7 @@ export class FieldPath extends Path<FieldPath> {
    * @override
    * @returns {string} The representation as expected by the API.
    */
-  canonicalString(): string {
+  formattedName(): string {
     return this.segments
         .map(str => {
           return UNESCAPED_FIELD_NAME_RE.test(str) ?
@@ -497,6 +462,16 @@ export class FieldPath extends Path<FieldPath> {
               '`' + str.replace('\\', '\\\\').replace('`', '\\`') + '`';
         })
         .join('.');
+  }
+
+  /**
+   * Returns a string representation of this path.
+   *
+   * @private
+   * @returns A string representing this path.
+   */
+  toString(): string {
+    return this.formattedName();
   }
 
   /**

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -113,8 +113,8 @@ export class DocumentReference {
    * @type {string}
    * @name DocumentReference#formattedName
    */
-  get formattedName(): string {
-    return this._path.formattedName;
+  formattedName(): string {
+    return this._path.formattedName();
   }
 
   /**
@@ -255,7 +255,7 @@ export class DocumentReference {
    * });
    */
   listCollections(): Promise<CollectionReference[]> {
-    const request = {parent: this._path.formattedName};
+    const request = {parent: this._path.formattedName()};
 
     return this._firestore
         .request<string[]>(
@@ -487,7 +487,7 @@ export class DocumentReference {
    * @private
    */
   toProto(): api.IValue {
-    return {referenceValue: this.formattedName};
+    return {referenceValue: this.formattedName()};
   }
 }
 
@@ -515,7 +515,7 @@ class FieldOrder {
   toProto(): api.StructuredQuery.IOrder {
     return {
       field: {
-        fieldPath: this.field.formattedName,
+        fieldPath: this.field.formattedName(),
       },
       direction: this.direction,
     };
@@ -564,11 +564,13 @@ class FieldFilter {
    * @private
    */
   toProto(): api.StructuredQuery.IFilter {
+    const fieldPath = this.field.formattedName();
+
     if (typeof this.value === 'number' && isNaN(this.value)) {
       return {
         unaryFilter: {
           field: {
-            fieldPath: this.field.formattedName,
+            fieldPath,
           },
           op: 'IS_NAN'
         },
@@ -579,7 +581,7 @@ class FieldFilter {
       return {
         unaryFilter: {
           field: {
-            fieldPath: this.field.formattedName,
+            fieldPath,
           },
           op: 'IS_NULL',
         },
@@ -589,7 +591,7 @@ class FieldFilter {
     return {
       fieldFilter: {
         field: {
-          fieldPath: this.field.formattedName,
+          fieldPath,
         },
         op: this.op,
         value: this.serializer.encodeValue(this.value),
@@ -952,8 +954,8 @@ export class Query {
    * The string representation of the Query's location.
    * @private
    */
-  get formattedName(): string {
-    return this._path.formattedName;
+  formattedName(): string {
+    return this._path.formattedName();
   }
 
   /**
@@ -969,7 +971,7 @@ export class Query {
    *
    * collectionRef.add({foo: 'bar'}).then(documentReference => {
    *   let firestore = documentReference.firestore;
-   *   console.log(`Root location for document is ${firestore.formattedName}`);
+   *   console.log(`Root location for document is ${firestore.path}`);
    * });
    */
   get firestore(): Firestore {
@@ -1054,12 +1056,12 @@ export class Query {
     const fields: api.StructuredQuery.IFieldReference[] = [];
 
     if (fieldPaths.length === 0) {
-      fields.push({fieldPath: FieldPath.documentId().formattedName});
+      fields.push({fieldPath: FieldPath.documentId().formattedName()});
     } else {
       for (let i = 0; i < fieldPaths.length; ++i) {
         validateFieldPath(i, fieldPaths[i]);
         fields.push(
-            {fieldPath: FieldPath.fromArgument(fieldPaths[i]).formattedName});
+            {fieldPath: FieldPath.fromArgument(fieldPaths[i]).formattedName()});
       }
     }
 
@@ -1294,7 +1296,7 @@ export class Query {
    * Throws a validation error or returns a DocumentReference that can
    * directly be used in the Query.
    *
-   * @param reference The value to validate.
+   * @param val The value to validate.
    * @throws If the value cannot be used for this query.
    * @return If valid, returns a DocumentReference that can be used with the
    * query.
@@ -1566,7 +1568,7 @@ export class Query {
    */
   toProto(transactionId?: Uint8Array): api.IRunQueryRequest {
     const reqOpts: api.IRunQueryRequest = {
-      parent: this._path.parent()!.formattedName,
+      parent: this._path.parent()!.formattedName(),
       structuredQuery: {
         from: [
           {
@@ -1833,7 +1835,7 @@ export class CollectionReference extends Query {
    */
   listDocuments(): Promise<DocumentReference[]> {
     const request: api.IListDocumentsRequest = {
-      parent: this._path.parent()!.formattedName,
+      parent: this._path.parent()!.formattedName(),
       collectionId: this.id,
       showMissing: true,
       mask: {fieldPaths: []}

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -309,7 +309,7 @@ export function validateUserInput(
   level = level || 0;
   inArray = inArray || false;
 
-  const fieldPathMessage = path ? ` (found in field ${path.toString()})` : '';
+  const fieldPathMessage = path ? ` (found in field ${path})` : '';
 
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; ++i) {

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -315,10 +315,9 @@ export class Transaction {
    *
    * @private
    */
-  begin(): Promise<void> {
-    const request: api.IBeginTransactionRequest = {
-      database: this._firestore.formattedName,
-    };
+  async begin(): Promise<void> {
+    const database = await this._firestore.formattedName();
+    const request: api.IBeginTransactionRequest = {database};
 
     if (this._previousTransaction) {
       request.options = {
@@ -355,9 +354,10 @@ export class Transaction {
    *
    * @private
    */
-  rollback(): Promise<void> {
+  async rollback(): Promise<void> {
+    const database = await this._firestore.formattedName();
     const request = {
-      database: this._firestore.formattedName,
+      database,
       transaction: this._transactionId,
     };
 

--- a/dev/src/validate.ts
+++ b/dev/src/validate.ts
@@ -47,7 +47,7 @@ export interface NumericRangeOptions {
  */
 export function customObjectMessage(
     arg: string|number, value: unknown, path?: FieldPath): string {
-  const fieldPathMessage = path ? ` (found in field ${path.toString()})` : '';
+  const fieldPathMessage = path ? ` (found in field ${path})` : '';
 
   if (isObject(value)) {
     const typeName = value.constructor.name;

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -257,7 +257,7 @@ export class Watch {
     return new Watch(
         documentRef.firestore, {
           documents: {
-            documents: [documentRef.formattedName],
+            documents: [documentRef.formattedName()],
           },
           targetId: WATCH_TARGET_ID,
         },
@@ -368,7 +368,7 @@ export class Watch {
     const REMOVED = {} as DocumentSnapshotBuilder;
 
     const request: api.IListenRequest = {
-      database: this._firestore.formattedName,
+      database: this._firestore.formattedName(),
       addTarget: this._target,
     };
 
@@ -387,7 +387,7 @@ export class Watch {
       docTree.forEach((snapshot: QueryDocumentSnapshot) => {
         // Mark each document as deleted. If documents are not deleted, they
         // will be send again by the server.
-        changeMap.set(snapshot.ref.formattedName, REMOVED);
+        changeMap.set(snapshot.ref.formattedName(), REMOVED);
       });
 
       current = false;
@@ -567,7 +567,7 @@ export class Watch {
            * @private
            */
           function addDoc(newDocument: QueryDocumentSnapshot): DocumentChange {
-            const name = newDocument.ref.formattedName;
+            const name = newDocument.ref.formattedName();
             assert(!updatedMap.has(name), 'Document to add already exists');
             updatedTree = updatedTree.insert(newDocument, null);
             const newIndex = updatedTree.find(newDocument).index;
@@ -584,7 +584,7 @@ export class Watch {
            */
           function modifyDoc(newDocument: QueryDocumentSnapshot):
               DocumentChange|null {
-            const name = newDocument.ref.formattedName;
+            const name = newDocument.ref.formattedName();
             assert(updatedMap.has(name), 'Document to modify does not exist');
             const oldDocument = updatedMap.get(name)!;
             if (!oldDocument.updateTime.isEqual(newDocument.updateTime)) {

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -1153,7 +1153,7 @@ describe('Query class', () => {
       const ref = randomCol.doc(id);
       return randomCol.firestore.snapshot_(
           {
-            name: ref.formattedName,
+            name: ref.formattedName(),
             fields: ref.firestore._serializer!.encodeFields(data),
             createTime: {seconds: 0, nanos: 0},
             updateTime: {seconds: 0, nanos: 0},

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -320,7 +320,7 @@ describe('instantiation', () => {
     const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
 
     return firestore['_runRequest'](() => {
-      expect(firestore.formattedName)
+      expect(firestore.formattedName())
           .to.equal(`projects/${PROJECT_ID}/databases/(default)`);
       return Promise.resolve();
     });
@@ -332,13 +332,13 @@ describe('instantiation', () => {
       keyFilename: __dirname + '/fake-certificate.json',
     });
 
-    expect(firestore.formattedName)
+    expect(firestore.formattedName())
         .to.equal('projects/{{projectId}}/databases/(default)');
 
     firestore['_detectProjectId'] = () => Promise.resolve(PROJECT_ID);
 
     return firestore['_runRequest'](() => {
-      expect(firestore.formattedName)
+      expect(firestore.formattedName())
           .to.equal(`projects/${PROJECT_ID}/databases/(default)`);
       return Promise.resolve();
     });
@@ -350,7 +350,7 @@ describe('instantiation', () => {
       keyFilename: './test/fake-certificate.json',
     });
 
-    expect(firestore.formattedName)
+    expect(firestore.formattedName())
         .to.equal('projects/{{projectId}}/databases/(default)');
 
     const gapicClient = {
@@ -371,7 +371,7 @@ describe('instantiation', () => {
 
     firestore.settings({projectId: PROJECT_ID});
 
-    expect(firestore.formattedName)
+    expect(firestore.formattedName())
         .to.equal(`projects/${PROJECT_ID}/databases/(default)`);
   });
 
@@ -458,8 +458,8 @@ describe('snapshot_() method', () => {
     const expected = extend(true, {}, allSupportedTypesOutput);
     // Deep Equal doesn't support matching instances of DocumentRefs, so we
     // compare them manually and remove them from the resulting object.
-    expect(actualObject.get('pathValue').formattedName)
-        .to.equal(expected.pathValue.formattedName);
+    expect(actualObject.get('pathValue').formattedName())
+        .to.equal(expected.pathValue.formattedName());
     const data = actualObject.data()!;
     delete data.pathValue;
     delete expected.pathValue;
@@ -708,10 +708,10 @@ describe('getAll() method', () => {
 
       if (doc.found) {
         expect(result[i].exists).to.be.true;
-        expect(result[i].ref.formattedName).to.equal(doc.found.name);
+        expect(result[i].ref.formattedName()).to.equal(doc.found.name);
       } else {
         expect(result[i].exists).to.be.false;
-        expect(result[i].ref.formattedName).to.equal(doc.missing);
+        expect(result[i].ref.formattedName()).to.equal(doc.missing);
       }
     }
   }

--- a/dev/test/path.ts
+++ b/dev/test/path.ts
@@ -30,25 +30,25 @@ describe('ResourcePath', () => {
 
   it('has append() method', () => {
     let path = new ResourcePath(PROJECT_ID, '(default)');
-    expect(path.formattedName).to.equal(`${DATABASE_ROOT}/documents`);
+    expect(path.formattedName()).to.equal(`${DATABASE_ROOT}/documents`);
     path = path.append('foo');
-    expect(path.formattedName).to.equal(`${DATABASE_ROOT}/documents/foo`);
+    expect(path.formattedName()).to.equal(`${DATABASE_ROOT}/documents/foo`);
   });
 
   it('has parent() method', () => {
     let path = new ResourcePath(PROJECT_ID, '(default)', 'foo');
-    expect(path.formattedName).to.equal(`${DATABASE_ROOT}/documents/foo`);
+    expect(path.formattedName()).to.equal(`${DATABASE_ROOT}/documents/foo`);
     path = path.parent()!;
-    expect(path.formattedName).to.equal(`${DATABASE_ROOT}/documents`);
+    expect(path.formattedName()).to.equal(`${DATABASE_ROOT}/documents`);
     expect(path.parent()).to.be.null;
   });
 
   it('parses strings', () => {
     let path = ResourcePath.fromSlashSeparatedString(DATABASE_ROOT);
-    expect(path.formattedName).to.equal(`${DATABASE_ROOT}/documents`);
+    expect(path.formattedName()).to.equal(`${DATABASE_ROOT}/documents`);
     path =
         ResourcePath.fromSlashSeparatedString(`${DATABASE_ROOT}/documents/foo`);
-    expect(path.formattedName).to.equal(`${DATABASE_ROOT}/documents/foo`);
+    expect(path.formattedName()).to.equal(`${DATABASE_ROOT}/documents/foo`);
     expect(() => {
       path =
           ResourcePath.fromSlashSeparatedString('projects/project/databases');
@@ -58,7 +58,8 @@ describe('ResourcePath', () => {
   it('accepts newlines', () => {
     const path = ResourcePath.fromSlashSeparatedString(
         `${DATABASE_ROOT}/documents/foo\nbar`);
-    expect(path.formattedName).to.equal(`${DATABASE_ROOT}/documents/foo\nbar`);
+    expect(path.formattedName())
+        .to.equal(`${DATABASE_ROOT}/documents/foo\nbar`);
   });
 });
 
@@ -88,18 +89,18 @@ describe('FieldPath', () => {
   it('has append() method', () => {
     let path = new FieldPath('foo');
     path = path.append('bar');
-    expect(path.formattedName).to.equal('foo.bar');
+    expect(path.formattedName()).to.equal('foo.bar');
   });
 
   it('has parent() method', () => {
     let path = new FieldPath('foo', 'bar');
     path = path.parent()!;
-    expect(path.formattedName).to.equal('foo');
+    expect(path.formattedName()).to.equal('foo');
   });
 
   it('escapes special characters', () => {
     const path = new FieldPath('f.o.o');
-    expect(path.formattedName).to.equal('`f.o.o`');
+    expect(path.formattedName()).to.equal('`f.o.o`');
   });
 
   it('doesn\'t allow empty components', () => {

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -441,7 +441,7 @@ class WatchHelper<T = QuerySnapshot | DocumentSnapshot> {
     this.streamHelper.write({
       documentChange: {
         document: {
-          name: ref.formattedName,
+          name: ref.formattedName(),
           fields: this.serializer.encodeFields(data),
           createTime: {seconds: 1, nanos: 2},
           updateTime: {seconds: 3, nanos: this.snapshotVersion},
@@ -461,7 +461,7 @@ class WatchHelper<T = QuerySnapshot | DocumentSnapshot> {
     this.streamHelper.write({
       documentChange: {
         document: {
-          name: ref.formattedName,
+          name: ref.formattedName(),
           fields: this.serializer.encodeFields(data),
         },
         removedTargetIds: [this.targetId],
@@ -477,7 +477,7 @@ class WatchHelper<T = QuerySnapshot | DocumentSnapshot> {
   sendDocDelete(ref: DocumentReference): void {
     this.streamHelper.write({
       documentDelete: {
-        document: ref.formattedName,
+        document: ref.formattedName(),
         removedTargetIds: [this.targetId],
       },
     });
@@ -1798,7 +1798,7 @@ describe('Query watch', () => {
             streamHelper.write({
               documentChange: {
                 document: {
-                  name: doc1.formattedName,
+                  name: doc1.formattedName(),
                   fields: watchHelper.serializer.encodeFields({foo: 'a'}),
                   createTime: {seconds: 1, nanos: 2},
                   updateTime: {seconds: 3, nanos: 5},
@@ -2116,7 +2116,7 @@ describe('DocumentReference watch', () => {
       database: `projects/${PROJECT_ID}/databases/(default)`,
       addTarget: {
         documents: {
-          documents: [doc.formattedName],
+          documents: [doc.formattedName()],
         },
         targetId,
       },
@@ -2129,7 +2129,7 @@ describe('DocumentReference watch', () => {
       database: `projects/${PROJECT_ID}/databases/(default)`,
       addTarget: {
         documents: {
-          documents: [doc.formattedName],
+          documents: [doc.formattedName()],
         },
         targetId,
         resumeToken,
@@ -2262,7 +2262,7 @@ describe('DocumentReference watch', () => {
             streamHelper.write({
               documentChange: {
                 document: {
-                  name: doc.parent.formattedName + '/wrong',
+                  name: doc.parent.formattedName() + '/wrong',
                   fields: {},
                   createTime: {seconds: 1, nanos: 2},
                   updateTime: {seconds: 3, nanos: 4},


### PR DESCRIPTION
This makes PR #564 smaller and turns formattedtName from a property to a method.  In the bigger PR, `formattedtName` returns a Promise is makes more sense as a method.

This PR also moves formattedName() from the base class to the ResourcePath and FieldPath class, as a the soon-to-be-introduced RelativePath class won't have this method. 