### PR TITLE
deps: Un-pin @gprc/grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "deep-equal": "^1.0.1",
     "functional-red-black-tree": "^1.0.1",
     "google-gax": "^1.0.0",
-    "@grpc/grpc-js": "0.4.0",
     "through2": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts googleapis/nodejs-firestore#668. `@gprc/grpc-js` released 0.4.2 which contains a fix for https://github.com/grpc/grpc-node/issues/895

Fixes https://github.com/googleapis/nodejs-firestore/issues/661