### PR TITLE
feat: deferred client initialization

### DIFF
--- a/dev/src/v1/firestore_admin_client.ts
+++ b/dev/src/v1/firestore_admin_client.ts
@@ -46,9 +46,14 @@ export class FirestoreAdminClient {
   private _innerApiCalls: {[name: string]: Function};
   private _pathTemplates: {[name: string]: gax.PathTemplate};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
   operationsClient: gax.OperationsClient;
-  firestoreAdminStub: Promise<{[name: string]: Function}>;
+  firestoreAdminStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of FirestoreAdminClient.
@@ -72,8 +77,6 @@ export class FirestoreAdminClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -103,25 +106,28 @@ export class FirestoreAdminClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof FirestoreAdminClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -137,7 +143,7 @@ export class FirestoreAdminClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -145,16 +151,16 @@ export class FirestoreAdminClient {
     // identifiers to uniquely identify resources within the API.
     // Create useful helper objects for these.
     this._pathTemplates = {
-      collectionGroupPathTemplate: new gaxModule.PathTemplate(
+      collectionGroupPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/databases/{database}/collectionGroups/{collection}'
       ),
-      databasePathTemplate: new gaxModule.PathTemplate(
+      databasePathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/databases/{database}'
       ),
-      fieldPathTemplate: new gaxModule.PathTemplate(
+      fieldPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/databases/{database}/collectionGroups/{collection}/fields/{field}'
       ),
-      indexPathTemplate: new gaxModule.PathTemplate(
+      indexPathTemplate: new this._gaxModule.PathTemplate(
         'projects/{project}/databases/{database}/collectionGroups/{collection}/indexes/{index}'
       ),
     };
@@ -163,12 +169,12 @@ export class FirestoreAdminClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listIndexes: new gaxModule.PageDescriptor(
+      listIndexes: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'indexes'
       ),
-      listFields: new gaxModule.PageDescriptor(
+      listFields: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'fields'
@@ -179,13 +185,15 @@ export class FirestoreAdminClient {
     // an Operation object that allows for tracking of the operation,
     // rather than holding a request open.
     const protoFilesRoot = opts.fallback
-      ? gaxModule.protobuf.Root.fromJSON(require('../../protos/protos.json'))
-      : gaxModule.protobuf.loadSync(nodejsProtoPath);
+      ? this._gaxModule.protobuf.Root.fromJSON(
+          require('../../protos/protos.json')
+        )
+      : this._gaxModule.protobuf.loadSync(nodejsProtoPath);
 
-    this.operationsClient = gaxModule
+    this.operationsClient = this._gaxModule
       .lro({
         auth: this.auth,
-        grpc: 'grpc' in gaxGrpc ? gaxGrpc.grpc : undefined,
+        grpc: 'grpc' in this._gaxGrpc ? this._gaxGrpc.grpc : undefined,
       })
       .operationsClient(opts);
     const createIndexResponse = protoFilesRoot.lookup(
@@ -214,22 +222,22 @@ export class FirestoreAdminClient {
     ) as gax.protobuf.Type;
 
     this._descriptors.longrunning = {
-      createIndex: new gaxModule.LongrunningDescriptor(
+      createIndex: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         createIndexResponse.decode.bind(createIndexResponse),
         createIndexMetadata.decode.bind(createIndexMetadata)
       ),
-      updateField: new gaxModule.LongrunningDescriptor(
+      updateField: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         updateFieldResponse.decode.bind(updateFieldResponse),
         updateFieldMetadata.decode.bind(updateFieldMetadata)
       ),
-      exportDocuments: new gaxModule.LongrunningDescriptor(
+      exportDocuments: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         exportDocumentsResponse.decode.bind(exportDocumentsResponse),
         exportDocumentsMetadata.decode.bind(exportDocumentsMetadata)
       ),
-      importDocuments: new gaxModule.LongrunningDescriptor(
+      importDocuments: new this._gaxModule.LongrunningDescriptor(
         this.operationsClient,
         importDocumentsResponse.decode.bind(importDocumentsResponse),
         importDocumentsMetadata.decode.bind(importDocumentsMetadata)
@@ -237,7 +245,7 @@ export class FirestoreAdminClient {
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.firestore.admin.v1.FirestoreAdmin',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -248,17 +256,35 @@ export class FirestoreAdminClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.firestoreAdminStub) {
+      return this.firestoreAdminStub;
+    }
 
     // Put together the "service stub" for
     // google.firestore.admin.v1.FirestoreAdmin.
-    this.firestoreAdminStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.firestoreAdminStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.firestore.admin.v1.FirestoreAdmin'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.firestore.admin.v1.FirestoreAdmin,
-      opts
+          (this._protos as any).google.firestore.admin.v1.FirestoreAdmin,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -288,9 +314,9 @@ export class FirestoreAdminClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -304,6 +330,8 @@ export class FirestoreAdminClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.firestoreAdminStub;
   }
 
   /**
@@ -429,6 +457,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getIndex(request, options, callback);
   }
   deleteIndex(
@@ -501,6 +530,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteIndex(request, options, callback);
   }
   getField(
@@ -573,6 +603,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getField(request, options, callback);
   }
 
@@ -602,9 +633,9 @@ export class FirestoreAdminClient {
     >
   ): void;
   /**
-   * Creates a composite index. This returns a [google.longrunning.Operation][google.longrunning.Operation]
+   * Creates a composite index. This returns a {@link google.longrunning.Operation|google.longrunning.Operation}
    * which may be used to track the status of the creation. The metadata for
-   * the operation will be the type [IndexOperationMetadata][google.firestore.admin.v1.IndexOperationMetadata].
+   * the operation will be the type {@link google.firestore.admin.v1.IndexOperationMetadata|IndexOperationMetadata}.
    *
    * @param {Object} request
    *   The request object that will be sent.
@@ -665,6 +696,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createIndex(request, options, callback);
   }
   updateField(
@@ -695,13 +727,13 @@ export class FirestoreAdminClient {
   /**
    * Updates a field configuration. Currently, field updates apply only to
    * single field index configuration. However, calls to
-   * [FirestoreAdmin.UpdateField][google.firestore.admin.v1.FirestoreAdmin.UpdateField] should provide a field mask to avoid
+   * {@link google.firestore.admin.v1.FirestoreAdmin.UpdateField|FirestoreAdmin.UpdateField} should provide a field mask to avoid
    * changing any configuration that the caller isn't aware of. The field mask
    * should be specified as: `{ paths: "index_config" }`.
    *
-   * This call returns a [google.longrunning.Operation][google.longrunning.Operation] which may be used to
+   * This call returns a {@link google.longrunning.Operation|google.longrunning.Operation} which may be used to
    * track the status of the field update. The metadata for
-   * the operation will be the type [FieldOperationMetadata][google.firestore.admin.v1.FieldOperationMetadata].
+   * the operation will be the type {@link google.firestore.admin.v1.FieldOperationMetadata|FieldOperationMetadata}.
    *
    * To configure the default field settings for the database, use
    * the special `Field` with resource name:
@@ -766,6 +798,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       'field.name': request.field!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateField(request, options, callback);
   }
   exportDocuments(
@@ -871,6 +904,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.exportDocuments(request, options, callback);
   }
   importDocuments(
@@ -918,7 +952,7 @@ export class FirestoreAdminClient {
    *   This must match the output_uri_prefix of an ExportDocumentsResponse from
    *   an export that has completed successfully.
    *   See:
-   *   [google.firestore.admin.v1.ExportDocumentsResponse.output_uri_prefix][google.firestore.admin.v1.ExportDocumentsResponse.output_uri_prefix].
+   *   {@link google.firestore.admin.v1.ExportDocumentsResponse.output_uri_prefix|google.firestore.admin.v1.ExportDocumentsResponse.output_uri_prefix}.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -971,6 +1005,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.importDocuments(request, options, callback);
   }
   listIndexes(
@@ -1006,7 +1041,7 @@ export class FirestoreAdminClient {
    *   The number of results to return.
    * @param {string} request.pageToken
    *   A page token, returned from a previous call to
-   *   [FirestoreAdmin.ListIndexes][google.firestore.admin.v1.FirestoreAdmin.ListIndexes], that may be used to get the next
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListIndexes|FirestoreAdmin.ListIndexes}, that may be used to get the next
    *   page of results.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1063,6 +1098,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listIndexes(request, options, callback);
   }
 
@@ -1090,7 +1126,7 @@ export class FirestoreAdminClient {
    *   The number of results to return.
    * @param {string} request.pageToken
    *   A page token, returned from a previous call to
-   *   [FirestoreAdmin.ListIndexes][google.firestore.admin.v1.FirestoreAdmin.ListIndexes], that may be used to get the next
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListIndexes|FirestoreAdmin.ListIndexes}, that may be used to get the next
    *   page of results.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1111,6 +1147,7 @@ export class FirestoreAdminClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listIndexes.createStream(
       this._innerApiCalls.listIndexes as gax.GaxCall,
       request,
@@ -1139,9 +1176,9 @@ export class FirestoreAdminClient {
   /**
    * Lists the field configuration and metadata for this database.
    *
-   * Currently, [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] only supports listing fields
+   * Currently, {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields} only supports listing fields
    * that have been explicitly overridden. To issue this query, call
-   * [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] with the filter set to
+   * {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields} with the filter set to
    * `indexConfig.usesAncestorConfig:false`.
    *
    * @param {Object} request
@@ -1151,15 +1188,15 @@ export class FirestoreAdminClient {
    *   `projects/{project_id}/databases/{database_id}/collectionGroups/{collection_id}`
    * @param {string} request.filter
    *   The filter to apply to list results. Currently,
-   *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] only supports listing fields
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields} only supports listing fields
    *   that have been explicitly overridden. To issue this query, call
-   *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] with the filter set to
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields} with the filter set to
    *   `indexConfig.usesAncestorConfig:false`.
    * @param {number} request.pageSize
    *   The number of results to return.
    * @param {string} request.pageToken
    *   A page token, returned from a previous call to
-   *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields], that may be used to get the next
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields}, that may be used to get the next
    *   page of results.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1216,6 +1253,7 @@ export class FirestoreAdminClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listFields(request, options, callback);
   }
 
@@ -1239,15 +1277,15 @@ export class FirestoreAdminClient {
    *   `projects/{project_id}/databases/{database_id}/collectionGroups/{collection_id}`
    * @param {string} request.filter
    *   The filter to apply to list results. Currently,
-   *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] only supports listing fields
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields} only supports listing fields
    *   that have been explicitly overridden. To issue this query, call
-   *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields] with the filter set to
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields} with the filter set to
    *   `indexConfig.usesAncestorConfig:false`.
    * @param {number} request.pageSize
    *   The number of results to return.
    * @param {string} request.pageToken
    *   A page token, returned from a previous call to
-   *   [FirestoreAdmin.ListFields][google.firestore.admin.v1.FirestoreAdmin.ListFields], that may be used to get the next
+   *   {@link google.firestore.admin.v1.FirestoreAdmin.ListFields|FirestoreAdmin.ListFields}, that may be used to get the next
    *   page of results.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
@@ -1268,6 +1306,7 @@ export class FirestoreAdminClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listFields.createStream(
       this._innerApiCalls.listFields as gax.GaxCall,
       request,
@@ -1510,8 +1549,9 @@ export class FirestoreAdminClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.firestoreAdminStub.then(stub => {
+      return this.firestoreAdminStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/dev/src/v1/firestore_client.ts
+++ b/dev/src/v1/firestore_client.ts
@@ -50,8 +50,13 @@ export class FirestoreClient {
   private _descriptors: Descriptors = {page: {}, stream: {}, longrunning: {}};
   private _innerApiCalls: {[name: string]: Function};
   private _terminated = false;
+  private _opts: ClientOptions;
+  private _gaxModule: typeof gax | typeof gax.fallback;
+  private _gaxGrpc: gax.GrpcClient | gax.fallback.GrpcClient;
+  private _protos: {};
+  private _defaults: {[method: string]: gax.CallSettings};
   auth: gax.GoogleAuth;
-  firestoreStub: Promise<{[name: string]: Function}>;
+  firestoreStub?: Promise<{[name: string]: Function}>;
 
   /**
    * Construct an instance of FirestoreClient.
@@ -75,8 +80,6 @@ export class FirestoreClient {
    *     app is running in an environment which supports
    *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
    *     your project ID will be detected automatically.
-   * @param {function} [options.promise] - Custom promise module to use instead
-   *     of native Promises.
    * @param {string} [options.apiEndpoint] - The domain name of the
    *     API remote host.
    */
@@ -106,25 +109,28 @@ export class FirestoreClient {
     // If we are in browser, we are already using fallback because of the
     // "browser" field in package.json.
     // But if we were explicitly requested to use fallback, let's do it now.
-    const gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
+    this._gaxModule = !isBrowser && opts.fallback ? gax.fallback : gax;
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
     opts.scopes = (this.constructor as typeof FirestoreClient).scopes;
-    const gaxGrpc = new gaxModule.GrpcClient(opts);
+    this._gaxGrpc = new this._gaxModule.GrpcClient(opts);
+
+    // Save options to use in initialize() method.
+    this._opts = opts;
 
     // Save the auth object to the client, for use by other methods.
-    this.auth = gaxGrpc.auth as gax.GoogleAuth;
+    this.auth = this._gaxGrpc.auth as gax.GoogleAuth;
 
     // Determine the client header string.
-    const clientHeader = [`gax/${gaxModule.version}`, `gapic/${version}`];
+    const clientHeader = [`gax/${this._gaxModule.version}`, `gapic/${version}`];
     if (typeof process !== 'undefined' && 'versions' in process) {
       clientHeader.push(`gl-node/${process.versions.node}`);
     } else {
-      clientHeader.push(`gl-web/${gaxModule.version}`);
+      clientHeader.push(`gl-web/${this._gaxModule.version}`);
     }
     if (!opts.fallback) {
-      clientHeader.push(`grpc/${gaxGrpc.grpcVersion}`);
+      clientHeader.push(`grpc/${this._gaxGrpc.grpcVersion}`);
     }
     if (opts.libName && opts.libVersion) {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
@@ -140,7 +146,7 @@ export class FirestoreClient {
       'protos',
       'protos.json'
     );
-    const protos = gaxGrpc.loadProto(
+    this._protos = this._gaxGrpc.loadProto(
       opts.fallback ? require('../../protos/protos.json') : nodejsProtoPath
     );
 
@@ -148,12 +154,12 @@ export class FirestoreClient {
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
     this._descriptors.page = {
-      listDocuments: new gaxModule.PageDescriptor(
+      listDocuments: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'documents'
       ),
-      listCollectionIds: new gaxModule.PageDescriptor(
+      listCollectionIds: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'collectionIds'
@@ -163,16 +169,22 @@ export class FirestoreClient {
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
     this._descriptors.stream = {
-      batchGetDocuments: new gaxModule.StreamDescriptor(
+      batchGetDocuments: new this._gaxModule.StreamDescriptor(
         gax.StreamType.SERVER_STREAMING
       ),
-      runQuery: new gaxModule.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-      write: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
-      listen: new gaxModule.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
+      runQuery: new this._gaxModule.StreamDescriptor(
+        gax.StreamType.SERVER_STREAMING
+      ),
+      write: new this._gaxModule.StreamDescriptor(
+        gax.StreamType.BIDI_STREAMING
+      ),
+      listen: new this._gaxModule.StreamDescriptor(
+        gax.StreamType.BIDI_STREAMING
+      ),
     };
 
     // Put together the default options sent with requests.
-    const defaults = gaxGrpc.constructSettings(
+    this._defaults = this._gaxGrpc.constructSettings(
       'google.firestore.v1.Firestore',
       gapicConfig as gax.ClientConfig,
       opts.clientConfig || {},
@@ -183,17 +195,35 @@ export class FirestoreClient {
     // of calling the API is handled in `google-gax`, with this code
     // merely providing the destination and request information.
     this._innerApiCalls = {};
+  }
+
+  /**
+   * Initialize the client.
+   * Performs asynchronous operations (such as authentication) and prepares the client.
+   * This function will be called automatically when any class method is called for the
+   * first time, but if you need to initialize it before calling an actual method,
+   * feel free to call initialize() directly.
+   *
+   * You can await on this method if you want to make sure the client is initialized.
+   *
+   * @returns {Promise} A promise that resolves to an authenticated service stub.
+   */
+  initialize() {
+    // If the client stub promise is already initialized, return immediately.
+    if (this.firestoreStub) {
+      return this.firestoreStub;
+    }
 
     // Put together the "service stub" for
     // google.firestore.v1.Firestore.
-    this.firestoreStub = gaxGrpc.createStub(
-      opts.fallback
-        ? (protos as protobuf.Root).lookupService(
+    this.firestoreStub = this._gaxGrpc.createStub(
+      this._opts.fallback
+        ? (this._protos as protobuf.Root).lookupService(
             'google.firestore.v1.Firestore'
           )
         : // tslint:disable-next-line no-any
-          (protos as any).google.firestore.v1.Firestore,
-      opts
+          (this._protos as any).google.firestore.v1.Firestore,
+      this._opts
     ) as Promise<{[method: string]: Function}>;
 
     // Iterate over each of the methods that the service provides
@@ -227,9 +257,9 @@ export class FirestoreClient {
         }
       );
 
-      const apiCall = gaxModule.createApiCall(
+      const apiCall = this._gaxModule.createApiCall(
         innerCallPromise,
-        defaults[methodName],
+        this._defaults[methodName],
         this._descriptors.page[methodName] ||
           this._descriptors.stream[methodName] ||
           this._descriptors.longrunning[methodName]
@@ -243,6 +273,8 @@ export class FirestoreClient {
         return apiCall(argument, callOptions, callback);
       };
     }
+
+    return this.firestoreStub;
   }
 
   /**
@@ -378,6 +410,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.getDocument(request, options, callback);
   }
   updateDocument(
@@ -466,6 +499,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       'document.name': request.document!.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.updateDocument(request, options, callback);
   }
   deleteDocument(
@@ -541,6 +575,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       name: request.name || '',
     });
+    this.initialize();
     return this._innerApiCalls.deleteDocument(request, options, callback);
   }
   beginTransaction(
@@ -616,6 +651,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       database: request.database || '',
     });
+    this.initialize();
     return this._innerApiCalls.beginTransaction(request, options, callback);
   }
   commit(
@@ -694,6 +730,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       database: request.database || '',
     });
+    this.initialize();
     return this._innerApiCalls.commit(request, options, callback);
   }
   rollback(
@@ -768,6 +805,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       database: request.database || '',
     });
+    this.initialize();
     return this._innerApiCalls.rollback(request, options, callback);
   }
   createDocument(
@@ -854,6 +892,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.createDocument(request, options, callback);
   }
 
@@ -906,6 +945,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       database: request.database || '',
     });
+    this.initialize();
     return this._innerApiCalls.batchGetDocuments(request, options);
   }
 
@@ -951,6 +991,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.runQuery(request, options);
   }
 
@@ -965,6 +1006,7 @@ export class FirestoreClient {
    *   will emit objects representing [WriteResponse]{@link google.firestore.v1.WriteResponse} on 'data' event asynchronously.
    */
   write(options?: gax.CallOptions): gax.CancellableStream {
+    this.initialize();
     return this._innerApiCalls.write(options);
   }
 
@@ -979,6 +1021,7 @@ export class FirestoreClient {
    *   will emit objects representing [ListenResponse]{@link google.firestore.v1.ListenResponse} on 'data' event asynchronously.
    */
   listen(options?: gax.CallOptions): gax.CancellableStream {
+    this.initialize();
     return this._innerApiCalls.listen({}, options);
   }
 
@@ -1035,8 +1078,8 @@ export class FirestoreClient {
    * @param {boolean} request.showMissing
    *   If the list should show missing documents. A missing document is a
    *   document that does not exist but has sub-documents. These documents will
-   *   be returned with a key but will not have fields, [Document.create_time][google.firestore.v1.Document.create_time],
-   *   or [Document.update_time][google.firestore.v1.Document.update_time] set.
+   *   be returned with a key but will not have fields, {@link google.firestore.v1.Document.create_time|Document.create_time},
+   *   or {@link google.firestore.v1.Document.update_time|Document.update_time} set.
    *
    *   Requests with `show_missing` may not specify `where` or
    *   `order_by`.
@@ -1095,6 +1138,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listDocuments(request, options, callback);
   }
 
@@ -1142,8 +1186,8 @@ export class FirestoreClient {
    * @param {boolean} request.showMissing
    *   If the list should show missing documents. A missing document is a
    *   document that does not exist but has sub-documents. These documents will
-   *   be returned with a key but will not have fields, [Document.create_time][google.firestore.v1.Document.create_time],
-   *   or [Document.update_time][google.firestore.v1.Document.update_time] set.
+   *   be returned with a key but will not have fields, {@link google.firestore.v1.Document.create_time|Document.create_time},
+   *   or {@link google.firestore.v1.Document.update_time|Document.update_time} set.
    *
    *   Requests with `show_missing` may not specify `where` or
    *   `order_by`.
@@ -1166,6 +1210,7 @@ export class FirestoreClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listDocuments.createStream(
       this._innerApiCalls.listDocuments as gax.GaxCall,
       request,
@@ -1205,7 +1250,7 @@ export class FirestoreClient {
    *   The maximum number of results to return.
    * @param {string} request.pageToken
    *   A page token. Must be a value from
-   *   [ListCollectionIdsResponse][google.firestore.v1.ListCollectionIdsResponse].
+   *   {@link google.firestore.v1.ListCollectionIdsResponse|ListCollectionIdsResponse}.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -1261,6 +1306,7 @@ export class FirestoreClient {
     ] = gax.routingHeader.fromParams({
       parent: request.parent || '',
     });
+    this.initialize();
     return this._innerApiCalls.listCollectionIds(request, options, callback);
   }
 
@@ -1288,7 +1334,7 @@ export class FirestoreClient {
    *   The maximum number of results to return.
    * @param {string} request.pageToken
    *   A page token. Must be a value from
-   *   [ListCollectionIdsResponse][google.firestore.v1.ListCollectionIdsResponse].
+   *   {@link google.firestore.v1.ListCollectionIdsResponse|ListCollectionIdsResponse}.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -1308,6 +1354,7 @@ export class FirestoreClient {
       parent: request.parent || '',
     });
     const callSettings = new gax.CallSettings(options);
+    this.initialize();
     return this._descriptors.page.listCollectionIds.createStream(
       this._innerApiCalls.listCollectionIds as gax.GaxCall,
       request,
@@ -1321,8 +1368,9 @@ export class FirestoreClient {
    * The client will no longer be usable and all future behavior is undefined.
    */
   close(): Promise<void> {
+    this.initialize();
     if (!this._terminated) {
-      return this.firestoreStub.then(stub => {
+      return this.firestoreStub!.then(stub => {
         this._terminated = true;
         stub.close();
       });

--- a/dev/synth.metadata
+++ b/dev/synth.metadata
@@ -1,12 +1,12 @@
 {
-  "updateTime": "2020-03-04T12:26:47.589350Z",
+  "updateTime": "2020-03-05T23:07:35.336516Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "541b1ded4abadcc38e8178680b0677f65594ea6f",
-        "internalRef": "298686266"
+        "sha": "f0b581b5bdf803e45201ecdb3688b60e381628a8",
+        "internalRef": "299181282"
       }
     },
     {

--- a/dev/test/gapic-firestore-v1.ts
+++ b/dev/test/gapic-firestore-v1.ts
@@ -123,12 +123,30 @@ describe('v1.FirestoreClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new firestoreModule.v1.FirestoreClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.firestoreStub, undefined);
+    await client.initialize();
+    assert(client.firestoreStub);
+  });
+  it('has close method', () => {
+    const client = new firestoreModule.v1.FirestoreClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getDocument', () => {
     it('invokes getDocument without error', done => {
       const client = new firestoreModule.v1.FirestoreClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IGetDocumentRequest = {};
       request.name = '';
@@ -152,6 +170,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IGetDocumentRequest = {};
       request.name = '';
@@ -177,6 +197,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IUpdateDocumentRequest = {};
       request.document = {};
@@ -201,6 +223,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IUpdateDocumentRequest = {};
       request.document = {};
@@ -227,6 +251,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IDeleteDocumentRequest = {};
       request.name = '';
@@ -250,6 +276,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IDeleteDocumentRequest = {};
       request.name = '';
@@ -275,6 +303,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IBeginTransactionRequest = {};
       request.database = '';
@@ -298,6 +328,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IBeginTransactionRequest = {};
       request.database = '';
@@ -323,6 +355,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.ICommitRequest = {};
       request.database = '';
@@ -346,6 +380,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.ICommitRequest = {};
       request.database = '';
@@ -367,6 +403,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IRollbackRequest = {};
       request.database = '';
@@ -390,6 +428,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IRollbackRequest = {};
       request.database = '';
@@ -415,6 +455,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.ICreateDocumentRequest = {};
       request.parent = '';
@@ -438,6 +480,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.ICreateDocumentRequest = {};
       request.parent = '';
@@ -463,6 +507,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IBatchGetDocumentsRequest = {};
       request.database = '';
@@ -489,6 +535,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IBatchGetDocumentsRequest = {};
       request.database = '';
@@ -518,6 +566,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IRunQueryRequest = {};
       request.parent = '';
@@ -544,6 +594,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IRunQueryRequest = {};
       request.parent = '';
@@ -573,6 +625,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IWriteRequest = {};
       request.database = '';
@@ -600,6 +654,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IWriteRequest = {};
       request.database = '';
@@ -630,6 +686,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IListenRequest = {};
       request.database = '';
@@ -657,6 +715,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IListenRequest = {};
       request.database = '';
@@ -687,6 +747,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IListDocumentsRequest = {};
       request.parent = '';
@@ -714,6 +776,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IListDocumentsRequest = {};
       request.parent = '';
@@ -746,6 +810,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IListCollectionIdsRequest = {};
       request.parent = '';
@@ -773,6 +839,8 @@ describe('v1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1.IListCollectionIdsRequest = {};
       request.parent = '';

--- a/dev/test/gapic-firestore-v1beta1.ts
+++ b/dev/test/gapic-firestore-v1beta1.ts
@@ -123,12 +123,30 @@ describe('v1beta1.FirestoreClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new firestoreModule.v1beta1.FirestoreClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.firestoreStub, undefined);
+    await client.initialize();
+    assert(client.firestoreStub);
+  });
+  it('has close method', () => {
+    const client = new firestoreModule.v1beta1.FirestoreClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getDocument', () => {
     it('invokes getDocument without error', done => {
       const client = new firestoreModule.v1beta1.FirestoreClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IGetDocumentRequest = {};
       request.name = '';
@@ -152,6 +170,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IGetDocumentRequest = {};
       request.name = '';
@@ -177,6 +197,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.ICreateDocumentRequest = {};
       request.parent = '';
@@ -200,6 +222,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.ICreateDocumentRequest = {};
       request.parent = '';
@@ -225,6 +249,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IUpdateDocumentRequest = {};
       request.document = {};
@@ -249,6 +275,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IUpdateDocumentRequest = {};
       request.document = {};
@@ -275,6 +303,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IDeleteDocumentRequest = {};
       request.name = '';
@@ -298,6 +328,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IDeleteDocumentRequest = {};
       request.name = '';
@@ -323,6 +355,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IBeginTransactionRequest = {};
       request.database = '';
@@ -346,6 +380,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IBeginTransactionRequest = {};
       request.database = '';
@@ -371,6 +407,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.ICommitRequest = {};
       request.database = '';
@@ -394,6 +432,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.ICommitRequest = {};
       request.database = '';
@@ -415,6 +455,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IRollbackRequest = {};
       request.database = '';
@@ -438,6 +480,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IRollbackRequest = {};
       request.database = '';
@@ -463,6 +507,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IBatchGetDocumentsRequest = {};
       request.database = '';
@@ -489,6 +535,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IBatchGetDocumentsRequest = {};
       request.database = '';
@@ -518,6 +566,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IRunQueryRequest = {};
       request.parent = '';
@@ -544,6 +594,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IRunQueryRequest = {};
       request.parent = '';
@@ -573,6 +625,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IWriteRequest = {};
       request.database = '';
@@ -600,6 +654,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IWriteRequest = {};
       request.database = '';
@@ -630,6 +686,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IListenRequest = {};
       request.database = '';
@@ -657,6 +715,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IListenRequest = {};
       request.database = '';
@@ -687,6 +747,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IListDocumentsRequest = {};
       request.parent = '';
@@ -714,6 +776,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IListDocumentsRequest = {};
       request.parent = '';
@@ -746,6 +810,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IListCollectionIdsRequest = {};
       request.parent = '';
@@ -773,6 +839,8 @@ describe('v1beta1.FirestoreClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.v1beta1.IListCollectionIdsRequest = {};
       request.parent = '';

--- a/dev/test/gapic-firestore_admin-v1.ts
+++ b/dev/test/gapic-firestore_admin-v1.ts
@@ -104,12 +104,30 @@ describe('v1.FirestoreAdminClient', () => {
     });
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new firestoreadminModule.v1.FirestoreAdminClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    assert.strictEqual(client.firestoreAdminStub, undefined);
+    await client.initialize();
+    assert(client.firestoreAdminStub);
+  });
+  it('has close method', () => {
+    const client = new firestoreadminModule.v1.FirestoreAdminClient({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
+    client.close();
+  });
   describe('getIndex', () => {
     it('invokes getIndex without error', done => {
       const client = new firestoreadminModule.v1.FirestoreAdminClient({
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IGetIndexRequest = {};
       request.name = '';
@@ -133,6 +151,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IGetIndexRequest = {};
       request.name = '';
@@ -158,6 +178,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IDeleteIndexRequest = {};
       request.name = '';
@@ -181,6 +203,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IDeleteIndexRequest = {};
       request.name = '';
@@ -206,6 +230,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IGetFieldRequest = {};
       request.name = '';
@@ -229,6 +255,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IGetFieldRequest = {};
       request.name = '';
@@ -254,6 +282,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.ICreateIndexRequest = {};
       request.parent = '';
@@ -284,6 +314,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.ICreateIndexRequest = {};
       request.parent = '';
@@ -317,6 +349,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IUpdateFieldRequest = {};
       request.field = {};
@@ -348,6 +382,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IUpdateFieldRequest = {};
       request.field = {};
@@ -382,6 +418,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IExportDocumentsRequest = {};
       request.name = '';
@@ -412,6 +450,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IExportDocumentsRequest = {};
       request.name = '';
@@ -445,6 +485,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IImportDocumentsRequest = {};
       request.name = '';
@@ -475,6 +517,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IImportDocumentsRequest = {};
       request.name = '';
@@ -508,6 +552,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IListIndexesRequest = {};
       request.parent = '';
@@ -535,6 +581,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IListIndexesRequest = {};
       request.parent = '';
@@ -567,6 +615,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IListFieldsRequest = {};
       request.parent = '';
@@ -594,6 +644,8 @@ describe('v1.FirestoreAdminClient', () => {
         credentials: {client_email: 'bogus', private_key: 'bogus'},
         projectId: 'bogus',
       });
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.firestore.admin.v1.IListFieldsRequest = {};
       request.parent = '';


### PR DESCRIPTION
This PR includes changes from https://github.com/googleapis/gapic-generator-typescript/pull/317
that will move the asynchronous initialization and authentication from the client constructor
to an `initialize()` method. This method will be automatically called when the first RPC call
is performed.

The client library usage has not changed, there is no need to update any code.

If you want to make sure the client is authenticated _before_ the first RPC call, you can do
```js
await client.initialize();
```
manually before calling any client method.