### PR TITLE
[fix]: allow async functions in transactions

### DIFF
--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -68,5 +68,5 @@ export function isEmpty(value: {}): boolean {
  * @private
  */
 export function isFunction(value: unknown): boolean {
-  return value && {}.toString.call(value) === '[object Function]';
+  return typeof value === 'function';
 }


### PR DESCRIPTION
Fixes #574.

The `toString()` call on an async function produces [object AsyncFunction] instead of [object Function]. This PR replaces the toString() check with the same typeof check we use in the Web SDK, which returns "function" for both. See https://github.com/lodash/lodash/issues/2768 for other examples of the same issue.

Note: The lack of tests in this PR is due to the fact that we still support Node 6 and don't use async/await in the transpiled code. It is therefore impossible to write an async Function that would trigger this failure.