### PR TITLE
fix: remove hasOwnProperty method

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -29,6 +29,8 @@ import {
   FieldPath,
   FieldValue,
   Firestore,
+  getObjectOwnProperties,
+  getPropValue,
   Query,
   QueryDocumentSnapshot,
   QuerySnapshot,
@@ -141,10 +143,8 @@ const convertInput = {
       }
     }
     function convertObject(obj: {[k: string]: unknown}) {
-      for (const key in obj) {
-        if (obj.hasOwnProperty(key)) {
-          obj[key] = convertValue(obj[key]);
-        }
+      for (const key of getObjectOwnProperties(obj)) {
+        obj[key] = convertValue(getPropValue(obj, key));
       }
       return obj;
     }

--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -20,6 +20,7 @@ import {ApiMapValue, ProtobufJsValue} from './types';
 import {validateObject} from './validate';
 
 import api = google.firestore.v1;
+import {getObjectOwnProperties, getPropValue} from '.';
 
 /*!
  * @module firestore/convert
@@ -200,10 +201,10 @@ export function valueFromJson(fieldValue: api.IValue): api.IValue {
     }
     case 'mapValue': {
       const mapValue: ApiMapValue = {};
-      for (const prop in fieldValue.mapValue!.fields!) {
-        if (fieldValue.mapValue!.fields!.hasOwnProperty(prop)) {
-          mapValue[prop] = valueFromJson(fieldValue.mapValue!.fields![prop]);
-        }
+      for (const prop of getObjectOwnProperties(fieldValue.mapValue!.fields!)) {
+        mapValue[prop] = valueFromJson(
+          getPropValue(fieldValue.mapValue!.fields!, prop)
+        );
       }
       return {
         mapValue: {
@@ -228,11 +229,8 @@ export function valueFromJson(fieldValue: api.IValue): api.IValue {
 export function fieldsFromJson(document: ApiMapValue): ApiMapValue {
   const result: ApiMapValue = {};
 
-  for (const prop in document) {
-    if (document.hasOwnProperty(prop)) {
-      result[prop] = valueFromJson(document[prop]);
-    }
+  for (const prop of getObjectOwnProperties(document)) {
+    result[prop] = valueFromJson(getPropValue(document, prop));
   }
-
   return result;
 }

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -87,6 +87,28 @@ export {
 const libVersion = require('../../package.json').version;
 setLibVersion(libVersion);
 
+/**
+ * find value of given property in object.
+ *
+ * @property {Object} obj
+ * @property {string} key Property in object
+ */
+export const getPropValue = <T, K extends keyof T>(obj: T, key: K) => {
+  return obj[key];
+};
+
+/**
+ * find all own enumerable property names in object.
+ *
+ * @property {Object} obj
+ */
+export const getObjectOwnProperties = <T>(obj: T) => {
+  if (obj) {
+    return Object.keys(obj);
+  }
+  return [];
+};
+
 /*!
  * DO NOT REMOVE THE FOLLOWING NAMESPACE DEFINITIONS
  */

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -23,7 +23,7 @@ import {
   DocumentTransform,
   Precondition,
 } from './document';
-import {Firestore} from './index';
+import {Firestore, getObjectOwnProperties, getPropValue} from './index';
 import {logger} from './logger';
 import {FieldPath, validateFieldPath} from './path';
 import {DocumentReference, validateDocumentReference} from './reference';
@@ -848,19 +848,17 @@ export function validateDocumentData(
     throw new Error(customObjectMessage(arg, obj));
   }
 
-  for (const prop in obj) {
-    if (obj.hasOwnProperty(prop)) {
-      validateUserInput(
-        arg,
-        obj[prop],
-        'Firestore document',
-        {
-          allowDeletes: allowDeletes ? 'all' : 'none',
-          allowTransforms: true,
-        },
-        new FieldPath(prop)
-      );
-    }
+  for (const prop of getObjectOwnProperties(obj)) {
+    validateUserInput(
+      arg,
+      getPropValue(obj, prop),
+      'Firestore document',
+      {
+        allowDeletes: allowDeletes ? 'all' : 'none',
+        allowTransforms: true,
+      },
+      new FieldPath(prop)
+    );
   }
 }
 
@@ -931,11 +929,9 @@ function validateUpdateMap(arg: string | number, obj: unknown): void {
 
   let isEmpty = true;
 
-  for (const prop in obj) {
-    if (obj.hasOwnProperty(prop)) {
-      isEmpty = false;
-      validateFieldValue(arg, obj[prop], new FieldPath(prop));
-    }
+  for (const prop of getObjectOwnProperties(obj)) {
+    isEmpty = false;
+    validateFieldValue(arg, getPropValue(obj, prop), new FieldPath(prop));
   }
 
   if (isEmpty) {

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -28,6 +28,8 @@ import {
   FieldPath,
   Firestore,
   GeoPoint,
+  getObjectOwnProperties,
+  getPropValue,
   setLogFunction,
   Timestamp,
 } from '../src';
@@ -885,46 +887,44 @@ describe('Query watch', () => {
 
     let result = Promise.resolve();
 
-    for (const statusCode in expectRetry) {
-      if (expectRetry.hasOwnProperty(statusCode)) {
-        result = result.then(() => {
-          const err = new GrpcError('GRPC Error');
-          err.code = Number(statusCode);
+    for (const statusCode of getObjectOwnProperties(expectRetry)) {
+      result = result.then(() => {
+        const err = new GrpcError('GRPC Error');
+        err.code = Number(statusCode);
 
-          if (expectRetry[statusCode]) {
-            return watchHelper.runTest(collQueryJSON(), () => {
+        if (getPropValue(expectRetry, +statusCode)) {
+          return watchHelper.runTest(collQueryJSON(), () => {
+            watchHelper.sendAddTarget();
+            watchHelper.sendCurrent();
+            watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
+            return watchHelper.await('snapshot').then(() => {
+              streamHelper.destroyStream(err);
+              return streamHelper.awaitReopen();
+            });
+          });
+        } else {
+          return watchHelper.runFailedTest(
+            collQueryJSON(),
+            () => {
               watchHelper.sendAddTarget();
               watchHelper.sendCurrent();
               watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
-              return watchHelper.await('snapshot').then(() => {
-                streamHelper.destroyStream(err);
-                return streamHelper.awaitReopen();
-              });
-            });
-          } else {
-            return watchHelper.runFailedTest(
-              collQueryJSON(),
-              () => {
-                watchHelper.sendAddTarget();
-                watchHelper.sendCurrent();
-                watchHelper.sendSnapshot(1, Buffer.from([0xabcd]));
-                return watchHelper
-                  .await('snapshot')
-                  .then(() => {
-                    streamHelper.destroyStream(err);
-                  })
-                  .then(() => {
-                    return streamHelper.await('error');
-                  })
-                  .then(() => {
-                    return streamHelper.await('close');
-                  });
-              },
-              'GRPC Error'
-            );
-          }
-        });
-      }
+              return watchHelper
+                .await('snapshot')
+                .then(() => {
+                  streamHelper.destroyStream(err);
+                })
+                .then(() => {
+                  return streamHelper.await('error');
+                })
+                .then(() => {
+                  return streamHelper.await('close');
+                });
+            },
+            'GRPC Error'
+          );
+        }
+      });
     }
 
     return result;


### PR DESCRIPTION
Fixes #732  (it's a good idea to open an issue first for discussion)

removed use of hasOwnProperty function in application.

created two generic function to list out all own properties from object and to find out value of given property in object.

export const getPropValue = <T, K extends keyof T>(obj: T, key: K) => {
return obj[key];
};

export const getObjectOwnProperties = (obj: T) => {
if (obj) {
return Object.keys(obj);
}
return [];
};