### PR TITLE
fix: wait for operations to complete before deleting clients

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -995,22 +995,22 @@ export class Firestore {
   }
 
   /**
-   * Registers the requestTag associated with the listener. This is used to
-   * ensure that all listeners are detached when terminate() is called.
+   * Registers a listener on this client, incrementing the listener count. This
+   * is used to ensure that all listeners are unsubscribed when terminate() is
+   * called.
    *
    * @private
-   * @param requestTag A unique client-assigned identifier
    */
   registerListener(): void {
     this.registeredListenersCount += 1;
   }
 
   /**
-   * Unregisters the requestTag associated with the listener. This is used to
-   * ensure that all listeners are detached when terminate() is called.
+   * Unregisters a listener on this client, decrementing the listener count.
+   * This is used to ensure that all listeners are unsubscribed when terminate()
+   * is called.
    *
    * @private
-   * @param requestTag A unique client-assigned identifier
    */
   unregisterListener(): void {
     this.registeredListenersCount -= 1;
@@ -1024,7 +1024,7 @@ export class Firestore {
   terminate(): Promise<void> {
     if (this.registeredListenersCount > 0) {
       return Promise.reject(
-        'All listeners must be disconnected before terminating the client.'
+        'All onSnapshot() listeners must be unsubscribed before terminating the client.'
       );
     }
     return this._clientPool.terminate();

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -299,8 +299,9 @@ export class Firestore {
   private _projectId: string | undefined = undefined;
 
   /**
-   * Set of requestTags associated with the listeners that have been registered
-   * on the client.
+   * Count of listeners that have been registered on the client.
+   *
+   * The client can only be terminated when there are no registered listeners.
    * @private
    */
   private registeredListenersCount = 0;
@@ -996,7 +997,7 @@ export class Firestore {
 
   /**
    * Registers a listener on this client, incrementing the listener count. This
-   * is used to ensure that all listeners are unsubscribed when terminate() is
+   * is used to verify that all listeners are unsubscribed when terminate() is
    * called.
    *
    * @private
@@ -1007,7 +1008,7 @@ export class Firestore {
 
   /**
    * Unregisters a listener on this client, decrementing the listener count.
-   * This is used to ensure that all listeners are unsubscribed when terminate()
+   * This is used to verify that all listeners are unsubscribed when terminate()
    * is called.
    *
    * @private

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -303,7 +303,7 @@ export class Firestore {
    * on the client.
    * @private
    */
-  private registeredListeners = new Set<string>();
+  private registeredListenersCount = 0;
 
   // GCF currently tears down idle connections after two minutes. Requests
   // that are issued after this period may fail. On GCF, we therefore issue
@@ -1001,8 +1001,8 @@ export class Firestore {
    * @private
    * @param requestTag A unique client-assigned identifier
    */
-  registerListener(requestTag: string): void {
-    this.registeredListeners.add(requestTag);
+  registerListener(): void {
+    this.registeredListenersCount += 1;
   }
 
   /**
@@ -1012,8 +1012,8 @@ export class Firestore {
    * @private
    * @param requestTag A unique client-assigned identifier
    */
-  unregisterListener(requestTag: string): void {
-    this.registeredListeners.delete(requestTag);
+  unregisterListener(): void {
+    this.registeredListenersCount -= 1;
   }
 
   /**
@@ -1022,7 +1022,7 @@ export class Firestore {
    * @return A Promise that resolves when the client is terminated.
    */
   terminate(): Promise<void> {
-    if (this.registeredListeners.size > 0) {
+    if (this.registeredListenersCount > 0) {
       return Promise.reject(
         'All listeners must be disconnected before terminating the client.'
       );

--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -44,7 +44,7 @@ export class ClientPool<T> {
 
   /**
    * Deferred promise that is resolved when there are no active operations on
-   * the client pool.
+   * the client pool after terminate() has been called.
    */
   private terminateDeferred = new Deferred<void>();
 
@@ -120,7 +120,7 @@ export class ClientPool<T> {
     const requestCount = this.activeClients.get(client) || 0;
     assert(requestCount > 0, 'No active requests');
     this.activeClients.set(client, requestCount - 1);
-    if (this.opCount === 0) {
+    if (this.terminated && this.opCount === 0) {
       this.terminateDeferred.resolve();
     }
 
@@ -207,7 +207,6 @@ export class ClientPool<T> {
 
     // Wait for all pending operations to complete before terminating.
     if (this.opCount > 0) {
-      this.terminateDeferred = new Deferred<void>();
       logger(
         'ClientPool.terminate',
         /* requestTag= */ null,

--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -42,6 +42,10 @@ export class ClientPool<T> {
    */
   private terminated = false;
 
+  /**
+   * Deferred promise that is resolved when there are no active operations on
+   * the client pool.
+   */
   private operationsDeferred = new Deferred<void>();
 
   /**
@@ -56,7 +60,7 @@ export class ClientPool<T> {
    */
   constructor(
     private readonly concurrentOperationLimit: number,
-    private maxIdleClients: number,
+    private readonly maxIdleClients: number,
     private readonly clientFactory: () => T,
     private readonly clientDestructor: (client: T) => Promise<void> = () =>
       Promise.resolve()

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -255,7 +255,7 @@ abstract class Watch<T = DocumentData> {
     const unsubscribe = () => {
       logger('Watch.onSnapshot', this.requestTag, 'Unsubscribe called');
       // Prevent further callbacks.
-      if (!this.isActive) {
+      if (this.isActive) {
         // Unregister the listener iff it has not already been unregistered.
         this.firestore.unregisterListener();
         this.isActive = false;

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -252,7 +252,8 @@ abstract class Watch<T = DocumentData> {
 
     this.initStream();
 
-    return () => {
+    const unsubscribe = () => {
+      this.firestore.unregisterListener(this.requestTag);
       logger('Watch.onSnapshot', this.requestTag, 'Unsubscribe called');
       // Prevent further callbacks.
       this.isActive = false;
@@ -262,6 +263,8 @@ abstract class Watch<T = DocumentData> {
         this.currentStream.end();
       }
     };
+    this.firestore.registerListener(this.requestTag);
+    return unsubscribe;
   }
 
   /**

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -253,17 +253,20 @@ abstract class Watch<T = DocumentData> {
     this.initStream();
 
     const unsubscribe = () => {
-      this.firestore.unregisterListener(this.requestTag);
       logger('Watch.onSnapshot', this.requestTag, 'Unsubscribe called');
       // Prevent further callbacks.
-      this.isActive = false;
+      if (!this.isActive) {
+        // Unregister the listener iff it has not already been unregistered.
+        this.firestore.unregisterListener();
+        this.isActive = false;
+      }
       this.onNext = () => {};
       this.onError = () => {};
       if (this.currentStream) {
         this.currentStream.end();
       }
     };
-    this.firestore.registerListener(this.requestTag);
+    this.firestore.registerListener();
     return unsubscribe;
   }
 
@@ -332,6 +335,7 @@ abstract class Watch<T = DocumentData> {
     }
 
     if (this.isActive) {
+      this.firestore.unregisterListener();
       this.isActive = false;
       logger('Watch.closeStream', this.requestTag, 'Invoking onError: ', err);
       this.onError(err);

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -164,7 +164,7 @@ describe('Firestore class', () => {
       throw new Error('terminate() should have failed');
     } catch (err) {
       expect(err).to.equal(
-        'All listeners must be disconnected before terminating the client.'
+        'All onSnapshot() listeners must be unsubscribed before terminating the client.'
       );
       unsubscribe();
     }

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -155,14 +155,11 @@ describe('Firestore class', () => {
 
   it('throws an error if terminate() is called with active listeners', async () => {
     const ref = randomCol.doc('doc-1');
-
     const unsubscribe = ref.onSnapshot(() => {
       // No-op
     });
 
     await ref.set({});
-    // unsubscribe();
-    // Terminate should allow unsubscribe to complete.
     try {
       await firestore.terminate();
       return Promise.reject('terminate() should have failed');

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -152,6 +152,28 @@ describe('Firestore class', () => {
         expect(err).to.equal('The client has already been terminated');
       });
   });
+
+  it('throws an error if terminate() is called with active listeners', async () => {
+    const ref = randomCol.doc('doc-1');
+
+    const unsubscribe = ref.onSnapshot(() => {
+      // No-op
+    });
+
+    await ref.set({});
+    // unsubscribe();
+    // Terminate should allow unsubscribe to complete.
+    try {
+      await firestore.terminate();
+      return Promise.reject('terminate() should have failed');
+    } catch (err) {
+      expect(err).to.equal(
+        'All listeners must be disconnected before terminating the client.'
+      );
+      unsubscribe();
+      return Promise.resolve();
+    }
+  });
 });
 
 describe('CollectionReference class', () => {

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -159,7 +159,6 @@ describe('Firestore class', () => {
       // No-op
     });
 
-    await ref.set({});
     try {
       await firestore.terminate();
       throw new Error('terminate() should have failed');

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -992,19 +992,6 @@ describe('DocumentReference class', () => {
       unsubscribeCallbacks.forEach(c => c());
     });
 
-    it('waits for existing operations to complete before releasing clients', async () => {
-      const ref = randomCol.doc('doc-1');
-
-      const unsubscribe = ref.onSnapshot(() => {
-        // No-op
-      });
-
-      await ref.set({});
-      unsubscribe();
-      // Terminate should allow unsubscribe to complete.
-      await firestore.terminate();
-    });
-
     it('handles query snapshots with converters', async () => {
       const setupDeferred = new Deferred<void>();
       const resultsDeferred = new Deferred<QuerySnapshot<Post>>();

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -162,13 +162,12 @@ describe('Firestore class', () => {
     await ref.set({});
     try {
       await firestore.terminate();
-      return Promise.reject('terminate() should have failed');
+      throw new Error('terminate() should have failed');
     } catch (err) {
       expect(err).to.equal(
         'All listeners must be disconnected before terminating the client.'
       );
       unsubscribe();
-      return Promise.resolve();
     }
   });
 });

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -992,6 +992,19 @@ describe('DocumentReference class', () => {
       unsubscribeCallbacks.forEach(c => c());
     });
 
+    it('waits for existing operations to complete before releasing clients', async () => {
+      const ref = randomCol.doc('doc-1');
+
+      const unsubscribe = ref.onSnapshot(() => {
+        // No-op
+      });
+
+      await ref.set({});
+      unsubscribe();
+      // Terminate should allow unsubscribe to complete.
+      await firestore.terminate();
+    });
+
     it('handles query snapshots with converters', async () => {
       const setupDeferred = new Deferred<void>();
       const resultsDeferred = new Deferred<QuerySnapshot<Post>>();

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -327,4 +327,20 @@ describe('Client pool', () => {
         expect(err).to.equal('The client has already been terminated');
       });
   });
+
+  it('waits for existing operations to complete before releasing clients', async () => {
+    const clientPool = new ClientPool<{}>(1, 0, () => {
+      return {};
+    });
+
+    const deferred = new Deferred<void>();
+
+    const op = clientPool.run(REQUEST_TAG, async () => {
+      await deferred.promise;
+      return Promise.resolve('success');
+    });
+    await clientPool.terminate();
+    deferred.resolve();
+    expect(op).to.become('success');
+  });
 });

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -343,11 +343,10 @@ describe('Client pool', () => {
       terminated = true;
     });
 
-    setImmediate(async () => {
-      expect(terminated).to.be.false;
-      // Mark the mock operation as "complete".
-      deferred.resolve();
-      await terminateOp;
+    expect(terminated).to.be.false;
+    // Mark the mock operation as "complete".
+    deferred.resolve();
+    terminateOp.then(() => {
       expect(terminated).to.be.true;
       done();
     });

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -332,15 +332,20 @@ describe('Client pool', () => {
     const clientPool = new ClientPool<{}>(1, 0, () => {
       return {};
     });
-
     const deferred = new Deferred<void>();
 
     const op = clientPool.run(REQUEST_TAG, async () => {
       await deferred.promise;
       return Promise.resolve('success');
     });
-    await clientPool.terminate();
+    const terminate = clientPool
+      .terminate()
+      .then(() => Promise.resolve('success'));
     deferred.resolve();
+
+    // Wait for the terminate promise to resolve after run() completes.
+    await terminate;
     expect(op).to.become('success');
+    expect(terminate).to.become('success');
   });
 });


### PR DESCRIPTION
Fixes #913 

Implemented the 2nd suggestion. I think it makes more sense to allow for existing operations to complete before calling terminate. In the user's repro it would be strange to have `close()` throw an error.