### PR TITLE
Revert "fix(docs): revert jsdoc and pin to 3.5.5"

### DIFF
--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -520,7 +520,6 @@ export class DocumentSnapshot {
  */
 export class QueryDocumentSnapshot extends DocumentSnapshot {
   /**
-   * @private
    * @hideconstructor
    *
    * @param ref The reference to the document.

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -130,7 +130,6 @@ export class WriteBatch {
   private _committed = false;
 
   /**
-   * @private
    * @hideconstructor
    *
    * @param firestore The Firestore Database client.

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "gts": "^1.0.0",
     "hard-rejection": "^2.0.0",
     "intelli-espower-loader": "^1.0.1",
-    "jsdoc": "3.5.5",
+    "jsdoc": "^3.6.2",
     "jsdoc-baseline": "git+https://github.com/hegemonic/jsdoc-baseline.git",
     "linkinator": "^1.1.2",
     "mocha": "^6.0.0",


### PR DESCRIPTION
We merged https://github.com/googleapis/nodejs-firestore/pull/628 and should now be able to unpin JSDoc.