### PR TITLE
 feat: support BigInt

### DIFF
--- a/dev/protos/firestore_admin_v1_proto_api.d.ts
+++ b/dev/protos/firestore_admin_v1_proto_api.d.ts
@@ -1451,10 +1451,10 @@ export namespace google {
                 interface IProgress {
 
                     /** Progress estimatedWork */
-                    estimatedWork?: (number|null);
+                    estimatedWork?: (number|string|null);
 
                     /** Progress completedWork */
-                    completedWork?: (number|null);
+                    completedWork?: (number|string|null);
                 }
 
                 /** Represents a Progress. */
@@ -1467,10 +1467,10 @@ export namespace google {
                     constructor(properties?: google.firestore.admin.v1.IProgress);
 
                     /** Progress estimatedWork. */
-                    public estimatedWork: number;
+                    public estimatedWork: (number|string);
 
                     /** Progress completedWork. */
-                    public completedWork: number;
+                    public completedWork: (number|string);
 
                     /**
                      * Creates a Progress message from a plain object. Also converts values to their respective internal types.
@@ -3097,10 +3097,10 @@ export namespace google {
             identifierValue?: (string|null);
 
             /** UninterpretedOption positiveIntValue */
-            positiveIntValue?: (number|null);
+            positiveIntValue?: (number|string|null);
 
             /** UninterpretedOption negativeIntValue */
-            negativeIntValue?: (number|null);
+            negativeIntValue?: (number|string|null);
 
             /** UninterpretedOption doubleValue */
             doubleValue?: (number|null);
@@ -3128,10 +3128,10 @@ export namespace google {
             public identifierValue: string;
 
             /** UninterpretedOption positiveIntValue. */
-            public positiveIntValue: number;
+            public positiveIntValue: (number|string);
 
             /** UninterpretedOption negativeIntValue. */
-            public negativeIntValue: number;
+            public negativeIntValue: (number|string);
 
             /** UninterpretedOption doubleValue. */
             public doubleValue: number;
@@ -3506,7 +3506,7 @@ export namespace google {
         interface ITimestamp {
 
             /** Timestamp seconds */
-            seconds?: (number|null);
+            seconds?: (number|string|null);
 
             /** Timestamp nanos */
             nanos?: (number|null);
@@ -3522,7 +3522,7 @@ export namespace google {
             constructor(properties?: google.protobuf.ITimestamp);
 
             /** Timestamp seconds. */
-            public seconds: number;
+            public seconds: (number|string);
 
             /** Timestamp nanos. */
             public nanos: number;
@@ -3842,7 +3842,7 @@ export namespace google {
         interface IInt64Value {
 
             /** Int64Value value */
-            value?: (number|null);
+            value?: (number|string|null);
         }
 
         /** Represents an Int64Value. */
@@ -3855,7 +3855,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IInt64Value);
 
             /** Int64Value value. */
-            public value: number;
+            public value: (number|string);
 
             /**
              * Creates an Int64Value message from a plain object. Also converts values to their respective internal types.
@@ -3883,7 +3883,7 @@ export namespace google {
         interface IUInt64Value {
 
             /** UInt64Value value */
-            value?: (number|null);
+            value?: (number|string|null);
         }
 
         /** Represents a UInt64Value. */
@@ -3896,7 +3896,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IUInt64Value);
 
             /** UInt64Value value. */
-            public value: number;
+            public value: (number|string);
 
             /**
              * Creates a UInt64Value message from a plain object. Also converts values to their respective internal types.
@@ -4129,7 +4129,7 @@ export namespace google {
         interface IDuration {
 
             /** Duration seconds */
-            seconds?: (number|null);
+            seconds?: (number|string|null);
 
             /** Duration nanos */
             nanos?: (number|null);
@@ -4145,7 +4145,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IDuration);
 
             /** Duration seconds. */
-            public seconds: number;
+            public seconds: (number|string);
 
             /** Duration nanos. */
             public nanos: number;

--- a/dev/protos/firestore_admin_v1_proto_api.js
+++ b/dev/protos/firestore_admin_v1_proto_api.js
@@ -3325,8 +3325,8 @@
                          * Properties of a Progress.
                          * @memberof google.firestore.admin.v1
                          * @interface IProgress
-                         * @property {number|null} [estimatedWork] Progress estimatedWork
-                         * @property {number|null} [completedWork] Progress completedWork
+                         * @property {number|string|null} [estimatedWork] Progress estimatedWork
+                         * @property {number|string|null} [completedWork] Progress completedWork
                          */
     
                         /**
@@ -3346,7 +3346,7 @@
     
                         /**
                          * Progress estimatedWork.
-                         * @member {number} estimatedWork
+                         * @member {number|string} estimatedWork
                          * @memberof google.firestore.admin.v1.Progress
                          * @instance
                          */
@@ -3354,7 +3354,7 @@
     
                         /**
                          * Progress completedWork.
-                         * @member {number} completedWork
+                         * @member {number|string} completedWork
                          * @memberof google.firestore.admin.v1.Progress
                          * @instance
                          */
@@ -7620,8 +7620,8 @@
                  * @interface IUninterpretedOption
                  * @property {Array.<google.protobuf.UninterpretedOption.INamePart>|null} [name] UninterpretedOption name
                  * @property {string|null} [identifierValue] UninterpretedOption identifierValue
-                 * @property {number|null} [positiveIntValue] UninterpretedOption positiveIntValue
-                 * @property {number|null} [negativeIntValue] UninterpretedOption negativeIntValue
+                 * @property {number|string|null} [positiveIntValue] UninterpretedOption positiveIntValue
+                 * @property {number|string|null} [negativeIntValue] UninterpretedOption negativeIntValue
                  * @property {number|null} [doubleValue] UninterpretedOption doubleValue
                  * @property {Uint8Array|null} [stringValue] UninterpretedOption stringValue
                  * @property {string|null} [aggregateValue] UninterpretedOption aggregateValue
@@ -7661,7 +7661,7 @@
     
                 /**
                  * UninterpretedOption positiveIntValue.
-                 * @member {number} positiveIntValue
+                 * @member {number|string} positiveIntValue
                  * @memberof google.protobuf.UninterpretedOption
                  * @instance
                  */
@@ -7669,7 +7669,7 @@
     
                 /**
                  * UninterpretedOption negativeIntValue.
-                 * @member {number} negativeIntValue
+                 * @member {number|string} negativeIntValue
                  * @memberof google.protobuf.UninterpretedOption
                  * @instance
                  */
@@ -8585,7 +8585,7 @@
                  * Properties of a Timestamp.
                  * @memberof google.protobuf
                  * @interface ITimestamp
-                 * @property {number|null} [seconds] Timestamp seconds
+                 * @property {number|string|null} [seconds] Timestamp seconds
                  * @property {number|null} [nanos] Timestamp nanos
                  */
     
@@ -8606,7 +8606,7 @@
     
                 /**
                  * Timestamp seconds.
-                 * @member {number} seconds
+                 * @member {number|string} seconds
                  * @memberof google.protobuf.Timestamp
                  * @instance
                  */
@@ -9361,7 +9361,7 @@
                  * Properties of an Int64Value.
                  * @memberof google.protobuf
                  * @interface IInt64Value
-                 * @property {number|null} [value] Int64Value value
+                 * @property {number|string|null} [value] Int64Value value
                  */
     
                 /**
@@ -9381,7 +9381,7 @@
     
                 /**
                  * Int64Value value.
-                 * @member {number} value
+                 * @member {number|string} value
                  * @memberof google.protobuf.Int64Value
                  * @instance
                  */
@@ -9458,7 +9458,7 @@
                  * Properties of a UInt64Value.
                  * @memberof google.protobuf
                  * @interface IUInt64Value
-                 * @property {number|null} [value] UInt64Value value
+                 * @property {number|string|null} [value] UInt64Value value
                  */
     
                 /**
@@ -9478,7 +9478,7 @@
     
                 /**
                  * UInt64Value value.
-                 * @member {number} value
+                 * @member {number|string} value
                  * @memberof google.protobuf.UInt64Value
                  * @instance
                  */
@@ -9979,7 +9979,7 @@
                  * Properties of a Duration.
                  * @memberof google.protobuf
                  * @interface IDuration
-                 * @property {number|null} [seconds] Duration seconds
+                 * @property {number|string|null} [seconds] Duration seconds
                  * @property {number|null} [nanos] Duration nanos
                  */
     
@@ -10000,7 +10000,7 @@
     
                 /**
                  * Duration seconds.
-                 * @member {number} seconds
+                 * @member {number|string} seconds
                  * @memberof google.protobuf.Duration
                  * @instance
                  */

--- a/dev/protos/firestore_v1_proto_api.d.ts
+++ b/dev/protos/firestore_v1_proto_api.d.ts
@@ -25,7 +25,7 @@ export namespace google {
         interface ITimestamp {
 
             /** Timestamp seconds */
-            seconds?: (number|null);
+            seconds?: (number|string|null);
 
             /** Timestamp nanos */
             nanos?: (number|null);
@@ -41,7 +41,7 @@ export namespace google {
             constructor(properties?: google.protobuf.ITimestamp);
 
             /** Timestamp seconds. */
-            public seconds: number;
+            public seconds: (number|string);
 
             /** Timestamp nanos. */
             public nanos: number;
@@ -1348,10 +1348,10 @@ export namespace google {
             identifierValue?: (string|null);
 
             /** UninterpretedOption positiveIntValue */
-            positiveIntValue?: (number|null);
+            positiveIntValue?: (number|string|null);
 
             /** UninterpretedOption negativeIntValue */
-            negativeIntValue?: (number|null);
+            negativeIntValue?: (number|string|null);
 
             /** UninterpretedOption doubleValue */
             doubleValue?: (number|null);
@@ -1379,10 +1379,10 @@ export namespace google {
             public identifierValue: string;
 
             /** UninterpretedOption positiveIntValue. */
-            public positiveIntValue: number;
+            public positiveIntValue: (number|string);
 
             /** UninterpretedOption negativeIntValue. */
-            public negativeIntValue: number;
+            public negativeIntValue: (number|string);
 
             /** UninterpretedOption doubleValue. */
             public doubleValue: number;
@@ -1958,7 +1958,7 @@ export namespace google {
         interface IInt64Value {
 
             /** Int64Value value */
-            value?: (number|null);
+            value?: (number|string|null);
         }
 
         /** Represents an Int64Value. */
@@ -1971,7 +1971,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IInt64Value);
 
             /** Int64Value value. */
-            public value: number;
+            public value: (number|string);
 
             /**
              * Creates an Int64Value message from a plain object. Also converts values to their respective internal types.
@@ -1999,7 +1999,7 @@ export namespace google {
         interface IUInt64Value {
 
             /** UInt64Value value */
-            value?: (number|null);
+            value?: (number|string|null);
         }
 
         /** Represents a UInt64Value. */
@@ -2012,7 +2012,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IUInt64Value);
 
             /** UInt64Value value. */
-            public value: number;
+            public value: (number|string);
 
             /**
              * Creates a UInt64Value message from a plain object. Also converts values to their respective internal types.
@@ -2333,7 +2333,7 @@ export namespace google {
         interface IDuration {
 
             /** Duration seconds */
-            seconds?: (number|null);
+            seconds?: (number|string|null);
 
             /** Duration nanos */
             nanos?: (number|null);
@@ -2349,7 +2349,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IDuration);
 
             /** Duration seconds. */
-            public seconds: number;
+            public seconds: (number|string);
 
             /** Duration nanos. */
             public nanos: number;
@@ -2681,7 +2681,7 @@ export namespace google {
                 booleanValue?: (boolean|null);
 
                 /** Value integerValue */
-                integerValue?: (number|null);
+                integerValue?: (number|string|null);
 
                 /** Value doubleValue */
                 doubleValue?: (number|null);
@@ -2724,7 +2724,7 @@ export namespace google {
                 public booleanValue: boolean;
 
                 /** Value integerValue. */
-                public integerValue: number;
+                public integerValue: (number|string);
 
                 /** Value doubleValue. */
                 public doubleValue: number;

--- a/dev/protos/firestore_v1_proto_api.js
+++ b/dev/protos/firestore_v1_proto_api.js
@@ -56,7 +56,7 @@
                  * Properties of a Timestamp.
                  * @memberof google.protobuf
                  * @interface ITimestamp
-                 * @property {number|null} [seconds] Timestamp seconds
+                 * @property {number|string|null} [seconds] Timestamp seconds
                  * @property {number|null} [nanos] Timestamp nanos
                  */
     
@@ -77,7 +77,7 @@
     
                 /**
                  * Timestamp seconds.
-                 * @member {number} seconds
+                 * @member {number|string} seconds
                  * @memberof google.protobuf.Timestamp
                  * @instance
                  */
@@ -3538,8 +3538,8 @@
                  * @interface IUninterpretedOption
                  * @property {Array.<google.protobuf.UninterpretedOption.INamePart>|null} [name] UninterpretedOption name
                  * @property {string|null} [identifierValue] UninterpretedOption identifierValue
-                 * @property {number|null} [positiveIntValue] UninterpretedOption positiveIntValue
-                 * @property {number|null} [negativeIntValue] UninterpretedOption negativeIntValue
+                 * @property {number|string|null} [positiveIntValue] UninterpretedOption positiveIntValue
+                 * @property {number|string|null} [negativeIntValue] UninterpretedOption negativeIntValue
                  * @property {number|null} [doubleValue] UninterpretedOption doubleValue
                  * @property {Uint8Array|null} [stringValue] UninterpretedOption stringValue
                  * @property {string|null} [aggregateValue] UninterpretedOption aggregateValue
@@ -3579,7 +3579,7 @@
     
                 /**
                  * UninterpretedOption positiveIntValue.
-                 * @member {number} positiveIntValue
+                 * @member {number|string} positiveIntValue
                  * @memberof google.protobuf.UninterpretedOption
                  * @instance
                  */
@@ -3587,7 +3587,7 @@
     
                 /**
                  * UninterpretedOption negativeIntValue.
-                 * @member {number} negativeIntValue
+                 * @member {number|string} negativeIntValue
                  * @memberof google.protobuf.UninterpretedOption
                  * @instance
                  */
@@ -4968,7 +4968,7 @@
                  * Properties of an Int64Value.
                  * @memberof google.protobuf
                  * @interface IInt64Value
-                 * @property {number|null} [value] Int64Value value
+                 * @property {number|string|null} [value] Int64Value value
                  */
     
                 /**
@@ -4988,7 +4988,7 @@
     
                 /**
                  * Int64Value value.
-                 * @member {number} value
+                 * @member {number|string} value
                  * @memberof google.protobuf.Int64Value
                  * @instance
                  */
@@ -5065,7 +5065,7 @@
                  * Properties of a UInt64Value.
                  * @memberof google.protobuf
                  * @interface IUInt64Value
-                 * @property {number|null} [value] UInt64Value value
+                 * @property {number|string|null} [value] UInt64Value value
                  */
     
                 /**
@@ -5085,7 +5085,7 @@
     
                 /**
                  * UInt64Value value.
-                 * @member {number} value
+                 * @member {number|string} value
                  * @memberof google.protobuf.UInt64Value
                  * @instance
                  */
@@ -5785,7 +5785,7 @@
                  * Properties of a Duration.
                  * @memberof google.protobuf
                  * @interface IDuration
-                 * @property {number|null} [seconds] Duration seconds
+                 * @property {number|string|null} [seconds] Duration seconds
                  * @property {number|null} [nanos] Duration nanos
                  */
     
@@ -5806,7 +5806,7 @@
     
                 /**
                  * Duration seconds.
-                 * @member {number} seconds
+                 * @member {number|string} seconds
                  * @memberof google.protobuf.Duration
                  * @instance
                  */
@@ -6588,7 +6588,7 @@
                      * @interface IValue
                      * @property {google.protobuf.NullValue|null} [nullValue] Value nullValue
                      * @property {boolean|null} [booleanValue] Value booleanValue
-                     * @property {number|null} [integerValue] Value integerValue
+                     * @property {number|string|null} [integerValue] Value integerValue
                      * @property {number|null} [doubleValue] Value doubleValue
                      * @property {google.protobuf.ITimestamp|null} [timestampValue] Value timestampValue
                      * @property {string|null} [stringValue] Value stringValue
@@ -6632,7 +6632,7 @@
     
                     /**
                      * Value integerValue.
-                     * @member {number} integerValue
+                     * @member {number|string} integerValue
                      * @memberof google.firestore.v1.Value
                      * @instance
                      */

--- a/dev/protos/firestore_v1beta1_proto_api.d.ts
+++ b/dev/protos/firestore_v1beta1_proto_api.d.ts
@@ -25,7 +25,7 @@ export namespace google {
         interface ITimestamp {
 
             /** Timestamp seconds */
-            seconds?: (number|null);
+            seconds?: (number|string|null);
 
             /** Timestamp nanos */
             nanos?: (number|null);
@@ -41,7 +41,7 @@ export namespace google {
             constructor(properties?: google.protobuf.ITimestamp);
 
             /** Timestamp seconds. */
-            public seconds: number;
+            public seconds: (number|string);
 
             /** Timestamp nanos. */
             public nanos: number;
@@ -1348,10 +1348,10 @@ export namespace google {
             identifierValue?: (string|null);
 
             /** UninterpretedOption positiveIntValue */
-            positiveIntValue?: (number|null);
+            positiveIntValue?: (number|string|null);
 
             /** UninterpretedOption negativeIntValue */
-            negativeIntValue?: (number|null);
+            negativeIntValue?: (number|string|null);
 
             /** UninterpretedOption doubleValue */
             doubleValue?: (number|null);
@@ -1379,10 +1379,10 @@ export namespace google {
             public identifierValue: string;
 
             /** UninterpretedOption positiveIntValue. */
-            public positiveIntValue: number;
+            public positiveIntValue: (number|string);
 
             /** UninterpretedOption negativeIntValue. */
-            public negativeIntValue: number;
+            public negativeIntValue: (number|string);
 
             /** UninterpretedOption doubleValue. */
             public doubleValue: number;
@@ -1958,7 +1958,7 @@ export namespace google {
         interface IInt64Value {
 
             /** Int64Value value */
-            value?: (number|null);
+            value?: (number|string|null);
         }
 
         /** Represents an Int64Value. */
@@ -1971,7 +1971,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IInt64Value);
 
             /** Int64Value value. */
-            public value: number;
+            public value: (number|string);
 
             /**
              * Creates an Int64Value message from a plain object. Also converts values to their respective internal types.
@@ -1999,7 +1999,7 @@ export namespace google {
         interface IUInt64Value {
 
             /** UInt64Value value */
-            value?: (number|null);
+            value?: (number|string|null);
         }
 
         /** Represents a UInt64Value. */
@@ -2012,7 +2012,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IUInt64Value);
 
             /** UInt64Value value. */
-            public value: number;
+            public value: (number|string);
 
             /**
              * Creates a UInt64Value message from a plain object. Also converts values to their respective internal types.
@@ -2333,7 +2333,7 @@ export namespace google {
         interface IDuration {
 
             /** Duration seconds */
-            seconds?: (number|null);
+            seconds?: (number|string|null);
 
             /** Duration nanos */
             nanos?: (number|null);
@@ -2349,7 +2349,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IDuration);
 
             /** Duration seconds. */
-            public seconds: number;
+            public seconds: (number|string);
 
             /** Duration nanos. */
             public nanos: number;
@@ -2681,7 +2681,7 @@ export namespace google {
                 booleanValue?: (boolean|null);
 
                 /** Value integerValue */
-                integerValue?: (number|null);
+                integerValue?: (number|string|null);
 
                 /** Value doubleValue */
                 doubleValue?: (number|null);
@@ -2724,7 +2724,7 @@ export namespace google {
                 public booleanValue: boolean;
 
                 /** Value integerValue. */
-                public integerValue: number;
+                public integerValue: (number|string);
 
                 /** Value doubleValue. */
                 public doubleValue: number;

--- a/dev/protos/firestore_v1beta1_proto_api.js
+++ b/dev/protos/firestore_v1beta1_proto_api.js
@@ -56,7 +56,7 @@
                  * Properties of a Timestamp.
                  * @memberof google.protobuf
                  * @interface ITimestamp
-                 * @property {number|null} [seconds] Timestamp seconds
+                 * @property {number|string|null} [seconds] Timestamp seconds
                  * @property {number|null} [nanos] Timestamp nanos
                  */
     
@@ -77,7 +77,7 @@
     
                 /**
                  * Timestamp seconds.
-                 * @member {number} seconds
+                 * @member {number|string} seconds
                  * @memberof google.protobuf.Timestamp
                  * @instance
                  */
@@ -3538,8 +3538,8 @@
                  * @interface IUninterpretedOption
                  * @property {Array.<google.protobuf.UninterpretedOption.INamePart>|null} [name] UninterpretedOption name
                  * @property {string|null} [identifierValue] UninterpretedOption identifierValue
-                 * @property {number|null} [positiveIntValue] UninterpretedOption positiveIntValue
-                 * @property {number|null} [negativeIntValue] UninterpretedOption negativeIntValue
+                 * @property {number|string|null} [positiveIntValue] UninterpretedOption positiveIntValue
+                 * @property {number|string|null} [negativeIntValue] UninterpretedOption negativeIntValue
                  * @property {number|null} [doubleValue] UninterpretedOption doubleValue
                  * @property {Uint8Array|null} [stringValue] UninterpretedOption stringValue
                  * @property {string|null} [aggregateValue] UninterpretedOption aggregateValue
@@ -3579,7 +3579,7 @@
     
                 /**
                  * UninterpretedOption positiveIntValue.
-                 * @member {number} positiveIntValue
+                 * @member {number|string} positiveIntValue
                  * @memberof google.protobuf.UninterpretedOption
                  * @instance
                  */
@@ -3587,7 +3587,7 @@
     
                 /**
                  * UninterpretedOption negativeIntValue.
-                 * @member {number} negativeIntValue
+                 * @member {number|string} negativeIntValue
                  * @memberof google.protobuf.UninterpretedOption
                  * @instance
                  */
@@ -4968,7 +4968,7 @@
                  * Properties of an Int64Value.
                  * @memberof google.protobuf
                  * @interface IInt64Value
-                 * @property {number|null} [value] Int64Value value
+                 * @property {number|string|null} [value] Int64Value value
                  */
     
                 /**
@@ -4988,7 +4988,7 @@
     
                 /**
                  * Int64Value value.
-                 * @member {number} value
+                 * @member {number|string} value
                  * @memberof google.protobuf.Int64Value
                  * @instance
                  */
@@ -5065,7 +5065,7 @@
                  * Properties of a UInt64Value.
                  * @memberof google.protobuf
                  * @interface IUInt64Value
-                 * @property {number|null} [value] UInt64Value value
+                 * @property {number|string|null} [value] UInt64Value value
                  */
     
                 /**
@@ -5085,7 +5085,7 @@
     
                 /**
                  * UInt64Value value.
-                 * @member {number} value
+                 * @member {number|string} value
                  * @memberof google.protobuf.UInt64Value
                  * @instance
                  */
@@ -5785,7 +5785,7 @@
                  * Properties of a Duration.
                  * @memberof google.protobuf
                  * @interface IDuration
-                 * @property {number|null} [seconds] Duration seconds
+                 * @property {number|string|null} [seconds] Duration seconds
                  * @property {number|null} [nanos] Duration nanos
                  */
     
@@ -5806,7 +5806,7 @@
     
                 /**
                  * Duration seconds.
-                 * @member {number} seconds
+                 * @member {number|string} seconds
                  * @memberof google.protobuf.Duration
                  * @instance
                  */
@@ -6588,7 +6588,7 @@
                      * @interface IValue
                      * @property {google.protobuf.NullValue|null} [nullValue] Value nullValue
                      * @property {boolean|null} [booleanValue] Value booleanValue
-                     * @property {number|null} [integerValue] Value integerValue
+                     * @property {number|string|null} [integerValue] Value integerValue
                      * @property {number|null} [doubleValue] Value doubleValue
                      * @property {google.protobuf.ITimestamp|null} [timestampValue] Value timestampValue
                      * @property {string|null} [stringValue] Value stringValue
@@ -6632,7 +6632,7 @@
     
                     /**
                      * Value integerValue.
-                     * @member {number} integerValue
+                     * @member {number|string} integerValue
                      * @memberof google.firestore.v1beta1.Value
                      * @instance
                      */

--- a/dev/protos/update.sh
+++ b/dev/protos/update.sh
@@ -83,8 +83,7 @@ PBJS_ARGS=( --proto_path=. \
   --no-decode \
   --no-verify \
   --no-delimited \
-  --force-enum-string \
-  --force-number)
+  --force-enum-string)
       
 "${PBJS}" "${PBJS_ARGS[@]}" -o firestore_v1_proto_api.js \
   -r firestore_v1 \
@@ -92,6 +91,7 @@ PBJS_ARGS=( --proto_path=. \
   "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" \
   "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto" \
   "${PROTOS_DIR}/google/longrunning/*.proto"
+sed -i .bak 's:number|Long:number|string:g' firestore_v1_proto_api.js
 "${PBTS}" -o firestore_v1_proto_api.d.ts firestore_v1_proto_api.js
 
 "${PBJS}" "${PBJS_ARGS[@]}" -o firestore_admin_v1_proto_api.js \
@@ -100,6 +100,7 @@ PBJS_ARGS=( --proto_path=. \
   "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" \
   "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto" \
   "${PROTOS_DIR}/google/longrunning/*.proto"
+sed -i .bak 's:number|Long:number|string:g' firestore_admin_v1_proto_api.js
 "${PBTS}" -o firestore_admin_v1_proto_api.d.ts firestore_admin_v1_proto_api.js
 
 "${PBJS}" "${PBJS_ARGS[@]}" -o firestore_v1beta1_proto_api.js \
@@ -108,6 +109,7 @@ PBJS_ARGS=( --proto_path=. \
   "${PROTOS_DIR}/google/protobuf/*.proto" "${PROTOS_DIR}/google/type/*.proto" \
   "${PROTOS_DIR}/google/rpc/*.proto" "${PROTOS_DIR}/google/api/*.proto" \
   "${PROTOS_DIR}/google/longrunning/*.proto"
+sed -i .bak 's:number|Long:number|string:g' firestore_v1beta1_proto_api.js
 "${PBTS}" -o firestore_v1beta1_proto_api.d.ts firestore_v1beta1_proto_api.js
 
 node  "${PROTOS_DIR}"/../../scripts/license.js *.d.ts *.js

--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -177,16 +177,12 @@ export function valueFromJson(fieldValue: api.IValue): api.IValue {
       return {
         bytesValue: bytesFromJson(fieldValue.bytesValue!),
       };
-    case 'integerValue':
-      return {
-        integerValue: Number(fieldValue.integerValue),
-      };
     case 'doubleValue':
       return {
         doubleValue: Number(fieldValue.doubleValue),
       };
     case 'arrayValue': {
-      const arrayValue: Array<{}> = [];
+      const arrayValue: Array<api.IValue> = [];
       if (Array.isArray(fieldValue.arrayValue!.values)) {
         for (const value of fieldValue.arrayValue!.values!) {
           arrayValue.push(valueFromJson(value));

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -267,7 +267,7 @@ export class Firestore {
    * The configuration options for the GAPIC client.
    * @private
    */
-  private _settings: Settings = {};
+  _settings: Settings = {};
 
   /**
    * Settings for the exponential backoff used by the streaming endpoints.

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -17,8 +17,7 @@
 import * as proto from '../protos/firestore_v1_proto_api';
 
 import {detectValueType} from './convert';
-import {FieldTransform} from './field-value';
-import {DeleteTransform} from './field-value';
+import {DeleteTransform, FieldTransform} from './field-value';
 import {GeoPoint} from './geo-point';
 import {DocumentReference, Firestore} from './index';
 import {FieldPath, QualifiedResourcePath} from './path';
@@ -53,12 +52,15 @@ export interface Serializable {
  */
 export class Serializer {
   private createReference: (path: string) => DocumentReference;
+  private createInteger: (n: number | string) => number | BigInt;
 
   constructor(firestore: Firestore) {
     // Instead of storing the `firestore` object, we store just a reference to
     // its `.doc()` method. This avoid a circular reference, which breaks
     // JSON.stringify().
     this.createReference = path => firestore.doc(path);
+    this.createInteger = n =>
+      firestore._settings.useBigInt ? BigInt(n) : Number(n);
   }
 
   /**
@@ -116,6 +118,12 @@ export class Serializer {
           doubleValue: val as number,
         };
       }
+    }
+
+    if (typeof val === 'bigint') {
+      return {
+        integerValue: val.toString(),
+      };
     }
 
     if (val instanceof Date) {
@@ -213,14 +221,13 @@ export class Serializer {
         return proto.booleanValue;
       }
       case 'integerValue': {
-        return Number(proto.integerValue);
+        return this.createInteger(proto.integerValue!);
       }
       case 'doubleValue': {
-        return Number(proto.doubleValue);
+        return proto.doubleValue;
       }
       case 'timestampValue': {
-        const timestamp = Timestamp.fromProto(proto.timestampValue!);
-        return timestamp;
+        return Timestamp.fromProto(proto.timestampValue!);
       }
       case 'referenceValue': {
         const resourcePath = QualifiedResourcePath.fromSlashSeparatedString(
@@ -298,7 +305,6 @@ export function validateUserInput(
     );
   }
 
-  options = options || {};
   level = level || 0;
   inArray = inArray || false;
 

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -116,10 +116,7 @@ export class Timestamp {
    * @param {Object} timestamp The `Timestamp` Protobuf object.
    */
   static fromProto(timestamp: google.protobuf.ITimestamp) {
-    return new Timestamp(
-      Number(timestamp.seconds || 0),
-      Number(timestamp.nanos || 0)
-    );
+    return new Timestamp(Number(timestamp.seconds || 0), timestamp.nanos || 0);
   }
 
   /**
@@ -165,7 +162,7 @@ export class Timestamp {
    *
    * @type {number}
    */
-  get seconds() {
+  get seconds(): number {
     return this._seconds;
   }
 
@@ -182,7 +179,7 @@ export class Timestamp {
    *
    * @type {number}
    */
-  get nanoseconds() {
+  get nanoseconds(): number {
     return this._nanoseconds;
   }
 
@@ -200,7 +197,7 @@ export class Timestamp {
    * @return {Date} JavaScript `Date` object representing the same point in time
    * as this `Timestamp`, with millisecond precision.
    */
-  toDate() {
+  toDate(): Date {
     return new Date(
       this._seconds * 1000 + Math.round(this._nanoseconds / MS_TO_NANOS)
     );
@@ -222,7 +219,7 @@ export class Timestamp {
    * represented as the number of milliseconds since Unix epoch
    * 1970-01-01T00:00:00Z.
    */
-  toMillis() {
+  toMillis(): number {
     return this._seconds * 1000 + Math.floor(this._nanoseconds / MS_TO_NANOS);
   }
 

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -199,6 +199,14 @@ export interface Settings {
    */
   maxIdleChannels?: number;
 
+  /**
+   * Whether to use `BigInt` for integer types when deserializing Firestore
+   * Documents. Regardless of magnitude, all integer values will be returned as
+   * `BigInt` and match the precision of the Firestore backend. Floating point
+   * numbers continue to use JavaScript's `number` type.
+   */
+  useBigInt?: boolean;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any; // Accept other properties, such as GRPC settings.
 }

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -202,7 +202,7 @@ export interface Settings {
   /**
    * Whether to use `BigInt` for integer types when deserializing Firestore
    * Documents. Regardless of magnitude, all integer values will be returned as
-   * `BigInt` and match the precision of the Firestore backend. Floating point
+   * `BigInt` to match the precision of the Firestore backend. Floating point
    * numbers continue to use JavaScript's `number` type.
    */
   useBigInt?: boolean;

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -201,7 +201,7 @@ export interface Settings {
 
   /**
    * Whether to use `BigInt` for integer types when deserializing Firestore
-   * Documents. Regardless of magnitude, all integer values will be returned as
+   * Documents. Regardless of magnitude, all integer values are returned as
    * `BigInt` to match the precision of the Firestore backend. Floating point
    * numbers continue to use JavaScript's `number` type.
    */

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -259,7 +259,7 @@ describe('DocumentReference class', () => {
   let randomCol: CollectionReference;
 
   beforeEach(() => {
-    firestore = new Firestore({});
+    firestore = new Firestore({useBigInt: true});
     randomCol = getTestRoot(firestore);
   });
 
@@ -355,6 +355,21 @@ describe('DocumentReference class', () => {
         const actualValue = doc.data()!.nanValue;
         expect(actualValue).to.be.a('number');
         expect(actualValue).to.be.NaN;
+      });
+  });
+
+  it('round-trips BigInts', () => {
+    const bigIntValue = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+    const ref = randomCol.doc('doc');
+    return ref
+      .set({bigIntValue})
+      .then(() => ref.get())
+      .then(doc => ref.set(doc.data()!))
+      .then(() => ref.get())
+      .then(doc => {
+        const actualValue = doc.data()!.bigIntValue;
+        expect(actualValue).to.be.a('bigint');
+        expect(actualValue).to.equal(bigIntValue);
       });
   });
 

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -279,6 +279,28 @@ describe('serialize document', () => {
     });
   });
 
+  it('supports BigInt', () => {
+    const overrides: ApiOverride = {
+      commit: request => {
+        requestEquals(
+          request,
+          set({
+            document: document('documentId', 'bigIntValue', {
+              integerValue: '9007199254740992',
+            }),
+          })
+        );
+        return response(writeResult(1));
+      },
+    };
+
+    return createInstance(overrides).then(firestore => {
+      return firestore.doc('collectionId/documentId').set({
+        bigIntValue: BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+      });
+    });
+  });
+
   it('serializes unicode keys', () => {
     const overrides: ApiOverride = {
       commit: request => {
@@ -524,6 +546,30 @@ describe('deserialize document', () => {
           expect(res.get('nanValue')).to.be.NaN;
           expect(res.get('posInfinity')).to.equal(Infinity);
           expect(res.get('negInfinity')).to.equal(-Infinity);
+        });
+    });
+  });
+
+  it('deserializes BigInt', () => {
+    const overrides: ApiOverride = {
+      batchGetDocuments: () => {
+        return stream(
+          found(
+            document('documentId', 'bigIntValue', {
+              integerValue: '9007199254740992',
+            })
+          )
+        );
+      },
+    };
+
+    return createInstance(overrides, {useBigInt: true}).then(firestore => {
+      return firestore
+        .doc('collectionId/documentId')
+        .get()
+        .then(res => {
+          expect(res.get('bigIntValue')).to.be.a('bigint');
+          expect(res.get('bigIntValue')).to.equal(BigInt('9007199254740992'));
         });
     });
   });

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -20,7 +20,7 @@ import * as through2 from 'through2';
 
 import * as proto from '../../protos/firestore_v1_proto_api';
 import * as v1 from '../../src/v1';
-import {Firestore, QueryDocumentSnapshot} from '../../src';
+import {Firestore, QueryDocumentSnapshot, Settings} from '../../src';
 import {ClientPool} from '../../src/pool';
 import {DocumentData, GapicClient} from '../../src/types';
 
@@ -50,7 +50,7 @@ export type ApiOverride = Partial<GapicClient>;
  */
 export function createInstance(
   apiOverrides?: ApiOverride,
-  firestoreSettings?: {}
+  firestoreSettings?: Settings
 ): Promise<Firestore> {
   const initializationOptions = {
     ...{projectId: PROJECT_ID, sslCreds: SSL_CREDENTIALS},

--- a/synth.metadata
+++ b/synth.metadata
@@ -4,15 +4,16 @@
       "git": {
         "name": ".",
         "remote": "git@github.com:googleapis/nodejs-firestore.git",
-        "sha": "eb77d86abb2cba21a42c20999b8b74c760069ffa"
+        "sha": "3cec3361084cff65c284482b3a526e67ddb41620"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "629e6bea8418ad4a5d081ab9eb48bb327ad368e1",
-        "internalRef": "306660765"
+        "sha": "c3f3cdeda70f60d808eaaae8fea44d306b6d5cc2",
+        "internalRef": "306746093",
+        "log": "c3f3cdeda70f60d808eaaae8fea44d306b6d5cc2\nfix: update {Create|Delete}Backup and RestoreDatabase timeouts to 1 hour\n\nPiperOrigin-RevId: 306746093\n\n"
       }
     },
     {

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -149,7 +149,7 @@ declare namespace FirebaseFirestore {
 
     /**
      * Whether to use `BigInt` for integer types when deserializing Firestore
-     * Documents. Regardless of magnitude, all integer values will be returned as
+     * Documents. Regardless of magnitude, all integer values are returned as
      * `BigInt` to match the precision of the Firestore backend. Floating point
      * numbers continue to use JavaScript's `number` type.
      */

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -150,7 +150,7 @@ declare namespace FirebaseFirestore {
     /**
      * Whether to use `BigInt` for integer types when deserializing Firestore
      * Documents. Regardless of magnitude, all integer values will be returned as
-     * `BigInt` and match the precision of the Firestore backend. Floating point
+     * `BigInt` to match the precision of the Firestore backend. Floating point
      * numbers continue to use JavaScript's `number` type.
      */
     useBigInt?: boolean;

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -147,6 +147,14 @@ declare namespace FirebaseFirestore {
      */
     maxIdleChannels?: number;
 
+    /**
+     * Whether to use `BigInt` for integer types when deserializing Firestore
+     * Documents. Regardless of magnitude, all integer values will be returned as
+     * `BigInt` and match the precision of the Firestore backend. Floating point
+     * numbers continue to use JavaScript's `number` type.
+     */
+    useBigInt?: boolean;
+
     [key: string]: any; // Accept other properties, such as GRPC settings.
   }
 


### PR DESCRIPTION
This PR adds support for serializing to BigInt and for deserializing to BigInt (optional, via flag). We still need to settle on a flag name.

Fixes https://github.com/googleapis/nodejs-firestore/issues/872