### PR TITLE
fix: Add overloads for doc() and doc(id:string)

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2055,6 +2055,8 @@ export class CollectionReference extends Query {
     });
   }
 
+  doc(): DocumentReference;
+  doc(documentPath: string): DocumentReference;
   /**
    * Gets a [DocumentReference]{@link DocumentReference} instance that
    * refers to the document at the specified path. If no path is specified, an

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -58,7 +58,7 @@ describe('Collection interface', () => {
     expect(() => collectionRef.doc('')).to.throw(
       'Value for argument "documentPath" is not a valid resource path. Path must be a non-empty string.'
     );
-    expect(() => collectionRef.doc(undefined)).to.throw(
+    expect(() => (collectionRef as InvalidApiUsage).doc(undefined)).to.throw(
       'Value for argument "documentPath" is not a valid resource path. Path must be a non-empty string.'
     );
     expect(() => collectionRef.doc('doc/coll')).to.throw(

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -1113,14 +1113,22 @@ declare namespace FirebaseFirestore {
     listDocuments(): Promise<DocumentReference[]>;
 
     /**
+     * Get a `DocumentReference` for a randomly-named document within this
+     * collection. An automatically-generated unique ID will be used as the
+     * document ID.
+     *
+     * @return The `DocumentReference` instance.
+     */
+    doc(): DocumentReference;
+
+    /**
      * Get a `DocumentReference` for the document within the collection at the
-     * specified path. If no path is specified, an automatically-generated
-     * unique ID will be used for the returned DocumentReference.
+     * specified path.
      *
      * @param documentPath A slash-separated path to a document.
      * @return The `DocumentReference` instance.
      */
-    doc(documentPath?: string): DocumentReference;
+    doc(documentPath: string): DocumentReference;
 
     /**
      * Add a new document to this collection with the specified data, assigning


### PR DESCRIPTION
This addresses the same issue as https://github.com/googleapis/nodejs-firestore/pull/658, but instead of relaxing our `CollectionReference.doc()` API, it fixes the types to reflect the invariant that we enforce via our argument validation. As in older releases, we still prevent users from passing "undefined", but with this PR this should generate a compile time error.

This is based on the following little experiment:

```
interface Foo {
    bar(): void;
    bar(baz: string): void;
}
class Foobar implements Foo {
    bar(baz?: string) {}
}
function createFoo(): Foo {
    return new Foobar();
}
const f = createFoo();
f.bar();
f.bar("foobar");
f.bar(undefined); // Compile error
```

Note that I am marking this as a "fix" rather than as a "breaking change" as any user that tried to use "undefined" before would have been broken already (and gotten a validation error). This PR will therefore go out with the next release, which is a minor version bump.