### PR TITLE
fix: Support non-ISO-8859-1 Collection Names in Queries

### DIFF
--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -1166,6 +1166,13 @@ describe('Query class', () => {
       });
   });
 
+  it('supports Unicode in document names', async () => {
+    const collRef = randomCol.doc('доброеутро').collection('coll');
+    await collRef.add({});
+    const snapshot = await collRef.get();
+    expect(snapshot.size).to.equal(1);
+  });
+
   it('supports pagination', () => {
     const batch = firestore.batch();
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "bun": "^0.0.12",
     "deep-equal": "^1.0.1",
     "functional-red-black-tree": "^1.0.1",
-    "google-gax": "^1.0.0",
+    "google-gax": "^1.1.2",
     "through2": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates google-gax to 1.1.2 to pull in https://github.com/googleapis/gax-nodejs/pull/521  and adds tests to verify that we can query non-Ascii collection.
