### PR TITLE
deps: Pin @gprc/grpc-js to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "deep-equal": "^1.0.1",
     "functional-red-black-tree": "^1.0.1",
     "google-gax": "^1.0.0",
+    "@grpc/grpc-js": "0.4.0",
     "through2": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It looks like stream can end prematurely in @gprc/grpc-js 0.4.1. This happens gracefully, resulting in fewer than expected results from a RunQueryRequest.

Addresses https://github.com/googleapis/nodejs-firestore/issues/667
