### PR TITLE
fix: retrying 13 INTERNAL RPC errors

### DIFF
--- a/dev/src/v1/firestore_client_config.json
+++ b/dev/src/v1/firestore_client_config.json
@@ -4,6 +4,7 @@
       "retry_codes": {
         "idempotent": [
           "DEADLINE_EXCEEDED",
+          "INTERNAL",
           "UNAVAILABLE"
         ],
         "non_idempotent": []


### PR DESCRIPTION
Retrying INTERNAL errors for Idempotent calls should help address https://github.com/firebase/firebase-functions/issues/536