### PR TITLE
docs: change batch() code sample

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -633,7 +633,7 @@ export class Firestore {
    * writeBatch.set(firestore.doc('col/doc2'), data);
    *
    * writeBatch.commit().then(res => {
-   *   console.log(`Added document at ${res.writeResults[0].updateTime}`);
+   *   console.log('Successfully executed batch.');
    * });
    */
   batch(): WriteBatch {


### PR DESCRIPTION
Found this while adding docs for BulkWriter. Technically it should be `res[0].writeTime`, but I changed it to be in sync with the code sample from WriteBatch.