### PR TITLE
fix: add logging to client pool

### DIFF
--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -161,6 +161,7 @@ export class ClientPool<T> {
    * Deletes clients that are no longer executing operations. Keeps up to one
    * idle client to reduce future initialization costs.
    *
+   * @return Number of clients deleted.
    * @private
    */
   private garbageCollect(): number {

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -281,13 +281,14 @@ export class DocumentReference implements Serializable {
    * });
    */
   listCollections(): Promise<CollectionReference[]> {
-    return this.firestore.initializeIfNeeded().then(() => {
+    const tag = requestTag();
+    return this.firestore.initializeIfNeeded(tag).then(() => {
       const request = {parent: this.formattedName};
       return this._firestore
         .request<string[]>(
           'listCollectionIds',
           request,
-          requestTag(),
+          tag,
           /* allowRetries= */ true
         )
         .then(collectionIds => {
@@ -1820,7 +1821,7 @@ export class Query {
       callback();
     });
 
-    this.firestore.initializeIfNeeded().then(() => {
+    this.firestore.initializeIfNeeded(tag).then(() => {
       const request = this.toProto(transactionId);
       this._firestore
         .readStream('runQuery', request, tag, true)
@@ -2037,7 +2038,8 @@ export class CollectionReference extends Query {
    * });
    */
   listDocuments(): Promise<DocumentReference[]> {
-    return this.firestore.initializeIfNeeded().then(() => {
+    const tag = requestTag();
+    return this.firestore.initializeIfNeeded(tag).then(() => {
       const parentPath = this._queryOptions.parentPath.toQualifiedResourcePath(
         this.firestore.projectId
       );
@@ -2053,7 +2055,7 @@ export class CollectionReference extends Query {
         .request<api.IDocument[]>(
           'listDocuments',
           request,
-          requestTag(),
+          tag,
           /*allowRetries=*/ true
         )
         .then(documents => {

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -495,7 +495,7 @@ abstract class Watch {
           return;
         }
 
-        await this.firestore.initializeIfNeeded();
+        await this.firestore.initializeIfNeeded(this.requestTag);
 
         const request: api.IListenRequest = {};
         request.database = this.firestore.formattedName;

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -528,8 +528,6 @@ export class WriteBatch {
     this._committed = true;
 
     const tag = (commitOptions && commitOptions.requestTag) || requestTag();
-    const explicitTransaction = commitOptions && commitOptions.transactionId;
-
     await this._firestore.initializeIfNeeded(tag);
 
     const database = this._firestore.formattedName;
@@ -537,6 +535,7 @@ export class WriteBatch {
 
     // On GCF, we periodically force transactional commits to allow for
     // request retries in case GCF closes our backend connection.
+    const explicitTransaction = commitOptions && commitOptions.transactionId;
     if (!explicitTransaction && this._shouldCreateTransaction()) {
       logger('WriteBatch.commit', tag, 'Using transaction for commit');
       return this._firestore

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -527,11 +527,11 @@ export class WriteBatch {
     // Note: We don't call `verifyNotCommitted()` to allow for retries.
     this._committed = true;
 
-    await this._firestore.initializeIfNeeded();
-
+    const tag = (commitOptions && commitOptions.requestTag) || requestTag();
     const explicitTransaction = commitOptions && commitOptions.transactionId;
 
-    const tag = (commitOptions && commitOptions.requestTag) || requestTag();
+    await this._firestore.initializeIfNeeded(tag);
+
     const database = this._firestore.formattedName;
     const request: api.ICommitRequest = {database};
 

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -318,7 +318,7 @@ describe('instantiation', () => {
 
   it('cannot change settings after client initialized', async () => {
     const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
-    await firestore.initializeIfNeeded();
+    await firestore.initializeIfNeeded('tag');
 
     expect(() => firestore.settings({})).to.throw(
       'Firestore has already been initialized. You can only call settings() once, and only before calling any other methods on a Firestore object.'
@@ -525,7 +525,7 @@ describe('instantiation', () => {
       },
       {projectId: undefined}
     ).then(async firestore => {
-      await firestore.initializeIfNeeded();
+      await firestore.initializeIfNeeded('tag');
       expect(firestore.projectId).to.equal('foo');
       expect(firestore.formattedName).to.equal(
         `projects/foo/databases/(default)`
@@ -566,7 +566,7 @@ describe('instantiation', () => {
       ssl: false,
       projectId: 'foo',
     });
-    await firestore['_clientPool'].run(() => Promise.resolve());
+    await firestore['_clientPool'].run('tag', () => Promise.resolve());
   });
 
   it('exports all types', () => {

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -22,6 +22,8 @@ import {Deferred} from '../src/util';
 
 use(chaiAsPromised);
 
+const REQUEST_TAG = 'tag';
+
 function deferredPromises(count: number): Array<Deferred<void>> {
   const deferred: Array<Deferred<void>> = [];
   for (let i = 0; i < count; ++i) {
@@ -40,14 +42,14 @@ describe('Client pool', () => {
 
     const operationPromises = deferredPromises(4);
 
-    clientPool.run(() => operationPromises[0].promise);
+    clientPool.run(REQUEST_TAG, () => operationPromises[0].promise);
     expect(clientPool.size).to.equal(1);
-    clientPool.run(() => operationPromises[1].promise);
+    clientPool.run(REQUEST_TAG, () => operationPromises[1].promise);
     expect(clientPool.size).to.equal(1);
-    clientPool.run(() => operationPromises[2].promise);
+    clientPool.run(REQUEST_TAG, () => operationPromises[2].promise);
     expect(clientPool.size).to.equal(1);
 
-    clientPool.run(() => operationPromises[3].promise);
+    clientPool.run(REQUEST_TAG, () => operationPromises[3].promise);
     expect(clientPool.size).to.equal(2);
   });
 
@@ -61,20 +63,21 @@ describe('Client pool', () => {
     const operationPromises = deferredPromises(5);
 
     const completionPromise = clientPool.run(
+      REQUEST_TAG,
       () => operationPromises[0].promise
     );
     expect(clientPool.size).to.equal(1);
-    clientPool.run(() => operationPromises[1].promise);
+    clientPool.run(REQUEST_TAG, () => operationPromises[1].promise);
     expect(clientPool.size).to.equal(1);
-    clientPool.run(() => operationPromises[2].promise);
+    clientPool.run(REQUEST_TAG, () => operationPromises[2].promise);
     expect(clientPool.size).to.equal(2);
-    clientPool.run(() => operationPromises[3].promise);
+    clientPool.run(REQUEST_TAG, () => operationPromises[3].promise);
     expect(clientPool.size).to.equal(2);
 
     operationPromises[0].resolve();
 
     return completionPromise.then(() => {
-      clientPool.run(() => operationPromises[4].promise);
+      clientPool.run(REQUEST_TAG, () => operationPromises[4].promise);
       expect(clientPool.size).to.equal(2);
     });
   });
@@ -89,13 +92,21 @@ describe('Client pool', () => {
     const operationPromises = deferredPromises(4);
     const completionPromises: Array<Promise<void>> = [];
 
-    completionPromises.push(clientPool.run(() => operationPromises[0].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[0].promise)
+    );
     expect(clientPool.size).to.equal(1);
-    completionPromises.push(clientPool.run(() => operationPromises[1].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[1].promise)
+    );
     expect(clientPool.size).to.equal(1);
-    completionPromises.push(clientPool.run(() => operationPromises[2].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[2].promise)
+    );
     expect(clientPool.size).to.equal(2);
-    completionPromises.push(clientPool.run(() => operationPromises[3].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[3].promise)
+    );
     expect(clientPool.size).to.equal(2);
 
     operationPromises.forEach(deferred => deferred.resolve());
@@ -115,13 +126,21 @@ describe('Client pool', () => {
     const operationPromises = deferredPromises(4);
     const completionPromises: Array<Promise<void>> = [];
 
-    completionPromises.push(clientPool.run(() => operationPromises[0].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[0].promise)
+    );
     expect(clientPool.size).to.equal(1);
-    completionPromises.push(clientPool.run(() => operationPromises[1].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[1].promise)
+    );
     expect(clientPool.size).to.equal(1);
-    completionPromises.push(clientPool.run(() => operationPromises[2].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[2].promise)
+    );
     expect(clientPool.size).to.equal(2);
-    completionPromises.push(clientPool.run(() => operationPromises[3].promise));
+    completionPromises.push(
+      clientPool.run(REQUEST_TAG, () => operationPromises[3].promise)
+    );
     expect(clientPool.size).to.equal(2);
 
     operationPromises.forEach(deferred => deferred.reject());
@@ -138,7 +157,7 @@ describe('Client pool', () => {
       return {};
     });
 
-    const op = clientPool.run(() => Promise.resolve('Success'));
+    const op = clientPool.run(REQUEST_TAG, () => Promise.resolve('Success'));
     return expect(op).to.become('Success');
   });
 
@@ -147,7 +166,9 @@ describe('Client pool', () => {
       return {};
     });
 
-    const op = clientPool.run(() => Promise.reject('Generated error'));
+    const op = clientPool.run(REQUEST_TAG, () =>
+      Promise.reject('Generated error')
+    );
     return expect(op).to.eventually.be.rejectedWith('Generated error');
   });
 });


### PR DESCRIPTION
This PR logs when we create or delete instances in the client pool, helping us debug https://github.com/firebase/firebase-admin-node/issues/620

Almost everything here is related to plumbing through the "request tag"