### PR TITLE
[docs] Further improve quickstart.js

### DIFF
--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -22,8 +22,8 @@ const Firestore = require('@google-cloud/firestore');
 const firestore = new Firestore();
 
 async function quickstart() {
+  // Obtain a document reference.
   const document = firestore.doc('posts/intro-to-firestore');
-  console.log('Document created');
 
   // Enter new data into the document.
   await document.set({

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -28,7 +28,6 @@ describe('should make some API calls',() =>{
   it('firestore_inspect_string', async () => {
       const output =  await tools.runAsync(cmd,cwd);
 
-      assert.strictEqual(output.includes('Document created'), true);
       assert.strictEqual(output.includes('Entered new data into the document'), true);
       assert.strictEqual(output.includes('Updated an existing document'), true);
       assert.strictEqual(output.includes('Read the document'), true);


### PR DESCRIPTION
To avoid confusion, I think we should remove the `Document created` console output since `firestore.doc()` merely returns a reference. It does not talk to the backend.

