### PR TITLE
feat: add support for Query.limitToLast()

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -969,6 +969,15 @@ interface QueryCursor {
   values: unknown[];
 }
 
+/*!
+ * Denotes whether a provided limit is applied to the beginning or the end of
+ * the result set.
+ */
+enum LimitType {
+  First,
+  Last,
+}
+
 /**
  * Internal class representing custom Query options.
  *
@@ -986,6 +995,7 @@ export class QueryOptions<T> {
     readonly startAt?: QueryCursor,
     readonly endAt?: QueryCursor,
     readonly limit?: number,
+    readonly limitType?: LimitType,
     readonly offset?: number,
     readonly projection?: api.StructuredQuery.IProjection
   ) {}
@@ -1041,6 +1051,7 @@ export class QueryOptions<T> {
       coalesce(settings.startAt, this.startAt),
       coalesce(settings.endAt, this.endAt),
       coalesce(settings.limit, this.limit),
+      coalesce(settings.limitType, this.limitType),
       coalesce(settings.offset, this.offset),
       coalesce(settings.projection, this.projection)
     );
@@ -1057,9 +1068,14 @@ export class QueryOptions<T> {
       this.startAt,
       this.endAt,
       this.limit,
+      this.limitType,
       this.offset,
       this.projection
     );
+  }
+
+  hasFieldOrders(): boolean {
+    return this.fieldOrders.length > 0;
   }
 
   isEqual(other: QueryOptions<T>) {
@@ -1349,7 +1365,38 @@ export class Query<T = DocumentData> {
   limit(limit: number): Query<T> {
     validateInteger('limit', limit);
 
-    const options = this._queryOptions.with({limit});
+    const options = this._queryOptions.with({
+      limit,
+      limitType: LimitType.First,
+    });
+    return new Query(this._firestore, options);
+  }
+
+  /**
+   * Creates and returns a new Query that only returns the last matching
+   * documents.
+   *
+   * You must specify at least one orderBy clause for limitToLast queries,
+   * otherwise an exception will be thrown during execution.
+   *
+   * Results for limitToLast queries cannot be streamed via the `stream()` API.
+   *
+   * @param limit The maximum number of items to return.
+   * @return The created Query.
+   *
+   * @example
+   * let query = firestore.collection('col').where('foo', '>', 42);
+   *
+   * query.limitToLast(1).get().then(querySnapshot => {
+   *   querySnapshot.forEach(documentSnapshot => {
+   *     console.log(`Last matching document is ${documentSnapshot.ref.path}`);
+   *   });
+   * });
+   */
+  limitToLast(limit: number): Query<T> {
+    validateInteger('limitToLast', limit);
+
+    const options = this._queryOptions.with({limit, limitType: LimitType.Last});
     return new Query(this._firestore, options);
   }
 
@@ -1744,12 +1791,14 @@ export class Query<T = DocumentData> {
    * @param {bytes=} transactionId A transaction ID.
    */
   _get(transactionId?: Uint8Array): Promise<QuerySnapshot<T>> {
+    const request = this.toProto(transactionId);
+
     const docs: Array<QueryDocumentSnapshot<T>> = [];
 
     return new Promise((resolve, reject) => {
       let readTime: Timestamp;
 
-      this._stream(transactionId)
+      this._stream(request)
         .on('error', err => {
           reject(err);
         })
@@ -1760,6 +1809,13 @@ export class Query<T = DocumentData> {
           }
         })
         .on('end', () => {
+          if (this._queryOptions.limitType === LimitType.Last) {
+            // The results for limitToLast queries need to be flipped since
+            // we reversed the ordering constraints before sending the query
+            // to the backend.
+            docs.reverse();
+          }
+
           resolve(
             new QuerySnapshot(
               this,
@@ -1799,7 +1855,15 @@ export class Query<T = DocumentData> {
    * });
    */
   stream(): NodeJS.ReadableStream {
-    const responseStream = this._stream();
+    if (this._queryOptions.limitType === LimitType.Last) {
+      throw new Error(
+        'Query results for queries that include limitToLast() ' +
+          'constraints cannot be streamed. Use Query.get() instead.'
+      );
+    }
+
+    const request = this.toProto();
+    const responseStream = this._stream(request);
 
     const transform = through2.obj(function(this, chunk, encoding, callback) {
       // Only send chunks with documents.
@@ -1816,14 +1880,22 @@ export class Query<T = DocumentData> {
 
   /**
    * Converts a QueryCursor to its proto representation.
+   *
+   * @param cursor The original cursor value
+   * @param reverse Whether to flip the "before" value (e.g. for limitToLast
+   * queries)
    * @private
    */
-  private _toCursor(cursor?: QueryCursor): api.ICursor | undefined {
+  private toCursor(
+    cursor: QueryCursor | undefined,
+    reverse = false
+  ): api.ICursor | undefined {
     if (cursor) {
       const values = cursor.values.map(
         val => this._serializer.encodeValue(val) as api.IValue
       );
-      return {before: cursor.before, values};
+      const before = (cursor.before === true) !== reverse ? true : undefined;
+      return {before, values};
     }
 
     return undefined;
@@ -1875,12 +1947,37 @@ export class Query<T = DocumentData> {
       };
     }
 
-    if (this._queryOptions.fieldOrders.length) {
-      const orderBy: api.StructuredQuery.IOrder[] = [];
-      for (const fieldOrder of this._queryOptions.fieldOrders) {
-        orderBy.push(fieldOrder.toProto());
+    if (this._queryOptions.limitType === LimitType.Last) {
+      if (!this._queryOptions.hasFieldOrders()) {
+        throw new Error(
+          'limitToLast() queries require specifying at least one orderBy() clause.'
+        );
       }
-      structuredQuery.orderBy = orderBy;
+
+      structuredQuery.orderBy = this._queryOptions.fieldOrders!.map(order => {
+        // Flip the orderBy directions since we want the last results
+        const dir =
+          order.direction === 'DESCENDING' ? 'ASCENDING' : 'DESCENDING';
+        return new FieldOrder(order.field, dir).toProto();
+      });
+
+      // Swap the cursors to match the now-flipped query ordering.
+      structuredQuery.startAt = this.toCursor(
+        this._queryOptions.endAt,
+        /* reverse= */ true
+      );
+      structuredQuery.endAt = this.toCursor(
+        this._queryOptions.startAt,
+        /* reverse= */ true
+      );
+    } else {
+      if (this._queryOptions.hasFieldOrders()) {
+        structuredQuery.orderBy = this._queryOptions.fieldOrders.map(o =>
+          o.toProto()
+        );
+      }
+      structuredQuery.startAt = this.toCursor(this._queryOptions.startAt);
+      structuredQuery.endAt = this.toCursor(this._queryOptions.endAt);
     }
 
     if (this._queryOptions.limit) {
@@ -1888,8 +1985,6 @@ export class Query<T = DocumentData> {
     }
 
     structuredQuery.offset = this._queryOptions.offset;
-    structuredQuery.startAt = this._toCursor(this._queryOptions.startAt);
-    structuredQuery.endAt = this._toCursor(this._queryOptions.endAt);
     structuredQuery.select = this._queryOptions.projection;
 
     reqOpts.transaction = transactionId;
@@ -1898,13 +1993,13 @@ export class Query<T = DocumentData> {
   }
 
   /**
-   * Internal streaming method that accepts an optional transaction id.
+   * Internal streaming method that accepts the requets proto.
    *
-   * @param transactionId A transaction ID.
+   * @param request The request proto.
    * @private
    * @returns A stream of document results.
    */
-  _stream(transactionId?: Uint8Array): NodeJS.ReadableStream {
+  _stream(request: api.IRunQueryRequest): NodeJS.ReadableStream {
     const tag = requestTag();
     const self = this;
 
@@ -1932,7 +2027,6 @@ export class Query<T = DocumentData> {
     });
 
     this.firestore.initializeIfNeeded(tag).then(() => {
-      const request = this.toProto(transactionId);
       this._firestore
         .requestStream('runQuery', request, tag)
         .then(backendStream => {
@@ -2009,12 +2103,11 @@ export class Query<T = DocumentData> {
   ) => number {
     return (doc1, doc2) => {
       // Add implicit sorting by name, using the last specified direction.
-      const lastDirection: api.StructuredQuery.Direction =
-        this._queryOptions.fieldOrders.length === 0
-          ? 'ASCENDING'
-          : this._queryOptions.fieldOrders[
-              this._queryOptions.fieldOrders.length - 1
-            ].direction;
+      const lastDirection = this._queryOptions.hasFieldOrders()
+        ? this._queryOptions.fieldOrders[
+            this._queryOptions.fieldOrders.length - 1
+          ].direction
+        : 'ASCENDING';
       const orderBys = this._queryOptions.fieldOrders.concat(
         new FieldOrder(FieldPath.documentId(), lastDirection)
       );

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -1285,7 +1285,7 @@ describe('Query class', () => {
       .get();
     expectDocs(res, {foo: 'b'});
   });
-  
+
   it('supports Unicode in document names', async () => {
     const collRef = randomCol.doc('доброеутро').collection('coll');
     await collRef.add({});
@@ -1346,13 +1346,13 @@ describe('Query class', () => {
         expect(results.docs).to.have.length(10);
       });
   });
-  
+
   it('has startAt() method', async () => {
     await addDocs({foo: 'a'}, {foo: 'b'});
     const res = await randomCol
-        .orderBy('foo')
-        .startAt('b')
-        .get();
+      .orderBy('foo')
+      .startAt('b')
+      .get();
     expectDocs(res, {foo: 'b'});
   });
 

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -1079,6 +1079,18 @@ describe('Query class', () => {
       });
   };
 
+  function addDocs(...data: DocumentData[]): Promise<WriteResult[]> {
+    let id = 0; // Guarantees consistent ordering for the first documents
+    return Promise.all(data.map(d => randomCol.doc('' + id++).set(d)));
+  }
+
+  function expectDocs(result: QuerySnapshot, ...data: DocumentData[]) {
+    expect(result.size).to.equal(data.length);
+    result.forEach(doc => {
+      expect(doc.data()).to.deep.equal(data.shift());
+    });
+  }
+
   beforeEach(() => {
     firestore = new Firestore({});
     randomCol = getTestRoot(firestore);
@@ -1159,46 +1171,44 @@ describe('Query class', () => {
       });
   });
 
-  it('supports in', () => {
-    return Promise.all([
-      randomCol.doc('a').set({zip: 98101}),
-      randomCol.doc('b').set({zip: 91102}),
-      randomCol.doc('c').set({zip: 98103}),
-      randomCol.doc('d').set({zip: [98101]}),
-      randomCol.doc('e').set({zip: ['98101', {zip: 98101}]}),
-      randomCol.doc('f').set({zip: {zip: 98101}}),
-    ])
-      .then(() => randomCol.where('zip', 'in', [98101, 98103]).get())
-      .then(res => {
-        expect(res.size).to.equal(2);
-        expect(res.docs[0].data()).to.deep.equal({zip: 98101});
-        expect(res.docs[1].data()).to.deep.equal({zip: 98103});
-      });
+  it('supports in', async () => {
+    await addDocs(
+      {zip: 98101},
+      {zip: 91102},
+      {zip: 98103},
+      {zip: [98101]},
+      {zip: ['98101', {zip: 98101}]},
+      {zip: {zip: 98101}}
+    );
+    const res = await randomCol.where('zip', 'in', [98101, 98103]).get();
+    expectDocs(res, {zip: 98101}, {zip: 98103});
   });
 
-  it('supports array-contains-any', () => {
-    return Promise.all([
-      randomCol.doc('a').set({array: [42]}),
-      randomCol.doc('b').set({array: ['a', 42, 'c']}),
-      randomCol.doc('c').set({array: [41.999, '42', {a: [42]}]}),
-      randomCol.doc('d').set({array: [42], array2: ['sigh']}),
-      randomCol.doc('e').set({array: [43]}),
-      randomCol.doc('f').set({array: [{a: 42}]}),
-      randomCol.doc('g').set({array: 42}),
-    ])
-      .then(() =>
-        randomCol.where('array', 'array-contains-any', [42, 43]).get()
-      )
-      .then(res => {
-        expect(res.size).to.equal(4);
-        expect(res.docs[0].data()).to.deep.equal({array: [42]});
-        expect(res.docs[1].data()).to.deep.equal({array: ['a', 42, 'c']});
-        expect(res.docs[2].data()).to.deep.equal({
-          array: [42],
-          array2: ['sigh'],
-        });
-        expect(res.docs[3].data()).to.deep.equal({array: [43]});
-      });
+  it('supports array-contains-any', async () => {
+    await addDocs(
+      {array: [42]},
+      {array: ['a', 42, 'c']},
+      {array: [41.999, '42', {a: [42]}]},
+      {array: [42], array2: ['sigh']},
+      {array: [43]},
+      {array: [{a: 42}]},
+      {array: 42}
+    );
+
+    const res = await randomCol
+      .where('array', 'array-contains-any', [42, 43])
+      .get();
+
+    expectDocs(
+      res,
+      {array: [42]},
+      {array: ['a', 42, 'c']},
+      {
+        array: [42],
+        array2: ['sigh'],
+      },
+      {array: [43]}
+    );
   });
 
   it('can query by FieldPath.documentId()', () => {
@@ -1214,23 +1224,14 @@ describe('Query class', () => {
       });
   });
 
-  it('has orderBy() method', () => {
-    const ref1 = randomCol.doc('doc1');
-    const ref2 = randomCol.doc('doc2');
+  it('has orderBy() method', async () => {
+    await addDocs({foo: 'a'}, {foo: 'b'});
 
-    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'b'})])
-      .then(() => {
-        return randomCol.orderBy('foo').get();
-      })
-      .then(res => {
-        expect(res.docs[0].data()).to.deep.equal({foo: 'a'});
-        expect(res.docs[1].data()).to.deep.equal({foo: 'b'});
-        return randomCol.orderBy('foo', 'desc').get();
-      })
-      .then(res => {
-        expect(res.docs[0].data()).to.deep.equal({foo: 'b'});
-        expect(res.docs[1].data()).to.deep.equal({foo: 'a'});
-      });
+    let res = await randomCol.orderBy('foo').get();
+    expectDocs(res, {foo: 'a'}, {foo: 'b'});
+
+    res = await randomCol.orderBy('foo', 'desc').get();
+    expectDocs(res, {foo: 'b'}, {foo: 'a'});
   });
 
   it('can order by FieldPath.documentId()', () => {
@@ -1247,56 +1248,44 @@ describe('Query class', () => {
       });
   });
 
-  it('has limit() method', () => {
-    const ref1 = randomCol.doc('doc1');
-    const ref2 = randomCol.doc('doc2');
-
-    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'b'})])
-      .then(() => {
-        return randomCol
-          .orderBy('foo')
-          .limit(1)
-          .get();
-      })
-      .then(res => {
-        expect(res.size).to.equal(1);
-        expect(res.docs[0].data()).to.deep.equal({foo: 'a'});
-      });
+  it('has limit() method', async () => {
+    await addDocs({foo: 'a'}, {foo: 'b'});
+    const res = await randomCol
+      .orderBy('foo')
+      .limit(1)
+      .get();
+    expectDocs(res, {foo: 'a'});
   });
 
-  it('has offset() method', () => {
-    const ref1 = randomCol.doc('doc1');
-    const ref2 = randomCol.doc('doc2');
-
-    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'b'})])
-      .then(() => {
-        return randomCol
-          .orderBy('foo')
-          .offset(1)
-          .get();
-      })
-      .then(res => {
-        expect(res.size).to.equal(1);
-        expect(res.docs[0].data()).to.deep.equal({foo: 'b'});
-      });
+  it('has limitToLast() method', async () => {
+    await addDocs({doc: 1}, {doc: 2}, {doc: 3});
+    const res = await randomCol
+      .orderBy('doc')
+      .limitToLast(2)
+      .get();
+    expectDocs(res, {doc: 2}, {doc: 3});
   });
 
-  it('has startAt() method', () => {
-    const ref1 = randomCol.doc('doc1');
-    const ref2 = randomCol.doc('doc2');
-
-    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'b'})])
-      .then(() => {
-        return randomCol
-          .orderBy('foo')
-          .startAt('a')
-          .get();
-      })
-      .then(res => {
-        expect(res.docs[0].data()).to.deep.equal({foo: 'a'});
-      });
+  it('limitToLast() supports Query cursors', async () => {
+    await addDocs({doc: 1}, {doc: 2}, {doc: 3}, {doc: 4}, {doc: 5});
+    const res = await randomCol
+      .orderBy('doc')
+      .startAt(2)
+      .endAt(4)
+      .limitToLast(5)
+      .get();
+    expectDocs(res, {doc: 2}, {doc: 3}, {doc: 4});
   });
 
+  it('has offset() method', async () => {
+    await addDocs({foo: 'a'}, {foo: 'b'});
+    const res = await randomCol
+      .orderBy('foo')
+      .offset(1)
+      .get();
+    expectDocs(res, {foo: 'b'});
+  });
+  
   it('supports Unicode in document names', async () => {
     const collRef = randomCol.doc('доброеутро').collection('coll');
     await collRef.add({});
@@ -1357,56 +1346,41 @@ describe('Query class', () => {
         expect(results.docs).to.have.length(10);
       });
   });
-
-  it('has startAfter() method', () => {
-    const ref1 = randomCol.doc('doc1');
-    const ref2 = randomCol.doc('doc2');
-
-    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'b'})])
-      .then(() => {
-        return randomCol
-          .orderBy('foo')
-          .startAfter('a')
-          .get();
-      })
-      .then(res => {
-        expect(res.docs[0].data()).to.deep.equal({foo: 'b'});
-      });
+  
+  it('has startAt() method', async () => {
+    await addDocs({foo: 'a'}, {foo: 'b'});
+    const res = await randomCol
+        .orderBy('foo')
+        .startAt('b')
+        .get();
+    expectDocs(res, {foo: 'b'});
   });
 
-  it('has endAt() method', () => {
-    const ref1 = randomCol.doc('doc1');
-    const ref2 = randomCol.doc('doc2');
-
-    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'b'})])
-      .then(() => {
-        return randomCol
-          .orderBy('foo')
-          .endAt('b')
-          .get();
-      })
-      .then(res => {
-        expect(res.size).to.equal(2);
-        expect(res.docs[0].data()).to.deep.equal({foo: 'a'});
-        expect(res.docs[1].data()).to.deep.equal({foo: 'b'});
-      });
+  it('has startAfter() method', async () => {
+    await addDocs({foo: 'a'}, {foo: 'b'});
+    const res = await randomCol
+      .orderBy('foo')
+      .startAfter('a')
+      .get();
+    expectDocs(res, {foo: 'b'});
   });
 
-  it('has endBefore() method', () => {
-    const ref1 = randomCol.doc('doc1');
-    const ref2 = randomCol.doc('doc2');
+  it('has endAt() method', async () => {
+    await addDocs({foo: 'a'}, {foo: 'b'});
+    const res = await randomCol
+      .orderBy('foo')
+      .endAt('b')
+      .get();
+    expectDocs(res, {foo: 'a'}, {foo: 'b'});
+  });
 
-    return Promise.all([ref1.set({foo: 'a'}), ref2.set({foo: 'b'})])
-      .then(() => {
-        return randomCol
-          .orderBy('foo')
-          .endBefore('b')
-          .get();
-      })
-      .then(res => {
-        expect(res.size).to.equal(1);
-        expect(res.docs[0].data()).to.deep.equal({foo: 'a'});
-      });
+  it('has endBefore() method', async () => {
+    await addDocs({foo: 'a'}, {foo: 'b'});
+    const res = await randomCol
+      .orderBy('foo')
+      .endBefore('b')
+      .get();
+    expectDocs(res, {foo: 'a'});
   });
 
   it('has stream() method', done => {
@@ -1819,6 +1793,29 @@ describe('Query class', () => {
           });
           unsubscribe();
         });
+    });
+
+    it('orders limitToLast() correctly', async () => {
+      const ref1 = randomCol.doc('doc1');
+      const ref2 = randomCol.doc('doc2');
+      const ref3 = randomCol.doc('doc3');
+
+      await ref1.set({doc: 1});
+      await ref2.set({doc: 2});
+      await ref3.set({doc: 3});
+
+      const unsubscribe = randomCol
+        .orderBy('doc')
+        .limitToLast(2)
+        .onSnapshot(snapshot => currentDeferred.resolve(snapshot));
+
+      const results = await waitForSnapshot();
+      snapshotsEqual(results, {
+        docs: [snapshot('doc2', {doc: 2}), snapshot('doc3', {doc: 3})],
+        docChanges: [added('doc2', {doc: 2}), added('doc3', {doc: 3})],
+      });
+
+      unsubscribe();
     });
   });
 });

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -26,7 +26,6 @@ import {
   createInstance,
   document,
   InvalidApiUsage,
-  Post,
   postConverter,
   requestEquals,
   response,
@@ -1196,6 +1195,115 @@ describe('limit() interface', () => {
         .limit(1)
         .limit(2)
         .limit(3);
+      return query.get();
+    });
+  });
+});
+
+describe('limitToLast() interface', () => {
+  let firestore: Firestore;
+
+  beforeEach(() => {
+    return createInstance().then(firestoreInstance => {
+      firestore = firestoreInstance;
+    });
+  });
+
+  afterEach(() => verifyInstance(firestore));
+
+  it('reverses order constraints', () => {
+    const overrides: ApiOverride = {
+      runQuery: request => {
+        queryEquals(request, orderBy('foo', 'DESCENDING'), limit(10));
+        return stream();
+      },
+    };
+
+    return createInstance(overrides).then(firestore => {
+      let query: Query = firestore.collection('collectionId');
+      query = query.orderBy('foo').limitToLast(10);
+      return query.get();
+    });
+  });
+
+  it('reverses cursors', () => {
+    const overrides: ApiOverride = {
+      runQuery: request => {
+        queryEquals(
+          request,
+          orderBy('foo', 'DESCENDING'),
+          startAt(true, 'end'),
+          endAt(false, 'start'),
+          limit(10)
+        );
+        return stream();
+      },
+    };
+
+    return createInstance(overrides).then(firestore => {
+      let query: Query = firestore.collection('collectionId');
+      query = query
+        .orderBy('foo')
+        .startAt('start')
+        .endAt('end')
+        .limitToLast(10);
+      return query.get();
+    });
+  });
+
+  it('reverses results', () => {
+    const overrides: ApiOverride = {
+      runQuery: request => {
+        queryEquals(request, orderBy('foo', 'DESCENDING'), limit(2));
+        return stream(result('second'), result('first'));
+      },
+    };
+
+    return createInstance(overrides).then(async firestore => {
+      let query: Query = firestore.collection('collectionId');
+      query = query.orderBy('foo').limitToLast(2);
+      const result = await query.get();
+      expect(result.docs[0].id).to.equal('first');
+      expect(result.docs[1].id).to.equal('second');
+    });
+  });
+
+  it('expects number', () => {
+    const query = firestore.collection('collectionId');
+    expect(() => query.limit(Infinity)).to.throw(
+      'Value for argument "limit" is not a valid integer.'
+    );
+  });
+
+  it('requires at least one ordering constraints', () => {
+    const query = firestore.collection('collectionId');
+    expect(() => query.limitToLast(1).get()).to.throw(
+      'limitToLast() queries require specifying at least one orderBy() clause.'
+    );
+  });
+
+  it('rejects Query.stream()', () => {
+    const query = firestore.collection('collectionId');
+    expect(() => query.limitToLast(1).stream()).to.throw(
+      'Query results for queries that include limitToLast() constraints cannot be streamed. Use Query.get() instead.'
+    );
+  });
+
+  it('uses latest limitToLast', () => {
+    const overrides: ApiOverride = {
+      runQuery: request => {
+        queryEquals(request, orderBy('foo', 'DESCENDING'), limit(3));
+        return stream();
+      },
+    };
+
+    return createInstance(overrides).then(firestore => {
+      let query: Query = firestore.collection('collectionId');
+      query = query
+        .orderBy('foo')
+        .limitToLast(1)
+        .limitToLast(2)
+        .limitToLast(3);
       return query.get();
     });
   });

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -1270,8 +1270,8 @@ describe('limitToLast() interface', () => {
 
   it('expects number', () => {
     const query = firestore.collection('collectionId');
-    expect(() => query.limit(Infinity)).to.throw(
-      'Value for argument "limit" is not a valid integer.'
+    expect(() => query.limitToLast(Infinity)).to.throw(
+      'Value for argument "limitToLast" is not a valid integer.'
     );
   });
 

--- a/dev/test/typescript.ts
+++ b/dev/test/typescript.ts
@@ -255,6 +255,7 @@ xdescribe('firestore.d.ts', () => {
       query = query.orderBy(new FieldPath('foo'));
       query = query.orderBy(new FieldPath('foo'), 'desc');
       query = query.limit(42);
+      query = query.limitToLast(42);
       query = query.offset(42);
       query = query.select('foo');
       query = query.select('foo', 'bar');

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -903,6 +903,21 @@ declare namespace FirebaseFirestore {
      * @return The created Query.
      */
     limit(limit: number): Query<T>;
+    
+    /**
+     * Creates and returns a new Query that only returns the last matching
+     * documents.
+     *
+     * You must specify at least one orderBy clause for limitToLast queries, 
+     * otherwise an exception will be thrown during execution.
+     * 
+     * Results for limitToLast queries cannot be streamed via the `stream()`
+     * API.
+     *
+     * @param limit The maximum number of items to return.
+     * @return The created Query.
+     */
+    limitToLast(limit: number): Query<T>;
 
     /**
      * Specifies the offset of the returned results.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -893,8 +893,8 @@ declare namespace FirebaseFirestore {
     ): Query<T>;
 
     /**
-     * Creates and returns a new Query that's additionally limited to only
-     * return up to the specified number of documents.
+     * Creates and returns a new Query that only returns the first matching 
+     * documents.
      *
      * This function returns a new (immutable) instance of the Query (rather
      * than modify the existing instance) to impose the limit.


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-firestore/issues/945

This adds support for limitToLast(), including order reserving for queries. Fortunately, Watch uses its own comparator, so we don't have to reverse the results in Watch.