### PR TITLE
fix: do not release client before retry

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1357,7 +1357,7 @@ export class Firestore {
             callback();
           });
           stream.pipe(logStream);
-          
+
           const lifetime = new Deferred<void>();
           const resultStream = await this._initializeStream(
             stream,
@@ -1367,7 +1367,7 @@ export class Firestore {
           );
           resultStream.on('end', () => stream.end());
           result.resolve(resultStream);
-          
+
           // While we return the stream to the callee early, we don't want to
           // release the GAPIC client until the callee has finished processing the
           // stream.

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1204,7 +1204,7 @@ export class Firestore {
           resolve(resultStream);
         }
       }
-      
+
       backendStream.on('data', () => streamReady());
 
       function streamEnded() {

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1183,7 +1183,7 @@ export class Firestore {
    */
   private _initializeStream(
     backendStream: Duplex,
-    liftime: Deferred<void>,
+    lifetime: Deferred<void>,
     requestTag: string,
     request?: {}
   ): Promise<Duplex> {
@@ -1204,6 +1204,8 @@ export class Firestore {
           resolve(resultStream);
         }
       }
+      
+      backendStream.on('data', () => streamReady());
 
       function streamEnded() {
         logger(
@@ -1213,10 +1215,9 @@ export class Firestore {
         );
         resultStream.unpipe(backendStream);
         resolve(resultStream);
-        liftime.resolve();
+        lifetime.resolve();
       }
 
-      backendStream.on('data', () => streamReady());
       backendStream.on('end', () => streamEnded());
       backendStream.on('close', () => streamEnded());
       backendStream.on('finish', () => streamEnded());

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -319,12 +319,12 @@ describe('Client pool', () => {
     return clientPool
       .terminate()
       .then(() => {
-        clientPool.run(REQUEST_TAG, () =>
+        return clientPool.run(REQUEST_TAG, () =>
           Promise.reject('Call to run() should have failed')
         );
       })
       .catch((err: Error) => {
-        expect(err.message).to.equal('The client has already been terminated');
+        expect(err).to.equal('The client has already been terminated');
       });
   });
 });


### PR DESCRIPTION
Addresses https://github.com/googleapis/nodejs-firestore/issues/829

I think there is a potential problem with stream retry in the existing client. I wasn't able to write a test that hit the scenario, but I can try to put it into words.

In the existing code, requestStream() takes a client object out of the client pool and then calls retry(). There are two Promises that manage all the logic: Result and Lifetime. Since there are separate, it is possible that result.reject() is called (causing a retry) just before lifetime.resolve() is called, which returns the client back to the pool. We then retry with a client that was already returned to the pool, which - if the use is unlucky - is a client that was already garbage collected.

The change in this PR reverses the order: Each retry attempt fetches its own client from the pool, and thus the lifetime is now bound to the length of a single retry attempt.
