### PR TITLE
test: Fix flaky system test

### DIFF
--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -951,7 +951,7 @@ describe('DocumentReference class', () => {
       }
 
       await Promise.all(emptyResults.map(d => d.promise));
-      ref.set({i: 1337});
+      await ref.set({i: 1337});
       await Promise.all(documentResults.map(d => d.promise));
       unsubscribeCallbacks.forEach(c => c());
     });


### PR DESCRIPTION
This maybe (hopefully?) fixes the flaky system test.

We currently verify at the end of each tests that no more streams are running. The change here is that for `handles more than 100 concurrent listeners` will also wait for the document write to succeed. 

Background: Since all operations are async, it is possible that Watch tells us about a write before we get the write acknowledgment. If that is the case, in the old test, we could tear down the watch streams and exist the test while the write stream is still open.

Fixes: https://github.com/googleapis/nodejs-firestore/issues/708