### PR TITLE
fix: reduce overhead for listDocuments()/listCollections()

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -286,7 +286,13 @@ export class DocumentReference implements Serializable {
   listCollections(): Promise<CollectionReference[]> {
     const tag = requestTag();
     return this.firestore.initializeIfNeeded(tag).then(() => {
-      const request = {parent: this.formattedName};
+      const request: api.IListCollectionIdsRequest = {
+        parent: this.formattedName,
+        // Setting `pageSize` to an arbitrarily large value lets the backend cap
+        // the page size (currently to 300). Note that the backend rejects
+        // MAX_INT32 (b/146883794).
+        pageSize: Math.pow(2, 16) - 1,
+      };
       return this._firestore
         .request<string[]>(
           'listCollectionIds',
@@ -2051,6 +2057,9 @@ export class CollectionReference extends Query {
         parent: parentPath.formattedName,
         collectionId: this.id,
         showMissing: true,
+        // Setting `pageSize` to the maximum allowed value lets the backend cap
+        // the page size (currently to 300).
+        pageSize: Math.pow(2, 32) - 1,
         mask: {fieldPaths: []},
       };
 

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -142,6 +142,7 @@ describe('Collection interface', () => {
           parent: `${DATABASE_ROOT}/documents/a/b`,
           collectionId: 'c',
           showMissing: true,
+          pageSize: 4294967295,
           mask: {fieldPaths: []},
         });
 

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -2003,6 +2003,7 @@ describe('listCollections() method', () => {
       listCollectionIds: (request, options, callback) => {
         expect(request).to.deep.eq({
           parent: `projects/${PROJECT_ID}/databases/(default)/documents/coll/doc`,
+          pageSize: 65535,
         });
 
         callback(null, ['second', 'first']);

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -871,6 +871,7 @@ describe('listCollections() method', () => {
       listCollectionIds: (request, options, callback) => {
         expect(request).to.deep.eq({
           parent: `projects/${PROJECT_ID}/databases/(default)/documents`,
+          pageSize: 65535,
         });
 
         callback(null, ['first', 'second']);


### PR DESCRIPTION
This increases the page size from 20 (default) to 300 (max).

Fixes https://github.com/googleapis/nodejs-firestore/issues/825