### PR TITLE
style: Prepare for Typescript 3.5 migration

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -863,8 +863,8 @@ export class Firestore {
     requestTag: string,
     transactionId?: Uint8Array
   ): Promise<DocumentSnapshot[]> {
-    const requestedDocuments = new Set();
-    const retrievedDocuments = new Map();
+    const requestedDocuments = new Set<string>();
+    const retrievedDocuments = new Map<string, DocumentSnapshot>();
 
     for (const docRef of docRefs) {
       requestedDocuments.add(docRef.formattedName);
@@ -947,12 +947,13 @@ export class Firestore {
               const orderedDocuments: DocumentSnapshot[] = [];
               for (const docRef of docRefs) {
                 const document = retrievedDocuments.get(docRef.path);
-                if (document === undefined) {
+                if (document !== undefined) {
+                  orderedDocuments.push(document);
+                } else {
                   reject(
                     new Error(`Did not receive document for "${docRef.path}".`)
                   );
                 }
-                orderedDocuments.push(document);
               }
               resolve(orderedDocuments);
             });

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -429,10 +429,7 @@ export class DocumentReference implements Serializable {
 
     const writeBatch = new WriteBatch(this._firestore);
     return writeBatch.update
-      .apply(writeBatch, [this, dataOrField].concat(preconditionOrValues) as [
-        DocumentReference,
-        string
-      ])
+      .apply(writeBatch, [this, dataOrField, ...preconditionOrValues])
       .commit()
       .then(([writeResult]) => writeResult);
   }

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -151,12 +151,11 @@ export class Serializer {
       };
     }
 
-    if (
-      isObject(val) &&
-      'toProto' in val &&
-      typeof (val as Serializable).toProto === 'function'
-    ) {
-      return (val as Serializable).toProto();
+    if (isObject(val)) {
+      const toProto = val['toProto'];
+      if (typeof toProto === 'function') {
+        return toProto.bind(val)();
+      }
     }
 
     if (val instanceof Array) {

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -312,7 +312,8 @@ export class Transaction {
     this._writeBatch.update.apply(this._writeBatch, [
       documentRef,
       dataOrField,
-    ].concat(preconditionOrValues) as [DocumentReference, string]);
+      ...preconditionOrValues,
+    ]);
     return this;
   }
 

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -68,7 +68,7 @@ export function requestTag(): string {
  *
  * @private
  */
-export function isObject(value: unknown): value is object {
+export function isObject(value: unknown): value is {[k: string]: unknown} {
   return Object.prototype.toString.call(value) === '[object Object]';
 }
 

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -162,7 +162,9 @@ describe('serialize document', () => {
 
     expect(() => {
       class Foo {}
-      firestore.doc('collectionId/documentId').set(new Foo());
+      firestore
+        .doc('collectionId/documentId')
+        .set(new Foo() as InvalidApiUsage);
     }).to.throw(
       'Value for argument "data" is not a valid Firestore document. Couldn\'t serialize object of type "Foo". Firestore doesn\'t support JavaScript objects with custom prototypes (i.e. objects that were created via the "new" operator).'
     );
@@ -652,7 +654,6 @@ describe('get document', () => {
               mapValue: {
                 fields: {
                   bar: {
-                    valueType: 'stringValue',
                     stringValue: 'foobar',
                   },
                 },
@@ -1221,7 +1222,7 @@ describe('set document', () => {
 
   it("doesn't accept arrays", () => {
     expect(() => {
-      firestore.doc('collectionId/documentId').set([42]);
+      firestore.doc('collectionId/documentId').set([42] as InvalidApiUsage);
     }).to.throw(
       'Value for argument "data" is not a valid Firestore document. Input is not a plain JavaScript object.'
     );
@@ -1345,7 +1346,7 @@ describe('create document', () => {
 
   it("doesn't accept arrays", () => {
     expect(() => {
-      firestore.doc('collectionId/documentId').create([42]);
+      firestore.doc('collectionId/documentId').create([42] as InvalidApiUsage);
     }).to.throw(
       'Value for argument "data" is not a valid Firestore document. Input is not a plain JavaScript object.'
     );
@@ -1923,7 +1924,7 @@ describe('update document', () => {
 
   it("doesn't accept arrays", () => {
     expect(() =>
-      firestore.doc('collectionId/documentId').update([42])
+      firestore.doc('collectionId/documentId').update([42] as InvalidApiUsage)
     ).to.throw(
       'Value for argument "dataOrField" is not a valid Firestore document. Input is not a plain JavaScript object.'
     );

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -353,10 +353,7 @@ export function writeResult(count: number): api.IWriteResponse {
   return response;
 }
 
-export function requestEquals(
-  actual: {[k: string]: unknown},
-  expected: {[k: string]: unknown}
-): void {
+export function requestEquals(actual: object, expected: object): void {
   // 'extend' removes undefined fields in the request object. The backend
   // ignores these fields, but we need to manually strip them before we compare
   // the expected and the actual request.

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -117,7 +117,9 @@ describe('update() method', () => {
 
   it('requires object', () => {
     expect(() => {
-      writeBatch.update(firestore.doc('sub/doc'), firestore.doc('sub/doc'));
+      writeBatch.update(firestore.doc('sub/doc'), firestore.doc(
+        'sub/doc'
+      ) as InvalidApiUsage);
     }).to.throw(
       'Update() requires either a single JavaScript object or an alternating list of field/value pairs that can be followed by an optional precondition. Value for argument "dataOrField" is not a valid Firestore document. Detected an object of type "DocumentReference" that doesn\'t match the expected instance. Please ensure that the Firestore types you are using are from the same NPM package.'
     );


### PR DESCRIPTION
The changes in this PR should let us migrate to TypeScript 3.5, unblocking https://github.com/googleapis/nodejs-firestore/pull/666

See the first two items in https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/#breaking-changes for context