### PR TITLE
fix: propagate converter in QueryOptions.with()

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1030,14 +1030,13 @@ export class QueryOptions<T> {
    * Returns the union of the current and the provided options.
    * @private
    */
-  with(
-    settings: Partial<Omit<QueryOptions<T>, 'converter'>>,
-    converter = defaultConverter as FirestoreDataConverter<T>
-  ): QueryOptions<T> {
+  with(settings: Partial<Omit<QueryOptions<T>, 'converter'>>): QueryOptions<T> {
     return new QueryOptions(
       coalesce(settings.parentPath, this.parentPath)!,
       coalesce(settings.collectionId, this.collectionId)!,
-      converter,
+      this.converter
+        ? this.converter
+        : (defaultConverter as FirestoreDataConverter<T>),
       coalesce(settings.allDescendants, this.allDescendants)!,
       coalesce(settings.fieldFilters, this.fieldFilters)!,
       coalesce(settings.fieldOrders, this.fieldOrders)!,

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1034,9 +1034,7 @@ export class QueryOptions<T> {
     return new QueryOptions(
       coalesce(settings.parentPath, this.parentPath)!,
       coalesce(settings.collectionId, this.collectionId)!,
-      this.converter
-        ? this.converter
-        : (defaultConverter as FirestoreDataConverter<T>),
+      this.converter,
       coalesce(settings.allDescendants, this.allDescendants)!,
       coalesce(settings.fieldFilters, this.fieldFilters)!,
       coalesce(settings.fieldOrders, this.fieldOrders)!,

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -658,6 +658,38 @@ describe('query interface', () => {
       expect(posts.docs[0].data().toString()).to.equal('post, by author');
     });
   });
+
+  it('for withConverter() propagation through queryOptions', async () => {
+    const doc = document('documentId', 'author', 'author', 'title', 'post');
+    const overrides: ApiOverride = {
+      commit: request => {
+        const expectedRequest = set({
+          document: doc,
+        });
+        requestEquals(request, expectedRequest);
+        return response(writeResult(1));
+      },
+      runQuery: request => {
+        queryEquals(request, fieldFilters('title', 'EQUAL', 'post'));
+        return stream({document: doc, readTime: {seconds: 5, nanos: 6}});
+      },
+    };
+
+    return createInstance(overrides).then(async firestore => {
+      await firestore
+        .collection('collectionId')
+        .doc('documentId')
+        .set({title: 'post', author: 'author'});
+      const coll = await firestore
+        .collection('collectionId')
+        .withConverter(postConverter);
+
+      // Verify that the converter is carried through.
+      const posts = await coll.where('title', '==', 'post').get();
+      expect(posts.size).to.equal(1);
+      expect(posts.docs[0].data().toString()).to.equal('post, by author');
+    });
+  });
 });
 
 describe('where() interface', () => {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -659,7 +659,7 @@ describe('query interface', () => {
     });
   });
 
-  it.only('propagates withConverter() through QueryOptions', async () => {
+  it('propagates withConverter() through QueryOptions', async () => {
     const doc = document('documentId', 'author', 'author', 'title', 'post');
     const overrides: ApiOverride = {
       runQuery: request => {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -659,16 +659,9 @@ describe('query interface', () => {
     });
   });
 
-  it('for withConverter() propagation through queryOptions', async () => {
+  it.only('propagates withConverter() through QueryOptions', async () => {
     const doc = document('documentId', 'author', 'author', 'title', 'post');
     const overrides: ApiOverride = {
-      commit: request => {
-        const expectedRequest = set({
-          document: doc,
-        });
-        requestEquals(request, expectedRequest);
-        return response(writeResult(1));
-      },
       runQuery: request => {
         queryEquals(request, fieldFilters('title', 'EQUAL', 'post'));
         return stream({document: doc, readTime: {seconds: 5, nanos: 6}});
@@ -676,10 +669,6 @@ describe('query interface', () => {
     };
 
     return createInstance(overrides).then(async firestore => {
-      await firestore
-        .collection('collectionId')
-        .doc('documentId')
-        .set({title: 'post', author: 'author'});
       const coll = await firestore
         .collection('collectionId')
         .withConverter(postConverter);


### PR DESCRIPTION
Reported in this [comment](https://github.com/googleapis/nodejs-firestore/issues/924#issuecomment-5872254330).

We previously were dropping the converter when calling `with()`, which meant that the return type would be typed `T` even though the underlying object was still `DocumentData`