### PR TITLE
deps: update TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "protobufjs": "^6.8.6",
     "proxyquire": "^2.1.3",
     "ts-node": "^8.5.4",
-    "typescript": "3.6.4"
+    "typescript": "3.8.3"
   }
 }


### PR DESCRIPTION
@JustinBeckwith Since we use our own manually generated types, does the reason for not updating all of GCloud to a newer TypeScript version apply to us?