### PR TITLE
feature: Adding CollectionGroup queries

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -24,7 +24,7 @@ import {DocumentSnapshot, DocumentSnapshotBuilder, QueryDocumentSnapshot} from '
 import {logger, setLibVersion} from './logger';
 import {DEFAULT_DATABASE_ID, FieldPath, QualifiedResourcePath, ResourcePath, validateResourcePath} from './path';
 import {ClientPool} from './pool';
-import {CollectionReference} from './reference';
+import {CollectionReference, Query, QueryOptions} from './reference';
 import {DocumentReference} from './reference';
 import {Serializer} from './serializer';
 import {Timestamp} from './timestamp';
@@ -435,6 +435,37 @@ export class Firestore {
     }
 
     return new CollectionReference(this, path);
+  }
+
+  /**
+   * Creates and returns a new Query that includes all documents in the
+   * database that are contained in a collection or subcollection with the
+   * given collectionId.
+   *
+   * @param {string} collectionId Identifies the collections to query over.
+   * Every collection or subcollection with this ID as the last segment of its
+   * path will be included. Cannot contain a slash.
+   * @returns {Query} The created Query.
+   *
+   * @example
+   * let docA = firestore.doc('mygroup/docA').set({foo: 'bar'});
+   * let docB = firestore.doc('abc/def/mygroup/docB').set({foo: 'bar'});
+   *
+   * Promise.all([docA, docB]).then(() => {
+   *    let query = firestore.collectionGroup('mygroup');
+   *    query = query.where('foo', '==', 'bar');
+   *    return query.get().then(snapshot => {
+   *       console.log(`Found ${snapshot.size} documents.`);
+   *    });
+   * });
+   */
+  collectionGroup(collectionId: string): Query {
+    if (collectionId.indexOf('/') !== -1) {
+      throw new Error(`Invalid collectionId '${
+          collectionId}'. Collection IDs must not contain '/'.`);
+    }
+
+    return new Query(this, QueryOptions.forCollectionGroupQuery(collectionId));
   }
 
   /**

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -907,18 +907,7 @@ export class QueryOptions {
    * Returns the union of the current and the provided options.
    * @private
    */
-  with(settings: {
-    parentPath?: ResourcePath;
-    collectionId?: string;
-    allDescendants?: boolean;
-    fieldFilters?: FieldFilter[];
-    fieldOrders?: FieldOrder[];
-    startAt?: QueryCursor;
-    endAt?: QueryCursor;
-    limit?: number;
-    offset?: number;
-    projection?: api.StructuredQuery.IProjection;
-  }): QueryOptions {
+  with(settings: Partial<QueryOptions>): QueryOptions {
     return new QueryOptions(
         coalesce(settings.parentPath, this.parentPath)!,
         coalesce(settings.collectionId, this.collectionId)!,

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -433,7 +433,7 @@ export function parseGetAllArguments(
  * @param value The input to validate.
  * @param options Options that specify whether the ReadOptions can be omitted.
  */
-export function validateReadOptions(
+function validateReadOptions(
     arg: number|string, value: unknown,
     options?: RequiredArgumentOptions): void {
   if (!validateOptional(value, options)) {

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -65,6 +65,7 @@ xdescribe('firestore.d.ts', () => {
     const collRef: CollectionReference = firestore.collection('coll');
     const docRef1: DocumentReference = firestore.doc('coll/doc');
     const docRef2: DocumentReference = firestore.doc('coll/doc');
+    const collectionGroup: Query = firestore.collectionGroup('collectionId');
     firestore.getAll(docRef1, docRef2).then((docs: DocumentSnapshot[]) => {});
     firestore.getAll(docRef1, docRef2, {})
         .then((docs: DocumentSnapshot[]) => {});

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -139,6 +139,18 @@ declare namespace FirebaseFirestore {
     doc(documentPath: string): DocumentReference;
 
     /**
+     * Creates and returns a new Query that includes all documents in the
+     * database that are contained in a collection or subcollection with the
+     * given collectionId.
+     *
+     * @param collectionId Identifies the collections to query over. Every
+     * collection or subcollection with this ID as the last segment of its path
+     * will be included. Cannot contain a slash.
+     * @return The created Query.
+     */
+    collectionGroup(collectionId: string): Query;
+
+    /**
      * Retrieves multiple documents from Firestore.
      *
      * The first argument is required and must be of type `DocumentReference`


### PR DESCRIPTION
CollectionGroup queries add support for queries to Firestore that query documents by collection ID rather than by collection path. With this feature, users can now query for documents in collections that share a name, no matter where these collection are located.

This the Node port of https://github.com/googleapis/google-cloud-java/pull/4652. The integration tests are ported from https://github.com/firebase/firebase-js-sdk/pull/1440

Note: This PR is blocked on a backend release.