### PR TITLE
feat: allow specifying how many idle GRPC channels to keep

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -325,7 +325,7 @@ export class Firestore {
    * @param {number=} settings.maxIdleChannels  The maximum number of idle GRPC
    * channels to keep. A smaller number of idle channels reduces memory usage
    * but increases request latency for clients with fluctuating request rates.
-   * If set to 0, shuts down all GRPC channels when the client becomes idle. 
+   * If set to 0, shuts down all GRPC channels when the client becomes idle.
    * Defaults to 1.
    */
   constructor(settings?: Settings) {

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -131,6 +131,11 @@ const CLOUD_RESOURCE_HEADER = 'google-cloud-resource-prefix';
 const MAX_REQUEST_RETRIES = 5;
 
 /*!
+ * The default number of idle GRPC channel to keep.
+ */
+const DEFAULT_MAX_IDLE_CHANNELS = 1;
+
+/*!
  * The maximum number of concurrent requests supported by a single GRPC channel,
  * as enforced by Google's Frontend. If the SDK issues more than 100 concurrent
  * operations, we need to use more than one GAPIC client since these clients
@@ -317,6 +322,10 @@ export class Firestore {
    * can specify a `keyFilename` instead.
    * @param {string=} settings.host The host to connect to.
    * @param {boolean=} settings.ssl Whether to use SSL when connecting.
+   * @param {number=} settings.maxIdleChannels  The maximum number of idle GRPC
+   * channels to keep. A smaller number of idle channels reduces memory usage
+   * but increases request latency for clients with fluctuating request rates.
+   * Defaults to 1.
    */
   constructor(settings?: Settings) {
     const libraryHeader = {
@@ -372,8 +381,13 @@ export class Firestore {
       logger('Firestore', null, 'Detected GCF environment');
     }
 
+    const maxIdleChannels =
+      this._settings.maxIdleChannels === undefined
+        ? DEFAULT_MAX_IDLE_CHANNELS
+        : this._settings.maxIdleChannels;
     this._clientPool = new ClientPool(
       MAX_CONCURRENT_REQUESTS_PER_CLIENT,
+      maxIdleChannels,
       /* clientFactory= */ () => {
         let client: GapicClient;
 
@@ -453,6 +467,12 @@ export class Firestore {
 
     if (settings.ssl !== undefined) {
       validateBoolean('settings.ssl', settings.ssl);
+    }
+
+    if (settings.maxIdleChannels !== undefined) {
+      validateInteger('settings.maxIdleChannels', settings.maxIdleChannels, {
+        minValue: 0,
+      });
     }
 
     this._settings = settings;

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -325,6 +325,7 @@ export class Firestore {
    * @param {number=} settings.maxIdleChannels  The maximum number of idle GRPC
    * channels to keep. A smaller number of idle channels reduces memory usage
    * but increases request latency for clients with fluctuating request rates.
+   * If set to 0, shuts down all GRPC channels when the client becomes idle. 
    * Defaults to 1.
    */
   constructor(settings?: Settings) {

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -72,6 +72,13 @@ export interface Settings {
   /** Whether to use SSL when connecting. */
   ssl?: boolean;
 
+  /**
+   * The maximum number of idle GRPC channels to keep. A smaller number of idle
+   * channels reduces memory usage but increases request latency for clients
+   * with fluctuating request rates. Defaults to 1.
+   */
+  maxIdleChannels?: number;
+
   // tslint:disable-next-line:no-any
   [key: string]: any; // Accept other properties, such as GRPC settings.
 }

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -75,7 +75,8 @@ export interface Settings {
   /**
    * The maximum number of idle GRPC channels to keep. A smaller number of idle
    * channels reduces memory usage but increases request latency for clients
-   * with fluctuating request rates. Defaults to 1.
+   * with fluctuating request rates. If set to 0, shuts down all GRPC channels
+   * when the client becomes idle. Defaults to 1.
    */
   maxIdleChannels?: number;
 

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -491,6 +491,19 @@ describe('instantiation', () => {
     }
   });
 
+  it('validates maxIdleChannels', () => {
+    const invalidValues = [-1, 'foo', 1.3];
+
+    for (const value of invalidValues) {
+      expect(() => {
+        const settings = {...DEFAULT_SETTINGS, maxIdleChannels: value};
+        new Firestore.Firestore(settings as InvalidApiUsage);
+      }).to.throw();
+    }
+
+    new Firestore.Firestore({maxIdleChannels: 1});
+  });
+
   it('uses project id from constructor', () => {
     const firestore = new Firestore.Firestore({projectId: 'foo'});
 

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -112,7 +112,7 @@ describe('Client pool', () => {
       return operationPromises[4].promise;
     });
 
-    // Free one slow on the second client.
+    // Free one slot on the second client.
     operationPromises[2].resolve();
     await thirdOperation;
 
@@ -261,7 +261,7 @@ describe('Client pool', () => {
   });
 
   it('default setting keeps at least one idle client', async () => {
-    const clientPool = new ClientPool<{}>(1, /* maxIdleClients=*/ 1, () => {
+    const clientPool = new ClientPool<{}>(1, /* maxIdleClients= git c*/ 1, () => {
       return {};
     });
 

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -261,9 +261,13 @@ describe('Client pool', () => {
   });
 
   it('default setting keeps at least one idle client', async () => {
-    const clientPool = new ClientPool<{}>(1, /* maxIdleClients= git c*/ 1, () => {
-      return {};
-    });
+    const clientPool = new ClientPool<{}>(
+      1,
+      /* maxIdleClients= git c*/ 1,
+      () => {
+        return {};
+      }
+    );
 
     const operationPromises = deferredPromises(2);
     clientPool.run(REQUEST_TAG, () => operationPromises[0].promise);

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -58,6 +58,7 @@ xdescribe('firestore.d.ts', () => {
     firestore.settings({
       keyFilename: 'foo',
       projectId: 'foo',
+      maxIdleChannels: 42,
       otherOption: 'foo',
     });
     const collRef: CollectionReference = firestore.collection('coll');

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -105,20 +105,26 @@ export function createInstance(
   const firestore = new Firestore();
   firestore.settings(initializationOptions);
 
-  const clientPool = new ClientPool(/* concurrentRequestLimit= */ 1, () => {
-    const gapicClient: GapicClient = new v1(initializationOptions);
-    if (apiOverrides) {
-      Object.keys(apiOverrides).forEach(override => {
-        const apiOverride = (apiOverrides as {[k: string]: unknown})[override];
-        if (override !== 'getProjectId') {
-          gapicClient._innerApiCalls[override] = apiOverride;
-        } else {
-          gapicClient[override] = apiOverride;
-        }
-      });
+  const clientPool = new ClientPool(
+    /* concurrentRequestLimit= */ 1,
+    /* maxIdleClients= */ 0,
+    () => {
+      const gapicClient: GapicClient = new v1(initializationOptions);
+      if (apiOverrides) {
+        Object.keys(apiOverrides).forEach(override => {
+          const apiOverride = (apiOverrides as {[k: string]: unknown})[
+            override
+          ];
+          if (override !== 'getProjectId') {
+            gapicClient._innerApiCalls[override] = apiOverride;
+          } else {
+            gapicClient[override] = apiOverride;
+          }
+        });
+      }
+      return gapicClient;
     }
-    return gapicClient;
-  });
+  );
 
   firestore['_clientPool'] = clientPool;
 

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -926,7 +926,7 @@ describe('Query watch', () => {
     }
 
     return result;
-  });
+  }).timeout(5000);
 
   it('retries with unknown code', () => {
     return watchHelper.runTest(collQueryJSON(), () => {

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -80,6 +80,13 @@ declare namespace FirebaseFirestore {
     /** Whether to use SSL when connecting. */
     ssl?: boolean;
 
+    /**
+     * The maximum number of idle GRPC channels to keep. A smaller number of idle
+     * channels reduces memory usage but increases request latency for clients
+     * with fluctuating request rates. Defaults to 1.
+     */
+    maxIdleChannels?: number;
+    
     [key: string]: any; // Accept other properties, such as GRPC settings.
   }
 

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -83,7 +83,8 @@ declare namespace FirebaseFirestore {
     /**
      * The maximum number of idle GRPC channels to keep. A smaller number of idle
      * channels reduces memory usage but increases request latency for clients
-     * with fluctuating request rates. Defaults to 1.
+     * with fluctuating request rates.  If set to 0, shuts down all GRPC channels
+     * when the client becomes idle. Defaults to 1.
      */
     maxIdleChannels?: number;
     

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -83,7 +83,7 @@ declare namespace FirebaseFirestore {
     /**
      * The maximum number of idle GRPC channels to keep. A smaller number of idle
      * channels reduces memory usage but increases request latency for clients
-     * with fluctuating request rates.  If set to 0, shuts down all GRPC channels
+     * with fluctuating request rates. If set to 0, shuts down all GRPC channels
      * when the client becomes idle. Defaults to 1.
      */
     maxIdleChannels?: number;


### PR DESCRIPTION
This PR lets users influence the memory profile of their Firestore usage:
- They can set the minimum client pool size to 0 to close all GRPC channels when Firestore is completely idle
- They can use a larger number to reduce the startup costs of new GRPC channels.

This PR aims to preserve the current behavior by always leaving at least one GRPC channel if no option is provided.

b/146363799