### PR TITLE
deps: drop through2

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2005,11 +2005,11 @@ export class Query<T = DocumentData> {
         const readTime = Timestamp.fromProto(proto.readTime);
         if (proto.document) {
           const document = this.firestore.snapshot_(
-              proto.document,
-              proto.readTime
+            proto.document,
+            proto.readTime
           );
           const finalDoc = new DocumentSnapshotBuilder(
-              document.ref.withConverter(this._queryOptions.converter)
+            document.ref.withConverter(this._queryOptions.converter)
           );
           // Recreate the QueryDocumentSnapshot with the DocumentReference
           // containing the original converter.
@@ -2021,7 +2021,7 @@ export class Query<T = DocumentData> {
         } else {
           callback(undefined, {readTime});
         }
-      }
+      },
     });
 
     this.firestore

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as through2 from 'through2';
+import {Transform} from 'stream';
 import * as deepEqual from 'fast-deep-equal';
 
 import * as proto from '../protos/firestore_v1_proto_api';
@@ -1865,13 +1865,11 @@ export class Query<T = DocumentData> {
     }
 
     const responseStream = this._stream();
-
-    const transform = through2.obj(function (this, chunk, encoding, callback) {
-      // Only send chunks with documents.
-      if (chunk.document) {
-        this.push(chunk.document);
-      }
-      callback();
+    const transform = new Transform({
+      objectMode: true,
+      transform(chunk, encoding, callback) {
+        callback(undefined, chunk.document);
+      },
     });
 
     responseStream.pipe(transform);
@@ -2000,31 +1998,30 @@ export class Query<T = DocumentData> {
    */
   _stream(transactionId?: Uint8Array): NodeJS.ReadableStream {
     const tag = requestTag();
-    // TODO(mrschmidt): Remove through2
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this;
 
-    const stream = through2.obj(function (this, proto, enc, callback) {
-      const readTime = Timestamp.fromProto(proto.readTime);
-      if (proto.document) {
-        const document = self.firestore.snapshot_(
-          proto.document,
-          proto.readTime
-        );
-        const finalDoc = new DocumentSnapshotBuilder(
-          document.ref.withConverter(self._queryOptions.converter)
-        );
-        // Recreate the QueryDocumentSnapshot with the DocumentReference
-        // containing the original converter.
-        finalDoc.fieldsProto = document._fieldsProto;
-        finalDoc.readTime = document.readTime;
-        finalDoc.createTime = document.createTime;
-        finalDoc.updateTime = document.updateTime;
-        this.push({document: finalDoc.build(), readTime});
-      } else {
-        this.push({readTime});
+    const stream = new Transform({
+      objectMode: true,
+      transform: (proto, enc, callback) => {
+        const readTime = Timestamp.fromProto(proto.readTime);
+        if (proto.document) {
+          const document = this.firestore.snapshot_(
+              proto.document,
+              proto.readTime
+          );
+          const finalDoc = new DocumentSnapshotBuilder(
+              document.ref.withConverter(this._queryOptions.converter)
+          );
+          // Recreate the QueryDocumentSnapshot with the DocumentReference
+          // containing the original converter.
+          finalDoc.fieldsProto = document._fieldsProto;
+          finalDoc.readTime = document.readTime;
+          finalDoc.createTime = document.createTime;
+          finalDoc.updateTime = document.updateTime;
+          callback(undefined, {document: finalDoc.build(), readTime});
+        } else {
+          callback(undefined, {readTime});
+        }
       }
-      callback();
     });
 
     this.firestore

--- a/package.json
+++ b/package.json
@@ -51,9 +51,7 @@
   "dependencies": {
     "fast-deep-equal": "^3.1.1",
     "functional-red-black-tree": "^1.0.1",
-    "google-gax": "^2.2.0",
-    "readable-stream": "^3.4.0",
-    "through2": "^3.0.0"
+    "google-gax": "^2.2.0"
   },
   "devDependencies": {
     "@types/assert": "^1.4.0",
@@ -82,6 +80,7 @@
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.2",
     "ts-node": "^8.5.4",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "through2": "^3.0.0"
   }
 }


### PR DESCRIPTION
Drops dependency on through2 (though dev dependency remains). Also drops readable-stream as Node10 supports async iterator out of the box. 