### PR TITLE
fix: Fix client pooling for long-lived listens

### DIFF
--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -49,7 +49,7 @@ export class ClientPool<T> {
    *
    * @private
    */
-  private acquire(): T {
+  acquire(): T {
     let selectedClient: T|null = null;
     let selectedRequestCount = 0;
 
@@ -77,7 +77,7 @@ export class ClientPool<T> {
    * removing it from the pool of active clients.
    * @private
    */
-  private release(client: T): void {
+  release(client: T): void {
     let requestCount = this.activeClients.get(client) || 0;
     assert(requestCount > 0, 'No active request');
 

--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -90,6 +90,26 @@ export class ClientPool<T> {
   }
 
   /**
+   * Creates a new function that will release the given client, when called.
+   *
+   * This guarantees that the given client can only be released once.
+   *
+   * @private
+   */
+  createReleaser(client: T): () => void {
+    // Unfortunately, once the release() call is disconnected from the Promise
+    // returned from _initializeStream, there's no single callback in which the
+    // releaser can be guaranteed to be called once.
+    let released = false;
+    return () => {
+      if (!released) {
+        released = true;
+        this.release(client);
+      }
+    };
+  }
+
+  /**
    * The number of currently registered clients.
    *
    * @return Number of currently registered clients.


### PR DESCRIPTION
Fixes firebase/firebase-admin-node#499

Previously _initializeStream returned a Promise that indicated that the
stream was "released", i.e. that it was was ready for attaching
listeners.
    
googleapis/nodejs-firestore#256 Added pooled clients and changed the
callers of _initializeStream to reuse this promise such that when it was
resolved, the stream could be returned to the pool. This works when
listeners are short-lived, but fails when listeners run indefinitely.
    
This change arranges to release the clients back to the pool only after
the stream has completed, which allows an arbitrary number of indefinite
listens to run without problems.

This turns out to be fiendishly difficult to test given the current structure
of the code. A second pass at this that reformulates this as just another
stream that composes with the others would make this easier to understand and
test. For now, this fix unblocks the customers waiting on the referenced issue.