### PR TITLE
refactor(deprecation)!: remove deprecated getCollections()

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -813,19 +813,6 @@ export class Firestore {
   }
 
   /**
-   * Fetches the root collections that are associated with this Firestore
-   * database.
-   *
-   * @deprecated Use `.listCollections()`.
-   *
-   * @returns {Promise.<Array.<CollectionReference>>} A Promise that resolves
-   * with an array of CollectionReferences.
-   */
-  getCollections() {
-    return this.listCollections();
-  }
-
-  /**
    * Retrieves multiple documents from Firestore.
    *
    * The first argument is required and must be of type `DocumentReference`

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -308,18 +308,6 @@ export class DocumentReference implements Serializable {
   }
 
   /**
-   * Fetches the subcollections that are direct children of this document.
-   *
-   * @deprecated Use `.listCollections()`.
-   *
-   * @returns {Promise.<Array.<CollectionReference>>} A Promise that resolves
-   * with an array of CollectionReferences.
-   */
-  getCollections(): Promise<CollectionReference[]> {
-    return this.listCollections();
-  }
-
-  /**
    * Create a document with the provided object values. This will fail the write
    * if a document exists at its location.
    *

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -1952,17 +1952,13 @@ describe('listCollections() method', () => {
     };
 
     return createInstance(overrides).then(firestore => {
-      // We are using `getCollections()` to ensure 100% code coverage
-      return (
-        firestore
-          .doc('coll/doc')
-          // tslint:disable-next-line deprecation
-          .getCollections()
-          .then(collections => {
-            expect(collections[0].path).to.equal('coll/doc/first');
-            expect(collections[1].path).to.equal('coll/doc/second');
-          })
-      );
+      return firestore
+        .doc('coll/doc')
+        .listCollections()
+        .then(collections => {
+          expect(collections[0].path).to.equal('coll/doc/first');
+          expect(collections[1].path).to.equal('coll/doc/second');
+        });
     });
   });
 });

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -732,9 +732,7 @@ describe('listCollections() method', () => {
     };
 
     return createInstance(overrides).then(firestore => {
-      // We are using `getCollections()` to ensure 100% code coverage
-      // tslint:disable-next-line deprecation
-      return firestore.getCollections().then(collections => {
+      return firestore.listCollections().then(collections => {
         expect(collections[0].path).to.equal('first');
         expect(collections[1].path).to.equal('second');
       });

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -73,8 +73,6 @@ xdescribe('firestore.d.ts', () => {
     firestore
       .getAll(docRef1, docRef2, {fieldMask: ['foo', new FieldPath('foo')]})
       .then((docs: DocumentSnapshot[]) => {});
-    // tslint:disable-next-line deprecation
-    firestore.getCollections().then((collections: CollectionReference[]) => {});
     firestore
       .listCollections()
       .then((collections: CollectionReference[]) => {});
@@ -154,8 +152,6 @@ xdescribe('firestore.d.ts', () => {
     const parent: CollectionReference = docRef.parent;
     const path: string = docRef.path;
     const subcollection: CollectionReference = docRef.collection('coll');
-    // tslint:disable-next-line deprecation
-    docRef.getCollections().then((collections: CollectionReference[]) => {});
     docRef.listCollections().then((collections: CollectionReference[]) => {});
     docRef.get().then((snapshot: DocumentSnapshot) => {});
     docRef

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -170,16 +170,6 @@ declare namespace FirebaseFirestore {
      * Fetches the root collections that are associated with this Firestore
      * database.
      *
-     * @deprecated Use `.listCollections()`.
-     *
-     * @returns A Promise that resolves with an array of CollectionReferences.
-     */
-    getCollections() : Promise<CollectionReference[]>;
-
-    /**
-     * Fetches the root collections that are associated with this Firestore
-     * database.
-     *
      * @returns A Promise that resolves with an array of CollectionReferences.
      */
     listCollections() : Promise<CollectionReference[]>;
@@ -570,15 +560,6 @@ declare namespace FirebaseFirestore {
      * @return The `CollectionReference` instance.
      */
     collection(collectionPath: string): CollectionReference;
-
-    /**
-     * Fetches the subcollections that are direct children of this document.
-     *
-     * @deprecated Use `.listCollections()`.
-     *
-     * @returns A Promise that resolves with an array of CollectionReferences.
-     */
-    getCollections() : Promise<CollectionReference[]>;
 
     /**
      * Fetches the subcollections that are direct children of this document.


### PR DESCRIPTION
BREAKING CHANGE: This removes the deprecated getCollections() method (deprecated in Oct 2018). This will be part of the v2 release.