### PR TITLE
fix: Support more than 100 long-lived streams

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1454,7 +1454,6 @@ export class Firestore {
         resultStream.on('error', lifetime.resolve);
 
         await this._initializeStream(resultStream, requestTag, request);
-
         result.resolve(resultStream);
       }).catch(err => {
         lifetime.resolve();

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -46,7 +46,7 @@ import {
   ReadOptions,
   Settings,
 } from './types';
-import {requestTag} from './util';
+import {Deferred, requestTag} from './util';
 import {
   validateBoolean,
   validateFunction,
@@ -58,7 +58,6 @@ import {
 import {WriteBatch} from './write-batch';
 
 import api = google.firestore.v1;
-import {Deferred} from '../test/util/helpers';
 
 export {
   CollectionReference,

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1383,6 +1383,8 @@ export class Firestore {
 
         const resultStream = bun([stream, logStream]);
         resultStream.on('close', lifetime.resolve);
+        resultStream.on('end', lifetime.resolve);
+        resultStream.on('error', lifetime.resolve);
 
         await this._initializeStream(resultStream, requestTag);
         result.resolve(resultStream);
@@ -1447,6 +1449,10 @@ export class Firestore {
 
         const resultStream = bun([requestStream, logStream]);
         resultStream.on('close', lifetime.resolve);
+        resultStream.on('finish', lifetime.resolve);
+        resultStream.on('end', lifetime.resolve);
+        resultStream.on('error', lifetime.resolve);
+
         await this._initializeStream(resultStream, requestTag, request);
 
         result.resolve(resultStream);

--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -103,6 +103,19 @@ export class ClientPool<T> {
   }
 
   /**
+   * The number of currently active operations.
+   *
+   * @return Number of currently active operations.
+   * @private
+   */
+  // Visible for testing.
+  get opCount(): number {
+    let activeOperationCount = 0;
+    this.activeClients.forEach(count => (activeOperationCount += count));
+    return activeOperationCount;
+  }
+
+  /**
    * Runs the provided operation in this pool. This function may create an
    * additional client if all existing clients already operate at the concurrent
    * operation limit.

--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -50,7 +50,7 @@ export class ClientPool<T> {
    *
    * @private
    */
-  acquire(): T {
+  private acquire(): T {
     let selectedClient: T | null = null;
     let selectedRequestCount = 0;
 
@@ -79,7 +79,7 @@ export class ClientPool<T> {
    * removing it from the pool of active clients.
    * @private
    */
-  release(client: T): void {
+  private release(client: T): void {
     let requestCount = this.activeClients.get(client) || 0;
     assert(requestCount > 0, 'No active request');
 
@@ -89,26 +89,6 @@ export class ClientPool<T> {
     if (requestCount === 0) {
       this.garbageCollect();
     }
-  }
-
-  /**
-   * Creates a new function that will release the given client, when called.
-   *
-   * This guarantees that the given client can only be released once.
-   *
-   * @private
-   */
-  createReleaser(client: T): () => void {
-    // Unfortunately, once the release() call is disconnected from the Promise
-    // returned from _initializeStream, there's no single callback in which the
-    // releaser can be guaranteed to be called once.
-    let released = false;
-    return () => {
-      if (!released) {
-        released = true;
-        this.release(client);
-      }
-    };
   }
 
   /**

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -14,6 +14,25 @@
  * limitations under the License.
  */
 
+/** A Promise implementation that supports deferred resolution. */
+export class Deferred<R> {
+  promise: Promise<R>;
+  resolve: (value?: R | Promise<R>) => void = () => {};
+  reject: (reason?: Error) => void = () => {};
+
+  constructor() {
+    this.promise = new Promise(
+      (
+        resolve: (value?: R | Promise<R>) => void,
+        reject: (reason?: Error) => void
+      ) => {
+        this.resolve = resolve;
+        this.reject = reject;
+      }
+    );
+  }
+}
+
 /**
  * Generate a unique client-side identifier.
  *

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -31,7 +31,7 @@ import {
   Timestamp,
 } from '../src';
 import {autoId} from '../src/util';
-import {Deferred} from '../test/util/helpers';
+import {Deferred, verifyInstance} from '../test/util/helpers';
 
 const version = require('../../package.json').version;
 
@@ -67,6 +67,8 @@ describe('Firestore class', () => {
     firestore = new Firestore({});
     randomCol = getTestRoot(firestore);
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('has collection() method', () => {
     const ref = firestore.collection('col');
@@ -137,6 +139,8 @@ describe('CollectionReference class', () => {
     randomCol = getTestRoot(firestore);
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('has firestore property', () => {
     const ref = firestore.collection('col');
     expect(ref.firestore).to.be.an.instanceOf(Firestore);
@@ -202,6 +206,8 @@ describe('DocumentReference class', () => {
     firestore = new Firestore({});
     randomCol = getTestRoot(firestore);
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('has firestore property', () => {
     const ref = firestore.doc('col/doc');
@@ -840,20 +846,22 @@ describe('DocumentReference class', () => {
       const exists1 = [false, true, false];
       const exists2 = [false, true, false];
 
+      const promises: Array<Promise<WriteResult>> = [];
+
       // Code blocks to run after each step.
       const run = [
         () => {
-          doc1.set({foo: 'foo'});
-          doc2.set({foo: 'foo'});
+          promises.push(doc1.set({foo: 'foo'}));
+          promises.push(doc2.set({foo: 'foo'}));
         },
         () => {
-          doc1.delete();
-          doc2.delete();
+          promises.push(doc1.delete());
+          promises.push(doc2.delete());
         },
         () => {
           unsubscribe1();
           unsubscribe2();
-          done();
+          Promise.all(promises).then(() => done());
         },
       ];
 
@@ -883,18 +891,20 @@ describe('DocumentReference class', () => {
       const exists1 = [false, true, false];
       const exists2 = [false, true, false];
 
+      const promises: Array<Promise<WriteResult>> = [];
+
       // Code blocks to run after each step.
       const run = [
         () => {
-          doc.set({foo: 'foo'});
+          promises.push(doc.set({foo: 'foo'}));
         },
         () => {
-          doc.delete();
+          promises.push(doc.delete());
         },
         () => {
           unsubscribe1();
           unsubscribe2();
-          done();
+          Promise.all(promises).then(() => done());
         },
       ];
 
@@ -984,6 +994,8 @@ describe('Query class', () => {
     firestore = new Firestore({});
     randomCol = getTestRoot(firestore);
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('has firestore property', () => {
     const ref = randomCol.limit(0);
@@ -1655,6 +1667,8 @@ describe('Transaction class', () => {
     randomCol = getTestRoot(firestore);
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('has get() method', () => {
     const ref = randomCol.doc('doc');
     return ref
@@ -1835,6 +1849,8 @@ describe('WriteBatch class', () => {
     randomCol = getTestRoot(firestore);
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('supports empty batches', () => {
     return firestore.batch().commit();
   });
@@ -1943,6 +1959,8 @@ describe('QuerySnapshot class', () => {
       return randomCol.get();
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('has query property', () => {
     return querySnapshot

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -30,8 +30,8 @@ import {
   setLogFunction,
   Timestamp,
 } from '../src';
-import {autoId} from '../src/util';
-import {Deferred, verifyInstance} from '../test/util/helpers';
+import {autoId, Deferred} from '../src/util';
+import {verifyInstance} from '../test/util/helpers';
 
 const version = require('../../package.json').version;
 

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -23,6 +23,7 @@ import {
   DATABASE_ROOT,
   document,
   InvalidApiUsage,
+  verifyInstance,
 } from './util/helpers';
 
 // Change the argument to 'console.log' to enable debug output.
@@ -36,6 +37,8 @@ describe('Collection interface', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('has doc() method', () => {
     const collectionRef = firestore.collection('colId');

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -42,6 +42,7 @@ import {
   stream,
   update,
   updateMask,
+  verifyInstance,
   writeResult,
 } from './util/helpers';
 
@@ -68,6 +69,8 @@ describe('DocumentReference interface', () => {
       documentRef = firestore.doc('collectionId/documentId');
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('has collection() method', () => {
     expect(() => documentRef.collection(42 as InvalidApiUsage)).to.throw(
@@ -110,6 +113,8 @@ describe('serialize document', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('serializes to Protobuf JS', () => {
     const overrides: ApiOverride = {
@@ -680,6 +685,8 @@ describe('delete document', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('generates proto', () => {
     const overrides: ApiOverride = {
       commit: (request, options, callback) => {
@@ -796,6 +803,8 @@ describe('set document', () => {
       firestore = firestoreClient;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('supports empty map', () => {
     const overrides: ApiOverride = {
@@ -1228,6 +1237,8 @@ describe('create document', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('creates document', () => {
     const overrides: ApiOverride = {
       commit: (request, options, callback) => {
@@ -1349,6 +1360,8 @@ describe('update document', () => {
       firestore = firestoreClient;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('generates proto', () => {
     const overrides: ApiOverride = {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -33,6 +33,7 @@ import {
   InvalidApiUsage,
   missing,
   stream,
+  verifyInstance,
 } from './util/helpers';
 
 import api = google.firestore.v1;
@@ -512,6 +513,8 @@ describe('snapshot_() method', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('handles ProtobufJS', () => {
     const doc = firestore.snapshot_(
       document('doc', 'foo', {bytesValue: bytesData}),
@@ -655,6 +658,8 @@ describe('doc() method', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('returns DocumentReference', () => {
     const documentRef = firestore.doc('collectionId/documentId');
     expect(documentRef).to.be.an.instanceOf(Firestore.DocumentReference);
@@ -693,6 +698,8 @@ describe('collection() method', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('returns collection', () => {
     const collection = firestore.collection('col1/doc1/col2');

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -28,7 +28,7 @@ import {GeoPoint} from '../src';
 import {DocumentReference} from '../src';
 import * as order from '../src/order';
 import {QualifiedResourcePath} from '../src/path';
-import {createInstance, InvalidApiUsage} from './util/helpers';
+import {createInstance, InvalidApiUsage, verifyInstance} from './util/helpers';
 
 import api = google.firestore.v1;
 
@@ -43,6 +43,8 @@ describe('Order', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   /** Converts a value into its proto representation. */
   function wrap(value: unknown): api.IValue {

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -18,7 +18,7 @@ import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
 import {ClientPool} from '../src/pool';
-import {Deferred} from './util/helpers';
+import {Deferred} from '../src/util';
 
 use(chaiAsPromised);
 

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -28,6 +28,7 @@ import {
   document,
   InvalidApiUsage,
   stream,
+  verifyInstance,
 } from './util/helpers';
 
 import api = google.firestore.v1;
@@ -291,6 +292,8 @@ describe('query interface', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('has isEqual() method', () => {
     const query = firestore.collection('collectionId');
@@ -624,6 +627,8 @@ describe('where() interface', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('generates proto', () => {
     const overrides: ApiOverride = {
       runQuery: request => {
@@ -904,6 +909,8 @@ describe('orderBy() interface', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('accepts empty string', () => {
     const overrides: ApiOverride = {
       runQuery: request => {
@@ -1071,6 +1078,8 @@ describe('limit() interface', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('generates proto', () => {
     const overrides: ApiOverride = {
       runQuery: request => {
@@ -1121,6 +1130,8 @@ describe('offset() interface', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('generates proto', () => {
     const overrides: ApiOverride = {
       runQuery: request => {
@@ -1170,6 +1181,8 @@ describe('select() interface', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('generates proto', () => {
     const overrides: ApiOverride = {
@@ -1239,6 +1252,8 @@ describe('startAt() interface', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('accepts fields', () => {
     const overrides: ApiOverride = {
@@ -1622,6 +1637,8 @@ describe('startAfter() interface', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('accepts fields', () => {
     const overrides: ApiOverride = {
       runQuery: request => {
@@ -1685,6 +1702,8 @@ describe('endAt() interface', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('accepts fields', () => {
     const overrides: ApiOverride = {
       runQuery: request => {
@@ -1743,6 +1762,8 @@ describe('endBefore() interface', () => {
       firestore = firestoreInstance;
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('accepts fields', () => {
     const overrides: ApiOverride = {

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -42,25 +42,6 @@ export const DOCUMENT_NAME = `${COLLECTION_ROOT}/documentId`;
 // tslint:disable-next-line:no-any
 export type InvalidApiUsage = any;
 
-/** A Promise implementation that supports deferred resolution. */
-export class Deferred<R> {
-  promise: Promise<R>;
-  resolve: (value?: R | Promise<R>) => void = () => {};
-  reject: (reason?: Error) => void = () => {};
-
-  constructor() {
-    this.promise = new Promise(
-      (
-        resolve: (value?: R | Promise<R>) => void,
-        reject: (reason?: Error) => void
-      ) => {
-        this.resolve = resolve;
-        this.reject = reject;
-      }
-    );
-  }
-}
-
 /**
  * Interface that defines the request handlers used by Firestore.
  */

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -146,6 +146,14 @@ export function createInstance(
   return Promise.resolve(firestore);
 }
 
+/**
+ * Verifies that all streams have been properly shutdown at the end of a test
+ * run.
+ */
+export function verifyInstance(firestore: Firestore): void {
+  expect(firestore['_clientPool'].opCount).to.equal(0);
+}
+
 function write(
   document: api.IDocument | null,
   mask: api.IDocumentMask | null,

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -132,7 +132,7 @@ export function createInstance(
  * run.
  */
 export function verifyInstance(firestore: Firestore): Promise<void> {
-  // Allow the setTimeout() call in _initializeStream to run d before
+  // Allow the setTimeout() call in _initializeStream to run before
   // verifying that all operations have finished executing.
   return new Promise<void>(resolve => {
     setTimeout(() => {

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -150,8 +150,15 @@ export function createInstance(
  * Verifies that all streams have been properly shutdown at the end of a test
  * run.
  */
-export function verifyInstance(firestore: Firestore): void {
-  expect(firestore['_clientPool'].opCount).to.equal(0);
+export function verifyInstance(firestore: Firestore): Promise<void> {
+  // Allow the setTimeout() call in _initializeStream to run d before
+  // verifying that all operations have finished executing.
+  return new Promise<void>(resolve => {
+    setTimeout(() => {
+      expect(firestore['_clientPool'].opCount).to.equal(0);
+      resolve();
+    }, 10);
+  });
 }
 
 function write(

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -319,7 +319,6 @@ class StreamHelper {
    */
   close(): void {
     this.backendStream!.emit('end');
-    this.backendStream!.end();
   }
 
   /**
@@ -719,7 +718,7 @@ describe('Query watch', () => {
 
   afterEach(() => {
     setTimeoutHandler(setTimeout);
-    verifyInstance(firestore);
+    return verifyInstance(firestore);
   });
 
   it('with invalid callbacks', () => {
@@ -810,11 +809,9 @@ describe('Query watch', () => {
       watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
       return watchHelper.await('snapshot').then(async () => {
         streamHelper.close();
-        await streamHelper.await('end');
         await streamHelper.awaitOpen();
 
         streamHelper.close();
-        await streamHelper.await('end');
         await streamHelper.awaitOpen();
 
         expect(streamHelper.streamCount).to.equal(3);
@@ -2242,7 +2239,7 @@ describe('DocumentReference watch', () => {
 
   afterEach(() => {
     setTimeoutHandler(setTimeout);
-    verifyInstance(firestore);
+    return verifyInstance(firestore);
   });
 
   it('with invalid callbacks', () => {

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -24,7 +24,12 @@ import {
   WriteBatch,
   WriteResult,
 } from '../src';
-import {ApiOverride, createInstance, InvalidApiUsage} from './util/helpers';
+import {
+  ApiOverride,
+  createInstance,
+  InvalidApiUsage,
+  verifyInstance,
+} from './util/helpers';
 
 const REQUEST_TIME = 'REQUEST_TIME';
 
@@ -43,6 +48,8 @@ describe('set() method', () => {
       writeBatch = firestore.batch();
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('requires document name', () => {
     expect(() => (writeBatch as InvalidApiUsage).set()).to.throw(
@@ -74,6 +81,8 @@ describe('delete() method', () => {
     });
   });
 
+  afterEach(() => verifyInstance(firestore));
+
   it('requires document name', () => {
     expect(() => (writeBatch as InvalidApiUsage).delete()).to.throw(
       'Value for argument "documentRef" is not a valid DocumentReference.'
@@ -97,6 +106,8 @@ describe('update() method', () => {
       writeBatch = firestore.batch();
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('requires document name', () => {
     expect(() => writeBatch.update({} as InvalidApiUsage, {})).to.throw(
@@ -131,6 +142,8 @@ describe('create() method', () => {
       writeBatch = firestore.batch();
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   it('requires document name', () => {
     expect(() => (writeBatch as InvalidApiUsage).create()).to.throw(
@@ -253,6 +266,8 @@ describe('batch support', () => {
       writeBatch = firestore.batch();
     });
   });
+
+  afterEach(() => verifyInstance(firestore));
 
   function verifyResponse(writeResults: WriteResult[]) {
     expect(writeResults[0].writeTime.isEqual(new Timestamp(0, 0))).to.be.true;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gts": "^1.0.0",
     "hard-rejection": "^2.0.0",
     "intelli-espower-loader": "^1.0.1",
-    "jsdoc": "3.5.5",
+    "jsdoc": "^3.6.2",
     "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
     "linkinator": "^1.1.2",
     "mocha": "^6.0.0",


### PR DESCRIPTION
Fixes firebase/firebase-admin-node#499

This is a different approach to https://github.com/googleapis/nodejs-firestore/pull/614 and solves the same problem. It re-uses more of the original code to achieve the same result. Instead of releasing the client back to the pool when a stream is marked as established, we instead keep it around until the stream is closed.