### PR TITLE
blocked: fix(deps): drop dependency on through2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "deep-equal": "^2.0.0",
     "functional-red-black-tree": "^1.0.1",
     "google-gax": "^1.13.0",
-    "readable-stream": "^3.4.0",
-    "through2": "^3.0.0"
+    "readable-stream": "^3.4.0"
   },
   "devDependencies": {
     "@types/assert": "^1.4.0",
@@ -83,6 +82,7 @@
     "proxyquire": "^2.1.3",
     "source-map-support": "^0.5.16",
     "ts-node": "^8.5.4",
-    "typescript": "3.6.4"
+    "typescript": "3.6.4",
+    "through2": "^3.0.0"
   }
 }


### PR DESCRIPTION
I believe that this will now pass CI since I dropped the dependency on  over the holidays and reworked our error piping. Fingers crossed

Follow up to https://github.com/googleapis/nodejs-firestore/pull/618