### PR TITLE
fix(docs): revert jsdoc and pin to 3.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gts": "^1.0.0",
     "hard-rejection": "^2.0.0",
     "intelli-espower-loader": "^1.0.1",
-    "jsdoc": "^3.6.2",
+    "jsdoc": "3.5.5",
     "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
     "linkinator": "^1.1.2",
     "mocha": "^6.0.0",


### PR DESCRIPTION
This reverts commit 83c5dd9cd3db8810fec9485bf52d2452fa40a2b7.  

fixes #626