### PR TITLE
feat!: remove deprecated timestampInSnapshots setting

### DIFF
--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -52,7 +52,6 @@ export interface Serializable {
  * @private
  */
 export class Serializer {
-  private timestampsInSnapshots: boolean;
   private createReference: (path: string) => DocumentReference;
 
   constructor(firestore: Firestore) {
@@ -60,13 +59,6 @@ export class Serializer {
     // its `.doc()` method. This avoid a circular reference, which breaks
     // JSON.stringify().
     this.createReference = path => firestore.doc(path);
-    // tslint:disable-next-line deprecation
-    if (firestore._settings.timestampsInSnapshots === undefined) {
-      this.timestampsInSnapshots = true;
-    } else {
-      // tslint:disable-next-line deprecation
-      this.timestampsInSnapshots = firestore._settings.timestampsInSnapshots;
-    }
   }
 
   /**
@@ -218,7 +210,7 @@ export class Serializer {
       }
       case 'timestampValue': {
         const timestamp = Timestamp.fromProto(proto.timestampValue!);
-        return this.timestampsInSnapshots ? timestamp : timestamp.toDate();
+        return timestamp;
       }
       case 'referenceValue': {
         const resourcePath = QualifiedResourcePath.fromSlashSeparatedString(

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -69,27 +69,6 @@ export interface Settings {
    */
   credentials?: {client_email?: string; private_key?: string};
 
-  /**
-   * Specifies whether to use `Timestamp` objects for timestamp fields in
-   * `DocumentSnapshot`s. This is enabled by default and should not be disabled.
-   *
-   * Previously, Firestore returned timestamp fields as `Date` but `Date` only
-   * supports millisecond precision, which leads to truncation and causes
-   * unexpected behavior when using a timestamp from a snapshot as a part of a
-   * subsequent query.
-   *
-   * So now Firestore returns `Timestamp` values instead of `Date`, avoiding
-   * this kind of problem.
-   *
-   * To opt into the old behavior of returning `Date` objects, you can
-   * temporarily set `timestampsInSnapshots` to false.
-   *
-   * @deprecated This setting will be removed in a future release. You should
-   * update your code to expect `Timestamp` objects and stop using the
-   * `timestampsInSnapshots` setting.
-   */
-  timestampsInSnapshots?: boolean;
-
   /** Whether to use SSL when connecting. */
   ssl?: boolean;
 

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -303,8 +303,10 @@ describe('instantiation', () => {
     const firestore = new Firestore.Firestore(DEFAULT_SETTINGS);
     firestore.settings({foo: 'bar'});
 
-    expect(firestore._settings.projectId).to.equal(PROJECT_ID);
-    expect(firestore._settings.foo).to.equal('bar');
+    /* tslint:disable:no-any */
+    expect((firestore as any)._settings.projectId).to.equal(PROJECT_ID);
+    expect((firestore as any)._settings.foo).to.equal('bar');
+    /* tslint:enable:no-any */
   });
 
   it('can only call settings() once', () => {
@@ -339,23 +341,6 @@ describe('instantiation', () => {
       } as InvalidApiUsage);
     }).to.throw(
       'Value for argument "settings.projectId" is not a valid string.'
-    );
-  });
-
-  it('validates timestampsInSnapshots is boolean', () => {
-    expect(() => {
-      const settings = {...DEFAULT_SETTINGS, timestampsInSnapshots: 1337};
-      new Firestore.Firestore(settings as InvalidApiUsage);
-    }).to.throw(
-      'Value for argument "settings.timestampsInSnapshots" is not a valid boolean.'
-    );
-
-    expect(() => {
-      new Firestore.Firestore(DEFAULT_SETTINGS).settings({
-        timestampsInSnapshots: 1337 as InvalidApiUsage,
-      });
-    }).to.throw(
-      'Value for argument "settings.timestampsInSnapshots" is not a valid boolean.'
     );
   });
 

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -69,27 +69,6 @@ describe('timestamps', () => {
     });
   });
 
-  it('converted to dates when disabled', () => {
-    const oldErrorLog = console.error;
-    // Prevent error message that prompts to enable `timestampsInSnapshots`
-    // behavior.
-    console.error = () => {};
-
-    return createInstance(
-      {timestampsInSnapshots: false},
-      DOCUMENT_WITH_TIMESTAMP
-    ).then(firestore => {
-      return firestore
-        .doc('collectionId/documentId')
-        .get()
-        .then(res => {
-          expect(res.data()!['moonLanding']).to.be.instanceOf(Date);
-          expect(res.get('moonLanding')).to.be.instanceOf(Date);
-          console.error = oldErrorLog;
-        });
-    });
-  });
-
   it('retain seconds and nanoseconds', () => {
     return createInstance({}, DOCUMENT_WITH_TIMESTAMP).then(firestore => {
       return firestore

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -41,7 +41,6 @@ xdescribe('firestore.d.ts', () => {
   const firestore: Firestore = new Firestore({
     keyFilename: 'foo',
     projectId: 'foo',
-    timestampsInSnapshots: true,
     host: 'localhost',
     ssl: false,
     otherOption: 'foo',
@@ -61,7 +60,6 @@ xdescribe('firestore.d.ts', () => {
     firestore.settings({
       keyFilename: 'foo',
       projectId: 'foo',
-      timestampsInSnapshots: true,
       otherOption: 'foo',
     });
     const collRef: CollectionReference = firestore.collection('coll');

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -77,27 +77,6 @@ declare namespace FirebaseFirestore {
      */
     credentials?: {client_email?:string, private_key?:string};
 
-    /**
-     * Specifies whether to use `Timestamp` objects for timestamp fields in
-     * `DocumentSnapshot`s. This is enabled by default and should not be disabled.
-     *
-     * Previously, Firestore returned timestamp fields as `Date` but `Date` only
-     * supports millisecond precision, which leads to truncation and causes
-     * unexpected behavior when using a timestamp from a snapshot as a part of a
-     * subsequent query.
-     *
-     * So now Firestore returns `Timestamp` values instead of `Date`, avoiding
-     * this kind of problem.
-     *
-     * To opt into the old behavior of returning `Date` objects, you can
-     * temporarily set `timestampsInSnapshots` to false.
-     *
-     * @deprecated This setting will be removed in a future release. You should
-     * update your code to expect `Timestamp` objects and stop using the
-     * `timestampsInSnapshots` setting.
-     */
-    timestampsInSnapshots?: boolean;
-
     /** Whether to use SSL when connecting. */
     ssl?: boolean;
 


### PR DESCRIPTION
The next release will be breaking (see https://github.com/googleapis/nodejs-firestore/pull/805). I would like to use this opportunity to clean up the code and remove timestampInSnapshots