### PR TITLE
fix: support array of references for IN queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ has instructions for running the samples.
 The [Cloud Firestore Node.js Client API Reference][client-docs] documentation
 also contains samples.
 
+## Supported Node.js Versions
+
+Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Libraries are compatible with all current _active_ and _maintenance_ versions of
+Node.js.
+
+Client libraries targetting some end-of-life versions of Node.js are available, and
+can be installed via npm [dist-tags](https://docs.npmjs.com/cli/dist-tag).
+The dist-tags follow the naming convention `legacy-(version)`.
+
+_Legacy Node.js versions are supported as a best effort:_
+
+* Legacy versions will not be tested in continuous integration.
+* Some security patches may not be able to be backported.
+* Dependencies will not be kept up-to-date, and features will not be backported.
+
+#### Legacy tags available
+
+* `legacy-8`: install client libraries from this dist-tag for versions
+  compatible with Node.js 8.
+
 ## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1240,7 +1240,23 @@ export class Query<T = DocumentData> {
     const path = FieldPath.fromArgument(fieldPath);
 
     if (FieldPath.documentId().isEqual(path)) {
-      value = this.validateReference(value);
+      if (opStr === 'array-contains' || opStr === 'array-contains-any') {
+        throw new Error(
+          `Invalid Query. You can't perform '${opStr}' ` +
+            'queries on FieldPath.documentId().'
+        );
+      }
+
+      if (opStr === 'in') {
+        if (!Array.isArray(value) || value.length === 0) {
+          throw new Error(
+            `Invalid Query. A non-empty array is required for '${opStr}' filters.`
+          );
+        }
+        value = value.map(el => this.validateReference(el));
+      } else {
+        value = this.validateReference(value);
+      }
     }
 
     const fieldFilter = new FieldFilter(
@@ -1595,7 +1611,7 @@ export class Query<T = DocumentData> {
     } else {
       throw new Error(
         'The corresponding value for FieldPath.documentId() must be a ' +
-          'string or a DocumentReference.'
+          `string or a DocumentReference, but was "${val}".`
       );
     }
 

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -1194,7 +1194,6 @@ describe('Query class', () => {
   });
 
   it('supports "in" with document ID array', async () => {
-    setLogFunction(console.log);
     const refs = await addDocs({count: 1}, {count: 2}, {count: 3});
     const res = await randomCol
       .where(FieldPath.documentId(), 'in', [refs[0].id, refs[1]])

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -18,6 +18,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import {
   CollectionReference,
   DocumentData,
+  DocumentReference,
   DocumentSnapshot,
   FieldPath,
   FieldValue,
@@ -1079,9 +1080,17 @@ describe('Query class', () => {
       });
   };
 
-  function addDocs(...data: DocumentData[]): Promise<WriteResult[]> {
+  async function addDocs(
+    ...docs: DocumentData[]
+  ): Promise<DocumentReference[]> {
     let id = 0; // Guarantees consistent ordering for the first documents
-    return Promise.all(data.map(d => randomCol.doc('' + id++).set(d)));
+    const refs: DocumentReference[] = [];
+    for (const doc of docs) {
+      const ref = randomCol.doc('doc' + id++);
+      await ref.set(doc);
+      refs.push(ref);
+    }
+    return refs;
   }
 
   function expectDocs(result: QuerySnapshot, ...data: DocumentData[]) {
@@ -1171,7 +1180,7 @@ describe('Query class', () => {
       });
   });
 
-  it('supports in', async () => {
+  it('supports "in"', async () => {
     await addDocs(
       {zip: 98101},
       {zip: 91102},
@@ -1182,6 +1191,15 @@ describe('Query class', () => {
     );
     const res = await randomCol.where('zip', 'in', [98101, 98103]).get();
     expectDocs(res, {zip: 98101}, {zip: 98103});
+  });
+
+  it('supports "in" with document ID array', async () => {
+    setLogFunction(console.log);
+    const refs = await addDocs({count: 1}, {count: 2}, {count: 3});
+    const res = await randomCol
+      .where(FieldPath.documentId(), 'in', [refs[0].id, refs[1]])
+      .get();
+    expectDocs(res, {count: 1}, {count: 2});
   });
 
   it('supports array-contains-any', async () => {


### PR DESCRIPTION
This ports the validation from Web.

Fixes https://github.com/googleapis/nodejs-firestore/issues/990