### PR TITLE
build: add typings for generated client

### DIFF
--- a/dev/test/fake-certificate.json
+++ b/dev/test/fake-certificate.json
@@ -1,8 +1,0 @@
-{
-  "type": "service_account",
-  "project_id": "...",
-  "private_key_id": "...",
-  "private_key": "...",
-  "client_email": "...",
-  "client_id": "..."
-}

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -47,7 +47,6 @@ const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
 const DEFAULT_SETTINGS = {
   projectId: PROJECT_ID,
   sslCreds: grpc.credentials.createInsecure(),
-  keyFilename: __dirname + '/fake-certificate.json',
 };
 
 // Change the argument to 'console.log' to enable debug output.
@@ -533,7 +532,6 @@ describe('instantiation', () => {
   it('uses project ID from settings()', () => {
     const firestore = new Firestore.Firestore({
       sslCreds: grpc.credentials.createInsecure(),
-      keyFilename: './test/fake-certificate.json',
     });
 
     firestore.settings({projectId: PROJECT_ID});
@@ -662,7 +660,6 @@ describe('snapshot_() method', () => {
     firestore = new Firestore.Firestore({
       projectId: PROJECT_ID,
       sslCreds: grpc.credentials.createInsecure(),
-      keyFilename: './test/fake-certificate.json',
     });
   });
 

--- a/dev/types/v1/firestore_admin_client.d.ts
+++ b/dev/types/v1/firestore_admin_client.d.ts
@@ -1,0 +1,319 @@
+/*!
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="node" />
+import * as gax from 'google-gax';
+import { Callback, ClientOptions, LROperation } from 'google-gax';
+import { Transform } from 'stream';
+import * as protosTypes from '../../protos/firestore_admin_v1_proto_api';
+/**
+ *  Operations are created by service `FirestoreAdmin`, but are accessed via
+ *  service `google.longrunning.Operations`.
+ * @class
+ * @memberof v1
+ */
+export declare class FirestoreAdminClient {
+    private _descriptors;
+    private _innerApiCalls;
+    private _pathTemplates;
+    private _terminated;
+    auth: gax.GoogleAuth;
+    operationsClient: gax.OperationsClient;
+    firestoreAdminStub: Promise<{
+        [name: string]: Function;
+    }>;
+    /**
+     * Construct an instance of FirestoreAdminClient.
+     *
+     * @param {object} [options] - The configuration object. See the subsequent
+     *   parameters for more details.
+     * @param {object} [options.credentials] - Credentials object.
+     * @param {string} [options.credentials.client_email]
+     * @param {string} [options.credentials.private_key]
+     * @param {string} [options.email] - Account email address. Required when
+     *     using a .pem or .p12 keyFilename.
+     * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+     *     .p12 key downloaded from the Google Developers Console. If you provide
+     *     a path to a JSON file, the projectId option below is not necessary.
+     *     NOTE: .pem and .p12 require you to specify options.email as well.
+     * @param {number} [options.port] - The port on which to connect to
+     *     the remote host.
+     * @param {string} [options.projectId] - The project ID from the Google
+     *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+     *     the environment variable GCLOUD_PROJECT for your project ID. If your
+     *     app is running in an environment which supports
+     *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+     *     your project ID will be detected automatically.
+     * @param {function} [options.promise] - Custom promise module to use instead
+     *     of native Promises.
+     * @param {string} [options.apiEndpoint] - The domain name of the
+     *     API remote host.
+     */
+    constructor(opts?: ClientOptions);
+    /**
+     * The DNS address for this API service.
+     */
+    static readonly servicePath: string;
+    /**
+     * The DNS address for this API service - same as servicePath(),
+     * exists for compatibility reasons.
+     */
+    static readonly apiEndpoint: string;
+    /**
+     * The port for this API service.
+     */
+    static readonly port: number;
+    /**
+     * The scopes needed to make gRPC calls for every method defined
+     * in this service.
+     */
+    static readonly scopes: string[];
+    getProjectId(): Promise<string>;
+    getProjectId(callback: Callback<string, undefined, undefined>): void;
+    getIndex(request: protosTypes.google.firestore.admin.v1.IGetIndexRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.admin.v1.IIndex, protosTypes.google.firestore.admin.v1.IGetIndexRequest | undefined, {} | undefined]>;
+    getIndex(request: protosTypes.google.firestore.admin.v1.IGetIndexRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.admin.v1.IIndex, protosTypes.google.firestore.admin.v1.IGetIndexRequest | undefined, {} | undefined>): void;
+    deleteIndex(request: protosTypes.google.firestore.admin.v1.IDeleteIndexRequest, options?: gax.CallOptions): Promise<[protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.admin.v1.IDeleteIndexRequest | undefined, {} | undefined]>;
+    deleteIndex(request: protosTypes.google.firestore.admin.v1.IDeleteIndexRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.admin.v1.IDeleteIndexRequest | undefined, {} | undefined>): void;
+    getField(request: protosTypes.google.firestore.admin.v1.IGetFieldRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.admin.v1.IField, protosTypes.google.firestore.admin.v1.IGetFieldRequest | undefined, {} | undefined]>;
+    getField(request: protosTypes.google.firestore.admin.v1.IGetFieldRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.admin.v1.IField, protosTypes.google.firestore.admin.v1.IGetFieldRequest | undefined, {} | undefined>): void;
+    createIndex(request: protosTypes.google.firestore.admin.v1.ICreateIndexRequest, options?: gax.CallOptions): Promise<[LROperation<protosTypes.google.firestore.admin.v1.IIndex, protosTypes.google.firestore.admin.v1.IIndexOperationMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined]>;
+    createIndex(request: protosTypes.google.firestore.admin.v1.ICreateIndexRequest, options: gax.CallOptions, callback: Callback<LROperation<protosTypes.google.firestore.admin.v1.IIndex, protosTypes.google.firestore.admin.v1.IIndexOperationMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined>): void;
+    updateField(request: protosTypes.google.firestore.admin.v1.IUpdateFieldRequest, options?: gax.CallOptions): Promise<[LROperation<protosTypes.google.firestore.admin.v1.IField, protosTypes.google.firestore.admin.v1.IFieldOperationMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined]>;
+    updateField(request: protosTypes.google.firestore.admin.v1.IUpdateFieldRequest, options: gax.CallOptions, callback: Callback<LROperation<protosTypes.google.firestore.admin.v1.IField, protosTypes.google.firestore.admin.v1.IFieldOperationMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined>): void;
+    exportDocuments(request: protosTypes.google.firestore.admin.v1.IExportDocumentsRequest, options?: gax.CallOptions): Promise<[LROperation<protosTypes.google.firestore.admin.v1.IExportDocumentsResponse, protosTypes.google.firestore.admin.v1.IExportDocumentsMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined]>;
+    exportDocuments(request: protosTypes.google.firestore.admin.v1.IExportDocumentsRequest, options: gax.CallOptions, callback: Callback<LROperation<protosTypes.google.firestore.admin.v1.IExportDocumentsResponse, protosTypes.google.firestore.admin.v1.IExportDocumentsMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined>): void;
+    importDocuments(request: protosTypes.google.firestore.admin.v1.IImportDocumentsRequest, options?: gax.CallOptions): Promise<[LROperation<protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.admin.v1.IImportDocumentsMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined]>;
+    importDocuments(request: protosTypes.google.firestore.admin.v1.IImportDocumentsRequest, options: gax.CallOptions, callback: Callback<LROperation<protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.admin.v1.IImportDocumentsMetadata>, protosTypes.google.longrunning.IOperation | undefined, {} | undefined>): void;
+    listIndexes(request: protosTypes.google.firestore.admin.v1.IListIndexesRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.admin.v1.IIndex[], protosTypes.google.firestore.admin.v1.IListIndexesRequest | null, protosTypes.google.firestore.admin.v1.IListIndexesResponse]>;
+    listIndexes(request: protosTypes.google.firestore.admin.v1.IListIndexesRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.admin.v1.IIndex[], protosTypes.google.firestore.admin.v1.IListIndexesRequest | null, protosTypes.google.firestore.admin.v1.IListIndexesResponse>): void;
+    /**
+     * Equivalent to {@link listIndexes}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listIndexes} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. A parent name of the form
+     *   `projects/{project_id}/databases/{database_id}/collectionGroups/{collection_id}`
+     * @param {string} request.filter
+     *   The filter to apply to list results.
+     * @param {number} request.pageSize
+     *   The number of results to return.
+     * @param {string} request.pageToken
+     *   A page token, returned from a previous call to
+     *   [FirestoreAdmin.ListIndexes][google.firestore.admin.v1.FirestoreAdmin.ListIndexes], that may be used to get the next
+     *   page of results.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing [Index]{@link google.firestore.admin.v1.Index} on 'data' event.
+     */
+    listIndexesStream(request?: protosTypes.google.firestore.admin.v1.IListIndexesRequest, options?: gax.CallOptions | {}): Transform;
+    listFields(request: protosTypes.google.firestore.admin.v1.IListFieldsRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.admin.v1.IField[], protosTypes.google.firestore.admin.v1.IListFieldsRequest | null, protosTypes.google.firestore.admin.v1.IListFieldsResponse]>;
+    listFields(request: protosTypes.google.firestore.admin.v1.IListFieldsRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.admin.v1.IField[], protosTypes.google.firestore.admin.v1.IListFieldsRequest | null, protosTypes.google.firestore.admin.v1.IListFieldsResponse>): void;
+    /**
+     * Equivalent to {@link listFields}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listFields} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. A parent name of the form
+     *   `projects/{project_id}/databases/{database_id}/collectionGroups/{collection_id}`
+     * @param {string} request.filter
+     *   The filter to apply to list results. Currently,
+     *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] only supports listing fields
+     *   that have been explicitly overridden. To issue this query, call
+     *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] with the filter set to
+     *   `indexConfig.usesAncestorConfig:false`.
+     * @param {number} request.pageSize
+     *   The number of results to return.
+     * @param {string} request.pageToken
+     *   A page token, returned from a previous call to
+     *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields], that may be used to get the next
+     *   page of results.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing [Field]{@link google.firestore.admin.v1.Field} on 'data' event.
+     */
+    listFieldsStream(request?: protosTypes.google.firestore.admin.v1.IListFieldsRequest, options?: gax.CallOptions | {}): Transform;
+    /**
+     * Return a fully-qualified collectiongroup resource name string.
+     *
+     * @param {string} project
+     * @param {string} database
+     * @param {string} collection
+     * @returns {string} Resource name string.
+     */
+    collectiongroupPath(project: string, database: string, collection: string): string;
+    /**
+     * Parse the project from CollectionGroup resource.
+     *
+     * @param {string} collectiongroupName
+     *   A fully-qualified path representing CollectionGroup resource.
+     * @returns {string} A string representing the project.
+     */
+    matchProjectFromCollectionGroupName(collectiongroupName: string): string;
+    /**
+     * Parse the database from CollectionGroup resource.
+     *
+     * @param {string} collectiongroupName
+     *   A fully-qualified path representing CollectionGroup resource.
+     * @returns {string} A string representing the database.
+     */
+    matchDatabaseFromCollectionGroupName(collectiongroupName: string): string;
+    /**
+     * Parse the collection from CollectionGroup resource.
+     *
+     * @param {string} collectiongroupName
+     *   A fully-qualified path representing CollectionGroup resource.
+     * @returns {string} A string representing the collection.
+     */
+    matchCollectionFromCollectionGroupName(collectiongroupName: string): string;
+    /**
+     * Return a fully-qualified index resource name string.
+     *
+     * @param {string} project
+     * @param {string} database
+     * @param {string} collection
+     * @param {string} index
+     * @returns {string} Resource name string.
+     */
+    indexPath(project: string, database: string, collection: string, index: string): string;
+    /**
+     * Parse the project from Index resource.
+     *
+     * @param {string} indexName
+     *   A fully-qualified path representing Index resource.
+     * @returns {string} A string representing the project.
+     */
+    matchProjectFromIndexName(indexName: string): string;
+    /**
+     * Parse the database from Index resource.
+     *
+     * @param {string} indexName
+     *   A fully-qualified path representing Index resource.
+     * @returns {string} A string representing the database.
+     */
+    matchDatabaseFromIndexName(indexName: string): string;
+    /**
+     * Parse the collection from Index resource.
+     *
+     * @param {string} indexName
+     *   A fully-qualified path representing Index resource.
+     * @returns {string} A string representing the collection.
+     */
+    matchCollectionFromIndexName(indexName: string): string;
+    /**
+     * Parse the index from Index resource.
+     *
+     * @param {string} indexName
+     *   A fully-qualified path representing Index resource.
+     * @returns {string} A string representing the index.
+     */
+    matchIndexFromIndexName(indexName: string): string;
+    /**
+     * Return a fully-qualified field resource name string.
+     *
+     * @param {string} project
+     * @param {string} database
+     * @param {string} collection
+     * @param {string} field
+     * @returns {string} Resource name string.
+     */
+    fieldPath(project: string, database: string, collection: string, field: string): string;
+    /**
+     * Parse the project from Field resource.
+     *
+     * @param {string} fieldName
+     *   A fully-qualified path representing Field resource.
+     * @returns {string} A string representing the project.
+     */
+    matchProjectFromFieldName(fieldName: string): string;
+    /**
+     * Parse the database from Field resource.
+     *
+     * @param {string} fieldName
+     *   A fully-qualified path representing Field resource.
+     * @returns {string} A string representing the database.
+     */
+    matchDatabaseFromFieldName(fieldName: string): string;
+    /**
+     * Parse the collection from Field resource.
+     *
+     * @param {string} fieldName
+     *   A fully-qualified path representing Field resource.
+     * @returns {string} A string representing the collection.
+     */
+    matchCollectionFromFieldName(fieldName: string): string;
+    /**
+     * Parse the field from Field resource.
+     *
+     * @param {string} fieldName
+     *   A fully-qualified path representing Field resource.
+     * @returns {string} A string representing the field.
+     */
+    matchFieldFromFieldName(fieldName: string): string;
+    /**
+     * Return a fully-qualified database resource name string.
+     *
+     * @param {string} project
+     * @param {string} database
+     * @returns {string} Resource name string.
+     */
+    databasePath(project: string, database: string): string;
+    /**
+     * Parse the project from Database resource.
+     *
+     * @param {string} databaseName
+     *   A fully-qualified path representing Database resource.
+     * @returns {string} A string representing the project.
+     */
+    matchProjectFromDatabaseName(databaseName: string): string;
+    /**
+     * Parse the database from Database resource.
+     *
+     * @param {string} databaseName
+     *   A fully-qualified path representing Database resource.
+     * @returns {string} A string representing the database.
+     */
+    matchDatabaseFromDatabaseName(databaseName: string): string;
+    /**
+     * Terminate the GRPC channel and close the client.
+     *
+     * The client will no longer be usable and all future behavior is undefined.
+     */
+    close(): Promise<void>;
+}

--- a/dev/types/v1/firestore_client.d.ts
+++ b/dev/types/v1/firestore_client.d.ts
@@ -1,0 +1,297 @@
+/*!
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="node" />
+import * as gax from 'google-gax';
+import { Callback, ClientOptions } from 'google-gax';
+import { Transform } from 'stream';
+import * as protosTypes from '../../protos/firestore_v1_proto_api';
+/**
+ *  The Cloud Firestore service.
+ *
+ *  This service exposes several types of comparable timestamps:
+ *
+ *  *    `create_time` - The time at which a document was created. Changes only
+ *       when a document is deleted, then re-created. Increases in a strict
+ *        monotonic fashion.
+ *  *    `update_time` - The time at which a document was last updated. Changes
+ *       every time a document is modified. Does not change when a write results
+ *       in no modifications. Increases in a strict monotonic fashion.
+ *  *    `read_time` - The time at which a particular state was observed. Used
+ *       to denote a consistent snapshot of the database or the time at which a
+ *       Document was observed to not exist.
+ *  *    `commit_time` - The time at which the writes in a transaction were
+ *       committed. Any read with an equal or greater `read_time` is guaranteed
+ *       to see the effects of the transaction.
+ * @class
+ * @memberof v1
+ */
+export declare class FirestoreClient {
+    private _descriptors;
+    private _innerApiCalls;
+    private _terminated;
+    auth: gax.GoogleAuth;
+    firestoreStub: Promise<{
+        [name: string]: Function;
+    }>;
+    /**
+     * Construct an instance of FirestoreClient.
+     *
+     * @param {object} [options] - The configuration object. See the subsequent
+     *   parameters for more details.
+     * @param {object} [options.credentials] - Credentials object.
+     * @param {string} [options.credentials.client_email]
+     * @param {string} [options.credentials.private_key]
+     * @param {string} [options.email] - Account email address. Required when
+     *     using a .pem or .p12 keyFilename.
+     * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+     *     .p12 key downloaded from the Google Developers Console. If you provide
+     *     a path to a JSON file, the projectId option below is not necessary.
+     *     NOTE: .pem and .p12 require you to specify options.email as well.
+     * @param {number} [options.port] - The port on which to connect to
+     *     the remote host.
+     * @param {string} [options.projectId] - The project ID from the Google
+     *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+     *     the environment variable GCLOUD_PROJECT for your project ID. If your
+     *     app is running in an environment which supports
+     *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+     *     your project ID will be detected automatically.
+     * @param {function} [options.promise] - Custom promise module to use instead
+     *     of native Promises.
+     * @param {string} [options.apiEndpoint] - The domain name of the
+     *     API remote host.
+     */
+    constructor(opts?: ClientOptions);
+    /**
+     * The DNS address for this API service.
+     */
+    static readonly servicePath: string;
+    /**
+     * The DNS address for this API service - same as servicePath(),
+     * exists for compatibility reasons.
+     */
+    static readonly apiEndpoint: string;
+    /**
+     * The port for this API service.
+     */
+    static readonly port: number;
+    /**
+     * The scopes needed to make gRPC calls for every method defined
+     * in this service.
+     */
+    static readonly scopes: string[];
+    getProjectId(): Promise<string>;
+    getProjectId(callback: Callback<string, undefined, undefined>): void;
+    getDocument(request: protosTypes.google.firestore.v1.IGetDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1.IDocument, protosTypes.google.firestore.v1.IGetDocumentRequest | undefined, {} | undefined]>;
+    getDocument(request: protosTypes.google.firestore.v1.IGetDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1.IDocument, protosTypes.google.firestore.v1.IGetDocumentRequest | undefined, {} | undefined>): void;
+    createDocument(request: protosTypes.google.firestore.v1.ICreateDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1.IDocument, protosTypes.google.firestore.v1.ICreateDocumentRequest | undefined, {} | undefined]>;
+    createDocument(request: protosTypes.google.firestore.v1.ICreateDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1.IDocument, protosTypes.google.firestore.v1.ICreateDocumentRequest | undefined, {} | undefined>): void;
+    updateDocument(request: protosTypes.google.firestore.v1.IUpdateDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1.IDocument, protosTypes.google.firestore.v1.IUpdateDocumentRequest | undefined, {} | undefined]>;
+    updateDocument(request: protosTypes.google.firestore.v1.IUpdateDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1.IDocument, protosTypes.google.firestore.v1.IUpdateDocumentRequest | undefined, {} | undefined>): void;
+    deleteDocument(request: protosTypes.google.firestore.v1.IDeleteDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1.IDeleteDocumentRequest | undefined, {} | undefined]>;
+    deleteDocument(request: protosTypes.google.firestore.v1.IDeleteDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1.IDeleteDocumentRequest | undefined, {} | undefined>): void;
+    beginTransaction(request: protosTypes.google.firestore.v1.IBeginTransactionRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1.IBeginTransactionResponse, protosTypes.google.firestore.v1.IBeginTransactionRequest | undefined, {} | undefined]>;
+    beginTransaction(request: protosTypes.google.firestore.v1.IBeginTransactionRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1.IBeginTransactionResponse, protosTypes.google.firestore.v1.IBeginTransactionRequest | undefined, {} | undefined>): void;
+    commit(request: protosTypes.google.firestore.v1.ICommitRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1.ICommitResponse, protosTypes.google.firestore.v1.ICommitRequest | undefined, {} | undefined]>;
+    commit(request: protosTypes.google.firestore.v1.ICommitRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1.ICommitResponse, protosTypes.google.firestore.v1.ICommitRequest | undefined, {} | undefined>): void;
+    rollback(request: protosTypes.google.firestore.v1.IRollbackRequest, options?: gax.CallOptions): Promise<[protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1.IRollbackRequest | undefined, {} | undefined]>;
+    rollback(request: protosTypes.google.firestore.v1.IRollbackRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1.IRollbackRequest | undefined, {} | undefined>): void;
+    /**
+     * Gets multiple documents.
+     *
+     * Documents returned by this method are not guaranteed to be returned in the
+     * same order that they were requested.
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.database
+     *   Required. The database name. In the format:
+     *   `projects/{project_id}/databases/{database_id}`.
+     * @param {string[]} request.documents
+     *   The names of the documents to retrieve. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   The request will fail if any of the document is not a child resource of the
+     *   given `database`. Duplicate names will be elided.
+     * @param {google.firestore.v1.DocumentMask} request.mask
+     *   The fields to return. If not set, returns all fields.
+     *
+     *   If a document has a field that is not present in this mask, that field will
+     *   not be returned in the response.
+     * @param {Buffer} request.transaction
+     *   Reads documents in a transaction.
+     * @param {google.firestore.v1.TransactionOptions} request.newTransaction
+     *   Starts a new transaction and reads the documents.
+     *   Defaults to a read-only transaction.
+     *   The new transaction ID will be returned as the first response in the
+     *   stream.
+     * @param {google.protobuf.Timestamp} request.readTime
+     *   Reads documents as they were at the given time.
+     *   This may not be older than 60 seconds.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits [BatchGetDocumentsResponse]{@link google.firestore.v1.BatchGetDocumentsResponse} on 'data' event.
+     */
+    batchGetDocuments(request?: protosTypes.google.firestore.v1.IBatchGetDocumentsRequest, options?: gax.CallOptions): gax.CancellableStream;
+    /**
+     * Runs a query.
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. The parent resource name. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents` or
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   For example:
+     *   `projects/my-project/databases/my-database/documents` or
+     *   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
+     * @param {google.firestore.v1.StructuredQuery} request.structuredQuery
+     *   A structured query.
+     * @param {Buffer} request.transaction
+     *   Reads documents in a transaction.
+     * @param {google.firestore.v1.TransactionOptions} request.newTransaction
+     *   Starts a new transaction and reads the documents.
+     *   Defaults to a read-only transaction.
+     *   The new transaction ID will be returned as the first response in the
+     *   stream.
+     * @param {google.protobuf.Timestamp} request.readTime
+     *   Reads documents as they were at the given time.
+     *   This may not be older than 60 seconds.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits [RunQueryResponse]{@link google.firestore.v1.RunQueryResponse} on 'data' event.
+     */
+    runQuery(request?: protosTypes.google.firestore.v1.IRunQueryRequest, options?: gax.CallOptions): gax.CancellableStream;
+    /**
+     * Streams batches of document updates and deletes, in order.
+     *
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which is both readable and writable. It accepts objects
+     *   representing [WriteRequest]{@link google.firestore.v1.WriteRequest} for write() method, and
+     *   will emit objects representing [WriteResponse]{@link google.firestore.v1.WriteResponse} on 'data' event asynchronously.
+     */
+    write(options?: gax.CallOptions): gax.CancellableStream;
+    /**
+     * Listens to changes.
+     *
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which is both readable and writable. It accepts objects
+     *   representing [ListenRequest]{@link google.firestore.v1.ListenRequest} for write() method, and
+     *   will emit objects representing [ListenResponse]{@link google.firestore.v1.ListenResponse} on 'data' event asynchronously.
+     */
+    listen(options?: gax.CallOptions): gax.CancellableStream;
+    listDocuments(request: protosTypes.google.firestore.v1.IListDocumentsRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1.IDocument[], protosTypes.google.firestore.v1.IListDocumentsRequest | null, protosTypes.google.firestore.v1.IListDocumentsResponse]>;
+    listDocuments(request: protosTypes.google.firestore.v1.IListDocumentsRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1.IDocument[], protosTypes.google.firestore.v1.IListDocumentsRequest | null, protosTypes.google.firestore.v1.IListDocumentsResponse>): void;
+    /**
+     * Equivalent to {@link listDocuments}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listDocuments} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. The parent resource name. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents` or
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   For example:
+     *   `projects/my-project/databases/my-database/documents` or
+     *   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
+     * @param {string} request.collectionId
+     *   Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`
+     *   or `messages`.
+     * @param {number} request.pageSize
+     *   The maximum number of documents to return.
+     * @param {string} request.pageToken
+     *   The `next_page_token` value returned from a previous List request, if any.
+     * @param {string} request.orderBy
+     *   The order to sort results by. For example: `priority desc, name`.
+     * @param {google.firestore.v1.DocumentMask} request.mask
+     *   The fields to return. If not set, returns all fields.
+     *
+     *   If a document has a field that is not present in this mask, that field
+     *   will not be returned in the response.
+     * @param {Buffer} request.transaction
+     *   Reads documents in a transaction.
+     * @param {google.protobuf.Timestamp} request.readTime
+     *   Reads documents as they were at the given time.
+     *   This may not be older than 60 seconds.
+     * @param {boolean} request.showMissing
+     *   If the list should show missing documents. A missing document is a
+     *   document that does not exist but has sub-documents. These documents will
+     *   be returned with a key but will not have fields, [Document.create_time][google.firestore.v1.Document.create_time],
+     *   or [Document.update_time][google.firestore.v1.Document.update_time] set.
+     *
+     *   Requests with `show_missing` may not specify `where` or
+     *   `order_by`.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing [Document]{@link google.firestore.v1.Document} on 'data' event.
+     */
+    listDocumentsStream(request?: protosTypes.google.firestore.v1.IListDocumentsRequest, options?: gax.CallOptions | {}): Transform;
+    listCollectionIds(request: protosTypes.google.firestore.v1.IListCollectionIdsRequest, options?: gax.CallOptions): Promise<[string[], protosTypes.google.firestore.v1.IListCollectionIdsRequest | null, protosTypes.google.firestore.v1.IListCollectionIdsResponse]>;
+    listCollectionIds(request: protosTypes.google.firestore.v1.IListCollectionIdsRequest, options: gax.CallOptions, callback: Callback<string[], protosTypes.google.firestore.v1.IListCollectionIdsRequest | null, protosTypes.google.firestore.v1.IListCollectionIdsResponse>): void;
+    /**
+     * Equivalent to {@link listCollectionIds}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listCollectionIds} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. The parent document. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   For example:
+     *   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
+     * @param {number} request.pageSize
+     *   The maximum number of results to return.
+     * @param {string} request.pageToken
+     *   A page token. Must be a value from
+     *   [ListCollectionIdsResponse][google.firestore.v1.ListCollectionIdsResponse].
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing string on 'data' event.
+     */
+    listCollectionIdsStream(request?: protosTypes.google.firestore.v1.IListCollectionIdsRequest, options?: gax.CallOptions | {}): Transform;
+    /**
+     * Terminate the GRPC channel and close the client.
+     *
+     * The client will no longer be usable and all future behavior is undefined.
+     */
+    close(): Promise<void>;
+}

--- a/dev/types/v1beta1/firestore_client.d.ts
+++ b/dev/types/v1beta1/firestore_client.d.ts
@@ -1,0 +1,297 @@
+/*!
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="node" />
+import * as gax from 'google-gax';
+import { Callback, ClientOptions } from 'google-gax';
+import { Transform } from 'stream';
+import * as protosTypes from '../../protos/firestore_v1beta1_proto_api';
+/**
+ *  The Cloud Firestore service.
+ *
+ *  This service exposes several types of comparable timestamps:
+ *
+ *  *    `create_time` - The time at which a document was created. Changes only
+ *       when a document is deleted, then re-created. Increases in a strict
+ *        monotonic fashion.
+ *  *    `update_time` - The time at which a document was last updated. Changes
+ *       every time a document is modified. Does not change when a write results
+ *       in no modifications. Increases in a strict monotonic fashion.
+ *  *    `read_time` - The time at which a particular state was observed. Used
+ *       to denote a consistent snapshot of the database or the time at which a
+ *       Document was observed to not exist.
+ *  *    `commit_time` - The time at which the writes in a transaction were
+ *       committed. Any read with an equal or greater `read_time` is guaranteed
+ *       to see the effects of the transaction.
+ * @class
+ * @memberof v1beta1
+ */
+export declare class FirestoreClient {
+    private _descriptors;
+    private _innerApiCalls;
+    private _terminated;
+    auth: gax.GoogleAuth;
+    firestoreStub: Promise<{
+        [name: string]: Function;
+    }>;
+    /**
+     * Construct an instance of FirestoreClient.
+     *
+     * @param {object} [options] - The configuration object. See the subsequent
+     *   parameters for more details.
+     * @param {object} [options.credentials] - Credentials object.
+     * @param {string} [options.credentials.client_email]
+     * @param {string} [options.credentials.private_key]
+     * @param {string} [options.email] - Account email address. Required when
+     *     using a .pem or .p12 keyFilename.
+     * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
+     *     .p12 key downloaded from the Google Developers Console. If you provide
+     *     a path to a JSON file, the projectId option below is not necessary.
+     *     NOTE: .pem and .p12 require you to specify options.email as well.
+     * @param {number} [options.port] - The port on which to connect to
+     *     the remote host.
+     * @param {string} [options.projectId] - The project ID from the Google
+     *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
+     *     the environment variable GCLOUD_PROJECT for your project ID. If your
+     *     app is running in an environment which supports
+     *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
+     *     your project ID will be detected automatically.
+     * @param {function} [options.promise] - Custom promise module to use instead
+     *     of native Promises.
+     * @param {string} [options.apiEndpoint] - The domain name of the
+     *     API remote host.
+     */
+    constructor(opts?: ClientOptions);
+    /**
+     * The DNS address for this API service.
+     */
+    static readonly servicePath: string;
+    /**
+     * The DNS address for this API service - same as servicePath(),
+     * exists for compatibility reasons.
+     */
+    static readonly apiEndpoint: string;
+    /**
+     * The port for this API service.
+     */
+    static readonly port: number;
+    /**
+     * The scopes needed to make gRPC calls for every method defined
+     * in this service.
+     */
+    static readonly scopes: string[];
+    getProjectId(): Promise<string>;
+    getProjectId(callback: Callback<string, undefined, undefined>): void;
+    getDocument(request: protosTypes.google.firestore.v1beta1.IGetDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1beta1.IDocument, protosTypes.google.firestore.v1beta1.IGetDocumentRequest | undefined, {} | undefined]>;
+    getDocument(request: protosTypes.google.firestore.v1beta1.IGetDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1beta1.IDocument, protosTypes.google.firestore.v1beta1.IGetDocumentRequest | undefined, {} | undefined>): void;
+    createDocument(request: protosTypes.google.firestore.v1beta1.ICreateDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1beta1.IDocument, protosTypes.google.firestore.v1beta1.ICreateDocumentRequest | undefined, {} | undefined]>;
+    createDocument(request: protosTypes.google.firestore.v1beta1.ICreateDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1beta1.IDocument, protosTypes.google.firestore.v1beta1.ICreateDocumentRequest | undefined, {} | undefined>): void;
+    updateDocument(request: protosTypes.google.firestore.v1beta1.IUpdateDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1beta1.IDocument, protosTypes.google.firestore.v1beta1.IUpdateDocumentRequest | undefined, {} | undefined]>;
+    updateDocument(request: protosTypes.google.firestore.v1beta1.IUpdateDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1beta1.IDocument, protosTypes.google.firestore.v1beta1.IUpdateDocumentRequest | undefined, {} | undefined>): void;
+    deleteDocument(request: protosTypes.google.firestore.v1beta1.IDeleteDocumentRequest, options?: gax.CallOptions): Promise<[protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1beta1.IDeleteDocumentRequest | undefined, {} | undefined]>;
+    deleteDocument(request: protosTypes.google.firestore.v1beta1.IDeleteDocumentRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1beta1.IDeleteDocumentRequest | undefined, {} | undefined>): void;
+    beginTransaction(request: protosTypes.google.firestore.v1beta1.IBeginTransactionRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1beta1.IBeginTransactionResponse, protosTypes.google.firestore.v1beta1.IBeginTransactionRequest | undefined, {} | undefined]>;
+    beginTransaction(request: protosTypes.google.firestore.v1beta1.IBeginTransactionRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1beta1.IBeginTransactionResponse, protosTypes.google.firestore.v1beta1.IBeginTransactionRequest | undefined, {} | undefined>): void;
+    commit(request: protosTypes.google.firestore.v1beta1.ICommitRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1beta1.ICommitResponse, protosTypes.google.firestore.v1beta1.ICommitRequest | undefined, {} | undefined]>;
+    commit(request: protosTypes.google.firestore.v1beta1.ICommitRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1beta1.ICommitResponse, protosTypes.google.firestore.v1beta1.ICommitRequest | undefined, {} | undefined>): void;
+    rollback(request: protosTypes.google.firestore.v1beta1.IRollbackRequest, options?: gax.CallOptions): Promise<[protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1beta1.IRollbackRequest | undefined, {} | undefined]>;
+    rollback(request: protosTypes.google.firestore.v1beta1.IRollbackRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.protobuf.IEmpty, protosTypes.google.firestore.v1beta1.IRollbackRequest | undefined, {} | undefined>): void;
+    /**
+     * Gets multiple documents.
+     *
+     * Documents returned by this method are not guaranteed to be returned in the
+     * same order that they were requested.
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.database
+     *   Required. The database name. In the format:
+     *   `projects/{project_id}/databases/{database_id}`.
+     * @param {string[]} request.documents
+     *   The names of the documents to retrieve. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   The request will fail if any of the document is not a child resource of the
+     *   given `database`. Duplicate names will be elided.
+     * @param {google.firestore.v1beta1.DocumentMask} request.mask
+     *   The fields to return. If not set, returns all fields.
+     *
+     *   If a document has a field that is not present in this mask, that field will
+     *   not be returned in the response.
+     * @param {Buffer} request.transaction
+     *   Reads documents in a transaction.
+     * @param {google.firestore.v1beta1.TransactionOptions} request.newTransaction
+     *   Starts a new transaction and reads the documents.
+     *   Defaults to a read-only transaction.
+     *   The new transaction ID will be returned as the first response in the
+     *   stream.
+     * @param {google.protobuf.Timestamp} request.readTime
+     *   Reads documents as they were at the given time.
+     *   This may not be older than 60 seconds.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits [BatchGetDocumentsResponse]{@link google.firestore.v1beta1.BatchGetDocumentsResponse} on 'data' event.
+     */
+    batchGetDocuments(request?: protosTypes.google.firestore.v1beta1.IBatchGetDocumentsRequest, options?: gax.CallOptions): gax.CancellableStream;
+    /**
+     * Runs a query.
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. The parent resource name. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents` or
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   For example:
+     *   `projects/my-project/databases/my-database/documents` or
+     *   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
+     * @param {google.firestore.v1beta1.StructuredQuery} request.structuredQuery
+     *   A structured query.
+     * @param {Buffer} request.transaction
+     *   Reads documents in a transaction.
+     * @param {google.firestore.v1beta1.TransactionOptions} request.newTransaction
+     *   Starts a new transaction and reads the documents.
+     *   Defaults to a read-only transaction.
+     *   The new transaction ID will be returned as the first response in the
+     *   stream.
+     * @param {google.protobuf.Timestamp} request.readTime
+     *   Reads documents as they were at the given time.
+     *   This may not be older than 60 seconds.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits [RunQueryResponse]{@link google.firestore.v1beta1.RunQueryResponse} on 'data' event.
+     */
+    runQuery(request?: protosTypes.google.firestore.v1beta1.IRunQueryRequest, options?: gax.CallOptions): gax.CancellableStream;
+    /**
+     * Streams batches of document updates and deletes, in order.
+     *
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which is both readable and writable. It accepts objects
+     *   representing [WriteRequest]{@link google.firestore.v1beta1.WriteRequest} for write() method, and
+     *   will emit objects representing [WriteResponse]{@link google.firestore.v1beta1.WriteResponse} on 'data' event asynchronously.
+     */
+    write(options?: gax.CallOptions): gax.CancellableStream;
+    /**
+     * Listens to changes.
+     *
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which is both readable and writable. It accepts objects
+     *   representing [ListenRequest]{@link google.firestore.v1beta1.ListenRequest} for write() method, and
+     *   will emit objects representing [ListenResponse]{@link google.firestore.v1beta1.ListenResponse} on 'data' event asynchronously.
+     */
+    listen(options?: gax.CallOptions): gax.CancellableStream;
+    listDocuments(request: protosTypes.google.firestore.v1beta1.IListDocumentsRequest, options?: gax.CallOptions): Promise<[protosTypes.google.firestore.v1beta1.IDocument[], protosTypes.google.firestore.v1beta1.IListDocumentsRequest | null, protosTypes.google.firestore.v1beta1.IListDocumentsResponse]>;
+    listDocuments(request: protosTypes.google.firestore.v1beta1.IListDocumentsRequest, options: gax.CallOptions, callback: Callback<protosTypes.google.firestore.v1beta1.IDocument[], protosTypes.google.firestore.v1beta1.IListDocumentsRequest | null, protosTypes.google.firestore.v1beta1.IListDocumentsResponse>): void;
+    /**
+     * Equivalent to {@link listDocuments}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listDocuments} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. The parent resource name. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents` or
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   For example:
+     *   `projects/my-project/databases/my-database/documents` or
+     *   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
+     * @param {string} request.collectionId
+     *   Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`
+     *   or `messages`.
+     * @param {number} request.pageSize
+     *   The maximum number of documents to return.
+     * @param {string} request.pageToken
+     *   The `next_page_token` value returned from a previous List request, if any.
+     * @param {string} request.orderBy
+     *   The order to sort results by. For example: `priority desc, name`.
+     * @param {google.firestore.v1beta1.DocumentMask} request.mask
+     *   The fields to return. If not set, returns all fields.
+     *
+     *   If a document has a field that is not present in this mask, that field
+     *   will not be returned in the response.
+     * @param {Buffer} request.transaction
+     *   Reads documents in a transaction.
+     * @param {google.protobuf.Timestamp} request.readTime
+     *   Reads documents as they were at the given time.
+     *   This may not be older than 60 seconds.
+     * @param {boolean} request.showMissing
+     *   If the list should show missing documents. A missing document is a
+     *   document that does not exist but has sub-documents. These documents will
+     *   be returned with a key but will not have fields, [Document.create_time][google.firestore.v1beta1.Document.create_time],
+     *   or [Document.update_time][google.firestore.v1beta1.Document.update_time] set.
+     *
+     *   Requests with `show_missing` may not specify `where` or
+     *   `order_by`.
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing [Document]{@link google.firestore.v1beta1.Document} on 'data' event.
+     */
+    listDocumentsStream(request?: protosTypes.google.firestore.v1beta1.IListDocumentsRequest, options?: gax.CallOptions | {}): Transform;
+    listCollectionIds(request: protosTypes.google.firestore.v1beta1.IListCollectionIdsRequest, options?: gax.CallOptions): Promise<[string[], protosTypes.google.firestore.v1beta1.IListCollectionIdsRequest | null, protosTypes.google.firestore.v1beta1.IListCollectionIdsResponse]>;
+    listCollectionIds(request: protosTypes.google.firestore.v1beta1.IListCollectionIdsRequest, options: gax.CallOptions, callback: Callback<string[], protosTypes.google.firestore.v1beta1.IListCollectionIdsRequest | null, protosTypes.google.firestore.v1beta1.IListCollectionIdsResponse>): void;
+    /**
+     * Equivalent to {@link listCollectionIds}, but returns a NodeJS Stream object.
+     *
+     * This fetches the paged responses for {@link listCollectionIds} continuously
+     * and invokes the callback registered for 'data' event for each element in the
+     * responses.
+     *
+     * The returned object has 'end' method when no more elements are required.
+     *
+     * autoPaginate option will be ignored.
+     *
+     * @see {@link https://nodejs.org/api/stream.html}
+     *
+     * @param {Object} request
+     *   The request object that will be sent.
+     * @param {string} request.parent
+     *   Required. The parent document. In the format:
+     *   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     *   For example:
+     *   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
+     * @param {number} request.pageSize
+     *   The maximum number of results to return.
+     * @param {string} request.pageToken
+     *   A page token. Must be a value from
+     *   [ListCollectionIdsResponse][google.firestore.v1beta1.ListCollectionIdsResponse].
+     * @param {object} [options]
+     *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+     * @returns {Stream}
+     *   An object stream which emits an object representing string on 'data' event.
+     */
+    listCollectionIdsStream(request?: protosTypes.google.firestore.v1beta1.IListCollectionIdsRequest, options?: gax.CallOptions | {}): Transform;
+    /**
+     * Terminate the GRPC channel and close the client.
+     *
+     * The client will no longer be usable and all future behavior is undefined.
+     */
+    close(): Promise<void>;
+}

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   },
   "repository": "googleapis/nodejs-firestore",
   "main": "./build/src/index.js",
-  "types": "./types/firestore.d.ts",
+  "types": "./build/types/firestore.d.ts",
   "files": [
     "build/protos",
     "build/src",
-    "!build/src/**/*.map",
-    "types"
+    "build/types",
+    "!build/src/**/*.map"
   ],
   "keywords": [
     "google apis client",
@@ -40,7 +40,8 @@
     "test": "npm run test-only && npm run conformance",
     "lint": "gts check",
     "clean": "gts clean",
-    "compile": "tsc -p . && cp -r dev/protos build && cp -r dev/test/fake-certificate.json build/test/fake-certificate.json && cp dev/src/v1beta1/*.json build/src/v1beta1/ && cp dev/src/v1/*.json build/src/v1/ && cp dev/conformance/test-definition.proto build/conformance && cp dev/conformance/test-suite.binproto build/conformance",
+    "compile": "tsc -p .&& cp -r dev/protos build && cp dev/src/v1beta1/*.json build/src/v1beta1/ && cp build/src/v1beta1/firestore_client.d.ts dev/types/v1beta1/ && cp dev/src/v1/*.json build/src/v1/ && cp build/src/v1/firestore_client.d.ts build/src/v1/firestore_admin_client.d.ts dev/types/v1/ && cp -r dev/types build && cp dev/conformance/test-definition.proto build/conformance && cp dev/conformance/test-suite.binproto build/conformance",
+    "postcompile": "node scripts/license.js dev/types/v1/firestore_client.d.ts dev/types/v1/firestore_admin_client.d.ts dev/types/v1beta1/firestore_client.d.ts",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "docs-test": "linkinator docs",


### PR DESCRIPTION
This PR abuses the TypeScript build pipeline to add the generated firestore_client.d.ts file to our public types.  It copies the result from the transpile step into the /src folder. This allows us to use a typed GAPIC layer without having to directly import the client (to avoid loading the GAX stack at startup).

To make the Protobuf imports work in the generated types, I move the /type folder under /src. I also removed the fake-certificate test hack, as I no longer see any warnings. This reduces the complexity of the "compile" step a tiny bit.

This is also part of the overall change in https://github.com/googleapis/nodejs-firestore/pull/849 (which is not to be submitted, but may provide some contents).