### PR TITLE
fix: Allow CollectionReference.doc(undefined)

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2073,7 +2073,7 @@ export class CollectionReference extends Query {
    * console.log(`Reference with auto-id: ${documentRefWithAutoId.path}`);
    */
   doc(documentPath?: string): DocumentReference {
-    if (arguments.length === 0) {
+    if (documentPath === undefined) {
       documentPath = autoId();
     } else {
       validateResourcePath('documentPath', documentPath!);

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -58,9 +58,6 @@ describe('Collection interface', () => {
     expect(() => collectionRef.doc('')).to.throw(
       'Value for argument "documentPath" is not a valid resource path. Path must be a non-empty string.'
     );
-    expect(() => collectionRef.doc(undefined)).to.throw(
-      'Value for argument "documentPath" is not a valid resource path. Path must be a non-empty string.'
-    );
     expect(() => collectionRef.doc('doc/coll')).to.throw(
       'Value for argument "documentPath" must point to a document, but was "doc/coll". Your path does not contain an even number of components.'
     );
@@ -82,6 +79,10 @@ describe('Collection interface', () => {
     expect(documentRef).to.be.an.instanceOf(DocumentReference);
     expect(collectionRef.id).to.equal('collectionId');
     expect(documentRef.id).to.have.length(20);
+    
+    const documentRefUndefined = collectionRef.doc(undefined);
+    expect(documentRefUndefined).to.be.an.instanceOf(DocumentReference);
+    expect(documentRefUndefined.id).to.have.length(20);
   });
 
   it('has add() method', () => {

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -75,14 +75,14 @@ describe('Collection interface', () => {
 
   it('supports auto-generated ids', () => {
     const collectionRef = firestore.collection('collectionId');
-    const documentRef = collectionRef.doc();
+    let documentRef = collectionRef.doc();
     expect(documentRef).to.be.an.instanceOf(DocumentReference);
     expect(collectionRef.id).to.equal('collectionId');
     expect(documentRef.id).to.have.length(20);
     
-    const documentRefUndefined = collectionRef.doc(undefined);
-    expect(documentRefUndefined).to.be.an.instanceOf(DocumentReference);
-    expect(documentRefUndefined.id).to.have.length(20);
+    documentRef = collectionRef.doc(undefined);
+    expect(documentRef).to.be.an.instanceOf(DocumentReference);
+    expect(documentRef.id).to.have.length(20);
   });
 
   it('has add() method', () => {


### PR DESCRIPTION
This PR Fixes Error below when passing `undefined` as parameter to `CollectionReference.doc()`

`CollectionReference.doc(undefined)` gives this error:
`'Value for argument "documentPath" is not a valid ' + 'resource path. Path must be a non-empty string.'`

undefined should be a valid parameter for `CollectionReference.doc()` according to the types because the **documentPath** argument is an optional string === `string | undefined`.

- [X] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
