### PR TITLE
feat: Add BulkWriter base

### DIFF
--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -479,11 +479,14 @@ export class BulkWriter {
    */
   private getEligibleBatch(ref: DocumentReference): BulkCommitBatch {
     let eligibleBatch = null;
-    let hasBatches = this.batchQueue.length > 0;
-    if (hasBatches) {
+    let logWarning = false;
+    if (this.batchQueue.length > 0) {
       const lastBatch = this.batchQueue[this.batchQueue.length - 1];
-      if (!lastBatch.docPaths.has(ref.path)) {
-        hasBatches = false;
+      if (
+        lastBatch.docPaths.has(ref.path) &&
+        lastBatch.state === BatchState.OPEN
+      ) {
+        logWarning = true;
       }
       if (lastBatch.canAddDoc(ref)) {
         eligibleBatch = lastBatch;
@@ -491,7 +494,7 @@ export class BulkWriter {
     }
 
     if (eligibleBatch === null) {
-      if (hasBatches) {
+      if (logWarning) {
         console.warn(
           '[BulkWriter]',
           `Duplicate write to document "${ref.path}" detected.`,

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -1,0 +1,604 @@
+/*!
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+
+import {FieldPath, Firestore} from '.';
+import {DocumentReference} from './reference';
+import {Timestamp} from './timestamp';
+import {DocumentData, Precondition, SetOptions, UpdateData} from './types';
+import {Deferred} from './util';
+import {BatchWriteResult, WriteBatch, WriteResult} from './write-batch';
+
+/**
+ * The default maximum number of writes that can be in a single batch.
+ */
+const MAX_BATCH_SIZE = 500;
+
+/**
+ * Used to represent the state of batch.
+ *
+ * Writes can only be added while the batch is OPEN. For a batch to be sent,
+ * the batch must be READY_TO_SEND. After a batch is sent, it is marked as SENT.
+ */
+enum BatchState {
+  OPEN,
+  READY_TO_SEND,
+  SENT,
+}
+
+/**
+ * Used to represent a batch on the BatchQueue.
+ *
+ * @private
+ */
+class BulkCommitBatch {
+  /**
+   * The state of the batch.
+   */
+  private _state = BatchState.OPEN;
+
+  // The set of document reference ids present in the WriteBatch.
+  readonly docPaths = new Set<string>();
+
+  // A deferred promise that is resolved after the batch has been sent, and a
+  // response is received.
+  private completedDeferred = new Deferred<void>();
+
+  // A map from each WriteBatch operation to its corresponding result.
+  private resultsMap = new Map<number, Deferred<BatchWriteResult>>();
+
+  constructor(
+    private readonly writeBatch: WriteBatch,
+    private readonly maxBatchSize: number
+  ) {}
+
+  /**
+   * The number of writes in this batch.
+   *
+   * @property
+   */
+  get opCount(): number {
+    return this.resultsMap.size;
+  }
+
+  get state(): BatchState {
+    return this._state;
+  }
+
+  /**
+   * Adds a `create` operation to the WriteBatch. Returns a promise that
+   * resolves with the result of the write.
+   */
+  create(
+    documentRef: DocumentReference,
+    data: DocumentData
+  ): Promise<WriteResult> {
+    this.writeBatch.create(documentRef, data);
+    return this.processOperation(documentRef);
+  }
+
+  /**
+   * Adds a `delete` operation to the WriteBatch. Returns a promise that
+   * resolves with the result of the delete.
+   */
+  delete(
+    documentRef: DocumentReference,
+    precondition?: Precondition
+  ): Promise<WriteResult> {
+    this.writeBatch.delete(documentRef, precondition);
+    return this.processOperation(documentRef);
+  }
+
+  /**
+   * Adds a `set` operation to the WriteBatch. Returns a promise that
+   * resolves with the result of the write.
+   */
+  set(
+    documentRef: DocumentReference,
+    data: DocumentData,
+    options?: SetOptions
+  ): Promise<WriteResult> {
+    this.writeBatch.set(documentRef, data, options);
+    return this.processOperation(documentRef);
+  }
+
+  /**
+   * Adds an `update` operation to the WriteBatch. Returns a promise that
+   * resolves with the result of the write.
+   */
+  update(
+    documentRef: DocumentReference,
+    dataOrField: UpdateData | string | FieldPath,
+    ...preconditionOrValues: Array<
+      {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
+    >
+  ): Promise<WriteResult> {
+    this.writeBatch.update(documentRef, dataOrField, ...preconditionOrValues);
+    return this.processOperation(documentRef);
+  }
+
+  /**
+   * Helper to update data structures associated with the operation and
+   * return the result.
+   */
+  private processOperation(
+    documentRef: DocumentReference
+  ): Promise<WriteResult> {
+    assert(
+      !this.docPaths.has(documentRef.path),
+      'Batch should not contain writes to the same document'
+    );
+    this.docPaths.add(documentRef.path);
+    this.resultsMap.set(this.opCount, new Deferred<BatchWriteResult>());
+
+    return this.resultsMap.get(this.opCount - 1)!.promise.then(result => {
+      if (result.writeTime) {
+        return new WriteResult(result.writeTime);
+      } else {
+        throw result.status;
+      }
+    });
+  }
+
+  /**
+   * Returns whether a write containing the provided document reference can be
+   * added to this batch.
+   */
+  canAddDoc(documentRef: DocumentReference): boolean {
+    return (
+      this._state === BatchState.OPEN &&
+      this.opCount < this.maxBatchSize &&
+      !this.docPaths.has(documentRef.path)
+    );
+  }
+
+  /**
+   * Commits the batch and returns a promise that resolves with the result of
+   * all writes in this batch.
+   */
+  bulkCommit(): Promise<BatchWriteResult[]> {
+    assert(
+      this._state === BatchState.READY_TO_SEND,
+      'The batch should be marked as READY_TO_SEND before committing'
+    );
+    this._state = BatchState.SENT;
+    return this.writeBatch.bulkCommit();
+  }
+
+  /**
+   * Resolves the individual operations in the batch with the results.
+   */
+  processResults(results: BatchWriteResult[]): void {
+    results.map((result, index) => {
+      this.resultsMap.get(index)!.resolve(result);
+    });
+    this.completedDeferred.resolve();
+  }
+
+  /**
+   * Returns a promise that resolves when the batch has been sent, and a
+   * response is received.
+   */
+  awaitBatch(): Promise<void> {
+    this.markReadyToSend();
+    return this.completedDeferred.promise;
+  }
+
+  markReadyToSend(): void {
+    if (this._state === BatchState.OPEN) {
+      this._state = BatchState.READY_TO_SEND;
+    }
+  }
+}
+
+/**
+ * A Firestore BulkWriter than can be used to perform large amounts of writes in
+ * parallel. Writes to the same document will be executed sequentially.
+ *
+ * @class
+ */
+export class BulkWriter {
+  /**
+   * The maximum number of writes that can be in a single batch.
+   */
+  private maxBatchSize = MAX_BATCH_SIZE;
+
+  /**
+   * A queue of batches to be written.
+   */
+  private batchQueue: BulkCommitBatch[] = [];
+
+  /**
+   * Whether this BulkWriter instance is closed. Once closed, it cannot be
+   * opened again.
+   */
+  private closed = false;
+
+  constructor(private readonly firestore: Firestore) {}
+
+  /**
+   * Create a document with the provided data. This single operation will fail
+   * if a document exists at its location.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * created.
+   * @param {T} data The object to serialize as the document.
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.collection('col').doc();
+   *
+   * bulkWriter
+   *  .create(documentRef, {foo: 'bar'})
+   *  .then(result => {
+   *    console.log('Successfully executed write at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Write failed with: ', err);
+   *  });
+   * });
+   */
+  create(
+    documentRef: DocumentReference,
+    data: DocumentData
+  ): Promise<WriteResult> {
+    this.verifyNotClosed();
+    const bulkCommitBatch = this.getEligibleBatch(documentRef);
+    const resultPromise = bulkCommitBatch.create(documentRef, data);
+    this.sendBatchIfFull(bulkCommitBatch);
+    return resultPromise;
+  }
+
+  /**
+   * Delete a document from the database.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * deleted.
+   * @param {Precondition=} precondition A precondition to enforce for this
+   * delete.
+   * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
+   * document was last updated at lastUpdateTime. Fails the batch if the
+   * document doesn't exist or was last updated at a different time.
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.doc('col/doc');
+   *
+   * bulkWriter
+   *  .delete(documentRef)
+   *  .then(result => {
+   *    console.log('Successfully delete document at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Delete failed with: ', err);
+   *  });
+   * });
+   */
+  delete(
+    documentRef: DocumentReference,
+    precondition?: Precondition
+  ): Promise<WriteResult> {
+    this.verifyNotClosed();
+    const bulkCommitBatch = this.getEligibleBatch(documentRef);
+    const resultPromise = bulkCommitBatch.delete(documentRef, precondition);
+    this.sendBatchIfFull(bulkCommitBatch);
+    return resultPromise;
+  }
+
+  /**
+   * Write to the document referred to by the provided
+   * [DocumentReference]{@link DocumentReference}. If the document does not
+   * exist yet, it will be created. If you pass [SetOptions]{@link SetOptions}.,
+   * the provided data can be merged into the existing document.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * set.
+   * @param {T} data The object to serialize as the document.
+   * @param {SetOptions=} options An object to configure the set behavior.
+   * @param {boolean=} options.merge - If true, set() merges the values
+   * specified in its data argument. Fields omitted from this set() call remain
+   * untouched.
+   * @param {Array.<string|FieldPath>=} options.mergeFields - If provided, set()
+   * only replaces the specified field paths. Any field path that is not
+   * specified is ignored and remains untouched.
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.collection('col').doc();
+   *
+   * bulkWriter
+   *  .set(documentRef, {foo: 'bar'})
+   *  .then(result => {
+   *    console.log('Successfully executed write at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Write failed with: ', err);
+   *  });
+   * });
+   */
+  set(
+    documentRef: DocumentReference,
+    data: DocumentData,
+    options?: SetOptions
+  ): Promise<WriteResult> {
+    this.verifyNotClosed();
+    const bulkCommitBatch = this.getEligibleBatch(documentRef);
+    const resultPromise = bulkCommitBatch.set(documentRef, data, options);
+    this.sendBatchIfFull(bulkCommitBatch);
+    return resultPromise;
+  }
+
+  /**
+   * Update fields of the document referred to by the provided
+   * [DocumentReference]{@link DocumentReference}. If the document doesn't yet
+   * exist, the update fails and the entire batch will be rejected.
+   *
+   * The update() method accepts either an object with field paths encoded as
+   * keys and field values encoded as values, or a variable number of arguments
+   * that alternate between field paths and field values. Nested fields can be
+   * updated by providing dot-separated field path strings or by providing
+   * FieldPath objects.
+   *
+   *
+   * A Precondition restricting this update can be specified as the last
+   * argument.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * updated.
+   * @param {UpdateData|string|FieldPath} dataOrField An object containing the
+   * fields and values with which to update the document or the path of the
+   * first field to update.
+   * @param {...(Precondition|*|string|FieldPath)} preconditionOrValues - An
+   * alternating list of field paths and values to update or a Precondition to
+   * restrict this update
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.doc('col/doc');
+   *
+   * bulkWriter
+   *  .update(documentRef, {foo: 'bar'})
+   *  .then(result => {
+   *    console.log('Successfully executed write at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Write failed with: ', err);
+   *  });
+   * });
+   */
+  update(
+    documentRef: DocumentReference,
+    dataOrField: UpdateData | string | FieldPath,
+    ...preconditionOrValues: Array<
+      {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
+    >
+  ): Promise<WriteResult> {
+    this.verifyNotClosed();
+    const bulkCommitBatch = this.getEligibleBatch(documentRef);
+    const resultPromise = bulkCommitBatch.update(
+      documentRef,
+      dataOrField,
+      preconditionOrValues
+    );
+    this.sendBatchIfFull(bulkCommitBatch);
+    return resultPromise;
+  }
+
+  /**
+   * Commits all writes that have been enqueued up to this point in parallel.
+   *
+   * Returns a Promise that resolves when there are no more pending writes. It
+   * never fails.
+   *
+   * The promise resolves immediately if there are no pending writes. Otherwise,
+   * the Promise waits for all previously issued writes, but it does not wait
+   * for writes that were added after the method is called. If you want to wait
+   * for additional writes, call `flush()` again.
+   *
+   * @return {Promise<void>} A promise that resolves when there are no more
+   * pending writes.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   *
+   * bulkWriter.create(documentRef, {foo: 'bar'});
+   * bulkWriter.update(documentRef2, {foo: 'bar'});
+   * bulkWriter.delete(documentRef3);
+   * await flush().then(() => {
+   *   console.log('Executed all writes');
+   * });
+   */
+  async flush(): Promise<void> {
+    this.verifyNotClosed();
+    const trackedBatches = this.batchQueue;
+    const writePromises = trackedBatches.map(batch => batch.awaitBatch());
+    this.sendBatches();
+    await Promise.all(writePromises);
+  }
+
+  /**
+   * Commits all enqueued writes and marks the BulkWriter instance as closed.
+   *
+   * After calling `close()`, calling any method wil throw an error.
+   *
+   * Returns a Promise that resolves when there are no more pending writes. It
+   * never fails. Calling this method will send all requests. The promise
+   * resolves immediately if there are no pending writes.
+   *
+   * @return {Promise<void>} A promise that resolves when there are no more
+   * pending writes.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   *
+   * bulkWriter.create(documentRef, {foo: 'bar'});
+   * bulkWriter.update(documentRef2, {foo: 'bar'});
+   * bulkWriter.delete(documentRef3);
+   * await close().then(() => {
+   *   console.log('Executed all writes');
+   * });
+   */
+  close(): Promise<void> {
+    const flushPromise = this.flush();
+    this.closed = true;
+    return flushPromise;
+  }
+
+  private verifyNotClosed(): void {
+    if (this.closed) {
+      throw new Error('BulkWriter has already been closed.');
+    }
+  }
+
+  /**
+   * Return the first eligible batch that can hold a write to the provided
+   * reference, or creates one if no eligible batches are found.
+   */
+  private getEligibleBatch(ref: DocumentReference): BulkCommitBatch {
+    let eligibleBatch = null;
+    let hasBatches = this.batchQueue.length > 0;
+    if (hasBatches) {
+      const lastBatch = this.batchQueue[this.batchQueue.length - 1];
+      if (!lastBatch.docPaths.has(ref.path)) {
+        hasBatches = false;
+      }
+      if (lastBatch.canAddDoc(ref)) {
+        eligibleBatch = lastBatch;
+      }
+    }
+
+    if (eligibleBatch === null) {
+      if (hasBatches) {
+        console.warn(
+          '[BulkWriter]',
+          `Duplicate write to document "${ref.path}" detected.`,
+          'Writing to the same document multiple times will slow down BulkWriter. ' +
+            'Write to unique documents in order to maximize throughput.'
+        );
+      }
+      return this.createNewBatch();
+    } else {
+      return eligibleBatch;
+    }
+  }
+
+  private createNewBatch(): BulkCommitBatch {
+    const newBatch = new BulkCommitBatch(
+      this.firestore.batch(),
+      this.maxBatchSize
+    );
+
+    if (this.batchQueue.length > 0) {
+      this.batchQueue[this.batchQueue.length - 1].markReadyToSend();
+      this.sendBatches();
+    }
+    this.batchQueue.push(newBatch);
+    return newBatch;
+  }
+
+  /**
+   * Attempts to send batches starting from the front of the BatchQueue until a
+   * batch cannot be sent.
+   *
+   * After a batch is complete, try sending batches again.
+   */
+  private sendBatches(): void {
+    const unsentBatches = this.batchQueue.filter(
+      batch => batch.state === BatchState.READY_TO_SEND
+    );
+
+    let index = 0;
+    while (
+      unsentBatches.length > index &&
+      this.isBatchSendable(unsentBatches[index])
+    ) {
+      const batch = unsentBatches[index];
+
+      batch.bulkCommit().then(results => {
+        batch.processResults(results);
+
+        // Remove the batch from the BatchQueue after it has been processed.
+        const batchIndex = this.batchQueue.indexOf(batch);
+        assert(batchIndex !== -1, 'The batch should be in the BatchQueue');
+        this.batchQueue.splice(batchIndex, 1);
+
+        this.sendBatches();
+      });
+
+      index++;
+    }
+  }
+
+  /**
+   * Checks that the provided batch is sendable. To be sendable, a batch must:
+   * (1) be marked as READY_TO_SEND
+   * (2) not write to references that are currently in flight
+   */
+  private isBatchSendable(batch: BulkCommitBatch): boolean {
+    if (batch.state !== BatchState.READY_TO_SEND) {
+      return false;
+    }
+
+    for (const path of batch.docPaths) {
+      if (this.isRefInFlight(path)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Whether the provided document reference path is currently in flight.
+   */
+  private isRefInFlight(docPath: string): boolean {
+    const refsInFlight = new Set<string>();
+    this.batchQueue
+      .filter(batch => batch.state === BatchState.SENT)
+      .map(batch => batch.docPaths.forEach(path => refsInFlight.add(path)));
+    return refsInFlight.has(docPath);
+  }
+
+  /**
+   * Sends the batch if it is at the maximum allowed size.
+   */
+  private sendBatchIfFull(batch: BulkCommitBatch): void {
+    if (batch.opCount === this.maxBatchSize) {
+      batch.markReadyToSend();
+      this.sendBatches();
+    }
+  }
+
+  /**
+   * Sets the maximum number of allowed operations in a batch.
+   *
+   * @private
+   */
+  // Visible for testing.
+  setMaxBatchSize(size: number): void {
+    this.maxBatchSize = size;
+  }
+}

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -284,7 +284,7 @@ export class BulkWriter {
    * bulkWriter
    *  .delete(documentRef)
    *  .then(result => {
-   *    console.log('Successfully delete document at: ', result);
+   *    console.log('Successfully deleted document at: ', result);
    *  })
    *  .catch(err => {
    *    console.log('Delete failed with: ', err);

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -176,9 +176,9 @@ class BulkCommitBatch {
    */
   processResults(results: BatchWriteResult[], error?: Error): void {
     if (error === undefined) {
-      results.map((result, index) => {
-        this.resultsMap.get(index)!.resolve(result);
-      });
+      for (let i = 0; i < this.opCount; i++) {
+        this.resultsMap.get(i)!.resolve(results[i]);
+      }
     } else {
       for (let i = 0; i < this.opCount; i++) {
         this.resultsMap.get(i)!.reject(error);
@@ -409,16 +409,17 @@ export class BulkWriter {
   /**
    * Commits all writes that have been enqueued up to this point in parallel.
    *
-   * Returns a Promise that resolves when there are no more pending writes.
-   * The Promise will never be rejected.
+   * Returns a Promise that resolves when all currently queued operations have
+   * been committed. The Promise will never be rejected since the results for
+   * each individual operation are conveyed via their individual Promises.
    *
    * The Promise resolves immediately if there are no pending writes. Otherwise,
    * the Promise waits for all previously issued writes, but it does not wait
    * for writes that were added after the method is called. If you want to wait
    * for additional writes, call `flush()` again.
    *
-   * @return {Promise<void>} A promise that resolves when there are no more
-   * pending writes.
+   * @return {Promise<void>} A promise that resolves when all enqueued writes
+   * up to this point have been committed.
    *
    * @example
    * let bulkWriter = firestore.bulkWriter();
@@ -447,8 +448,8 @@ export class BulkWriter {
    * Promise will never be rejected. Calling this method will send all requests.
    * The promise resolves immediately if there are no pending writes.
    *
-   * @return {Promise<void>} A promise that resolves when there are no more
-   * pending writes.
+   * @return {Promise<void>} A promise that resolves when all enqueued writes
+   * up to this point have been committed.
    *
    * @example
    * let bulkWriter = firestore.bulkWriter();

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -67,6 +67,7 @@ import {interfaces} from './v1/firestore_client_config.json';
 const serviceConfig = interfaces['google.firestore.v1.Firestore'];
 
 import api = google.firestore.v1;
+import {BulkWriter} from './bulk-writer';
 
 export {
   CollectionReference,
@@ -638,6 +639,37 @@ export class Firestore {
    */
   batch(): WriteBatch {
     return new WriteBatch(this);
+  }
+
+  /**
+   * Creates a [BulkWriter]{@link BulkWriter}, used for performing
+   * multiple writes in parallel.
+   *
+   * @returns {WriteBatch} A BulkWriter that operates on this Firestore
+   * client.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   *
+   * bulkWriter.create(firestore.doc('col/doc1'), {foo: 'bar'})
+   *   .then(res => {
+   *     console.log(`Added document at ${res.writeTime}`);
+   *   });
+   * bulkWriter.update(firestore.doc('col/doc2), {foo: 'bar'})
+   *   .then(res => {
+   *     console.log(`Updated document at ${res.writeTime}`);
+   *   });
+   * bulkWriter.delete(firestore.doc('col/doc3'))
+   *   .then(res => {
+   *     console.log(`Deleted document at ${res.writeTime}`);
+   *   });
+   * await bulkWriter.flush().then(() => {
+   *   console.log('Executed all writes');
+   * });
+   * bulkWriter.close();
+   */
+  bulkWriter(): BulkWriter {
+    return new BulkWriter(this);
   }
 
   /**

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -21,6 +21,7 @@ import {URL} from 'url';
 
 import {google} from '../protos/firestore_v1_proto_api';
 import {ExponentialBackoff, ExponentialBackoffSetting} from './backoff';
+import {BulkWriter} from './bulk-writer';
 import {fieldsFromJson, timestampFromJson} from './convert';
 import {
   DocumentSnapshot,
@@ -67,7 +68,6 @@ import {interfaces} from './v1/firestore_client_config.json';
 const serviceConfig = interfaces['google.firestore.v1.Firestore'];
 
 import api = google.firestore.v1;
-import {BulkWriter} from './bulk-writer';
 
 export {
   CollectionReference,
@@ -75,6 +75,7 @@ export {
   QuerySnapshot,
   Query,
 } from './reference';
+export {BulkWriter} from './bulk-writer';
 export {DocumentSnapshot, QueryDocumentSnapshot} from './document';
 export {FieldValue} from './field-value';
 export {WriteBatch, WriteResult} from './write-batch';

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -52,6 +52,7 @@ describe('BulkWriter', () => {
   let requestCounter: number;
   let opCount: number;
   let flushDeferred = new Deferred<void>();
+  let flushCounter = 0;
 
   beforeEach(() => {
     requestCounter = -1;
@@ -167,14 +168,14 @@ describe('BulkWriter', () => {
           writes: mock[requestCounter].request.writes,
         });
         if (manualFlush) {
-          return Promise.resolve().then(async () => {
-            await flushDeferred.promise;
+          flushCounter++;
+          return flushDeferred.promise.then(() => {
             flushDeferred = new Deferred<void>();
             return response({
-              writeResults: mock[requestCounter].response.writeResults,
-              status: mock[requestCounter].response.status,
-            });
-          });
+            writeResults: mock[requestCounter].response.writeResults,
+            status: mock[requestCounter].response.status,
+          })
+        });
         }
         return response({
           writeResults: mock[requestCounter].response.writeResults,
@@ -292,6 +293,26 @@ describe('BulkWriter', () => {
     return bulkWriter.flush().then(() => verifyOpCount(0));
   });
 
+  it('adds writes to a new batch after calling flush()', async() => {
+    await instantiateInstance([
+      {
+        request: createRequest([createOp('col/doc', 'bar')]),
+        response: createResponse([successResponse(2)]),
+      },
+      {
+        request: createRequest([setOp('col/doc', 'bar1')]),
+        response: createResponse([successResponse(2)]),
+      },
+    ]);
+    const doc = firestore.doc('col/doc');
+    bulkWriter.create(doc, {foo: 'bar'}).then(incrementOpCount);
+    bulkWriter.flush();
+    bulkWriter.set(doc, {foo: 'bar1'}).then(incrementOpCount);
+    await bulkWriter.flush().then(async () => {
+      verifyOpCount(2);
+    });
+  })
+
   it('close() sends all writes', async () => {
     await instantiateInstance([
       {
@@ -300,14 +321,9 @@ describe('BulkWriter', () => {
       },
     ]);
     const doc = firestore.doc('col/doc');
-    let writeResult: WriteResult;
-    bulkWriter.create(doc, {foo: 'bar'}).then(result => {
-      incrementOpCount();
-      writeResult = result;
-    });
+    bulkWriter.create(doc, {foo: 'bar'}).then(incrementOpCount);
     return bulkWriter.close().then(async () => {
       verifyOpCount(1);
-      expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
     });
   });
 
@@ -489,4 +505,33 @@ describe('BulkWriter', () => {
       verifyOpCount(4);
     });
   });
+
+  it.only('does not send batches if a document containing the same write is in flight', async () => {
+    await instantiateInstance(
+      [
+        {
+          request: createRequest([
+            setOp('col/doc1', 'bar'),
+            setOp('col/doc2', 'bar'),
+          ]),
+          response: createResponse([successResponse(1), successResponse(2)]),
+        },
+        {
+          request: createRequest([setOp('col/doc3', 'bar')]),
+          response: createResponse([successResponse(3)]),
+        },
+      ],
+      /** manualFlush= */ true
+    );
+    bulkWriter.set(firestore.doc('col/doc1'), {foo: 'bar'});
+    bulkWriter.set(firestore.doc('col/doc2'), {foo: 'bar'});
+    const flush1 = bulkWriter.flush();
+    // The third write will be placed in a new batch
+    bulkWriter.set(firestore.doc('col/doc3'), {foo: 'bar'});
+    const flush2 = bulkWriter.flush();
+    flushDeferred.resolve();
+    await flush1;
+    expect(flushCounter).to.equal(1);
+    await flush2;
+  })
 });

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -20,8 +20,14 @@ import {BulkWriter} from '../src/bulk-writer';
 import {Deferred} from '../src/util';
 import {
   ApiOverride,
+  create,
   createInstance,
+  document,
+  remove,
   response,
+  set,
+  update,
+  updateMask,
   verifyInstance,
 } from './util/helpers';
 
@@ -44,9 +50,7 @@ interface RequestResponse {
   response: BulkWriterResponse;
 }
 
-describe.only('BulkWriter', () => {
-  const documentNameRoot = `projects/${PROJECT_ID}/databases/(default)/documents/`;
-
+describe('BulkWriter', () => {
   let firestore: Firestore;
   let bulkWriter: BulkWriter;
   let requestCounter: number;
@@ -67,62 +71,34 @@ describe.only('BulkWriter', () => {
     expect(opCount).to.equal(expected);
   }
 
-  function setOp(doc: string, value: string): {[key: string]: {}} {
-    return {
-      update: {
-        fields: {
-          foo: {
-            stringValue: value,
-          },
-        },
-        name: documentNameRoot + doc,
-      },
-    };
+  function setOp(doc: string, value: string): BulkWriterRequest {
+    return set({
+      document: document(doc, 'foo', value),
+    }) as BulkWriterRequest;
   }
 
-  function createOp(doc: string, value: string): {[key: string]: {}} {
-    return {
-      currentDocument: {
-        exists: false,
-      },
-      update: {
-        fields: {
-          foo: {
-            stringValue: value,
-          },
-        },
-        name: documentNameRoot + doc,
-      },
-    };
+  function createOp(doc: string, value: string): BulkWriterRequest {
+    return create({
+      document: document(doc, 'foo', value),
+    }) as BulkWriterRequest;
   }
 
-  function updateOp(doc: string, value: string): {[key: string]: {}} {
-    return {
-      update: {
-        fields: {
-          foo: {
-            stringValue: value,
-          },
-        },
-        name: documentNameRoot + doc,
-      },
-      updateMask: {
-        fieldPaths: ['foo'],
-      },
-    };
+  function updateOp(doc: string, value: string): BulkWriterRequest {
+    const updateRequest = update({
+      document: document(doc, 'foo', value),
+      mask: updateMask('foo'),
+    }) as BulkWriterRequest;
+    delete updateRequest.writes[0].currentDocument;
+    return updateRequest;
   }
 
-  function deleteOp(doc: string): {[key: string]: {}} {
-    return {
-      delete: documentNameRoot + doc,
-    };
+  function deleteOp(doc: string): BulkWriterRequest {
+    return remove(doc) as BulkWriterRequest;
   }
 
-  function createRequest(
-    requests: Array<{[key: string]: {}}>
-  ): BulkWriterRequest {
+  function joinRequests(requests: BulkWriterRequest[]): BulkWriterRequest {
     return {
-      writes: requests,
+      writes: requests.map(req => req.writes[0]),
     };
   }
 
@@ -194,17 +170,17 @@ describe.only('BulkWriter', () => {
   it('has a set() method', async () => {
     await instantiateInstance([
       {
-        request: createRequest([setOp('col/doc', 'bar')]),
+        request: setOp('doc', 'bar'),
         response: createResponse([successResponse(2)]),
       },
     ]);
-    const doc = firestore.doc('col/doc');
+    const doc = firestore.doc('collectionId/doc');
     let writeResult: WriteResult;
     bulkWriter.set(doc, {foo: 'bar'}).then(result => {
       incrementOpCount();
       writeResult = result;
     });
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(1);
       expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
     });
@@ -213,17 +189,17 @@ describe.only('BulkWriter', () => {
   it('has an update() method', async () => {
     await instantiateInstance([
       {
-        request: createRequest([updateOp('col/doc', 'bar')]),
+        request: updateOp('doc', 'bar'),
         response: createResponse([successResponse(2)]),
       },
     ]);
-    const doc = firestore.doc('col/doc');
+    const doc = firestore.doc('collectionId/doc');
     let writeResult: WriteResult;
     bulkWriter.update(doc, {foo: 'bar'}).then(result => {
       incrementOpCount();
       writeResult = result;
     });
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(1);
       expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
     });
@@ -232,17 +208,17 @@ describe.only('BulkWriter', () => {
   it('has a delete() method', async () => {
     await instantiateInstance([
       {
-        request: createRequest([deleteOp('col/doc')]),
+        request: deleteOp('doc'),
         response: createResponse([successResponse(2)]),
       },
     ]);
-    const doc = firestore.doc('col/doc');
+    const doc = firestore.doc('collectionId/doc');
     let writeResult: WriteResult;
     bulkWriter.delete(doc).then(result => {
       incrementOpCount();
       writeResult = result;
     });
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(1);
       expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
     });
@@ -251,41 +227,37 @@ describe.only('BulkWriter', () => {
   it('has a create() method', async () => {
     await instantiateInstance([
       {
-        request: createRequest([createOp('col/doc', 'bar')]),
+        request: createOp('doc', 'bar'),
         response: createResponse([successResponse(2)]),
       },
     ]);
-    const doc = firestore.doc('col/doc');
+    const doc = firestore.doc('collectionId/doc');
     let writeResult: WriteResult;
     bulkWriter.create(doc, {foo: 'bar'}).then(result => {
       incrementOpCount();
       writeResult = result;
     });
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(1);
       expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
     });
   });
 
-  // TODO: Do I need to include other tests similar to the ones in WriteBatch
-  // that check for adding preconditions, passing in null values, etc? OR can I
-  // assume that WriteBatch will handle them?
-
   it('surfaces errors', async () => {
     await instantiateInstance([
       {
-        request: createRequest([setOp('col/doc', 'bar')]),
+        request: setOp('doc', 'bar'),
         response: createResponse([failResponse()]),
       },
     ]);
 
-    const doc = firestore.doc('col/doc');
+    const doc = firestore.doc('collectionId/doc');
     bulkWriter.set(doc, {foo: 'bar'}).catch(err => {
       incrementOpCount();
       expect(err.code).to.equal(Status.UNAVAILABLE);
     });
 
-    return bulkWriter.flush().then(async () => verifyOpCount(1));
+    return bulkWriter.close().then(async () => verifyOpCount(1));
   });
 
   it('flush() resolves immediately if there are no writes', async () => {
@@ -296,18 +268,22 @@ describe.only('BulkWriter', () => {
   it('adds writes to a new batch after calling flush()', async () => {
     await instantiateInstance([
       {
-        request: createRequest([createOp('col/doc', 'bar')]),
+        request: createOp('doc', 'bar'),
         response: createResponse([successResponse(2)]),
       },
       {
-        request: createRequest([setOp('col/doc2', 'bar1')]),
+        request: setOp('doc2', 'bar1'),
         response: createResponse([successResponse(2)]),
       },
     ]);
-    bulkWriter.create(firestore.doc('col/doc'), {foo: 'bar'}).then(incrementOpCount);
+    bulkWriter
+      .create(firestore.doc('collectionId/doc'), {foo: 'bar'})
+      .then(incrementOpCount);
     bulkWriter.flush();
-    bulkWriter.set(firestore.doc('col/doc2'), {foo: 'bar1'}).then(incrementOpCount);
-    await bulkWriter.flush().then(async () => {
+    bulkWriter
+      .set(firestore.doc('collectionId/doc2'), {foo: 'bar1'})
+      .then(incrementOpCount);
+    await bulkWriter.close().then(async () => {
       verifyOpCount(2);
     });
   });
@@ -315,11 +291,11 @@ describe.only('BulkWriter', () => {
   it('close() sends all writes', async () => {
     await instantiateInstance([
       {
-        request: createRequest([createOp('col/doc', 'bar')]),
+        request: createOp('doc', 'bar'),
         response: createResponse([successResponse(2)]),
       },
     ]);
-    const doc = firestore.doc('col/doc');
+    const doc = firestore.doc('collectionId/doc');
     bulkWriter.create(doc, {foo: 'bar'}).then(incrementOpCount);
     return bulkWriter.close().then(async () => {
       verifyOpCount(1);
@@ -335,19 +311,12 @@ describe.only('BulkWriter', () => {
     await instantiateInstance([]);
 
     const expected = 'BulkWriter has already been closed.';
+    const doc = firestore.doc('collectionId/doc');
     await bulkWriter.close();
-    expect(() => bulkWriter.set(firestore.doc('col/doc'), {})).to.throw(
-      expected
-    );
-    expect(() => bulkWriter.create(firestore.doc('col/doc'), {})).to.throw(
-      expected
-    );
-    expect(() => bulkWriter.update(firestore.doc('col/doc'), {})).to.throw(
-      expected
-    );
-    expect(() => bulkWriter.delete(firestore.doc('col/doc'))).to.throw(
-      expected
-    );
+    expect(() => bulkWriter.set(doc, {})).to.throw(expected);
+    expect(() => bulkWriter.create(doc, {})).to.throw(expected);
+    expect(() => bulkWriter.update(doc, {})).to.throw(expected);
+    expect(() => bulkWriter.delete(doc)).to.throw(expected);
     expect(bulkWriter.flush()).to.eventually.be.rejectedWith(expected);
     expect(bulkWriter.close()).to.eventually.be.rejectedWith(expected);
   });
@@ -355,20 +324,20 @@ describe.only('BulkWriter', () => {
   it('sends writes to the same document in separate batches', async () => {
     await instantiateInstance([
       {
-        request: createRequest([setOp('col/doc', 'bar')]),
+        request: setOp('doc', 'bar'),
         response: createResponse([successResponse(0)]),
       },
       {
-        request: createRequest([updateOp('col/doc', 'bar1')]),
+        request: updateOp('doc', 'bar1'),
         response: createResponse([successResponse(1)]),
       },
     ]);
 
-    const doc = firestore.doc('col/doc');
+    const doc = firestore.doc('collectionId/doc');
     bulkWriter.set(doc, {foo: 'bar'}).then(incrementOpCount);
     bulkWriter.update(doc, {foo: 'bar1'}).then(incrementOpCount);
 
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(2);
     });
   });
@@ -376,51 +345,48 @@ describe.only('BulkWriter', () => {
   it('sends writes to different documents in the same batch', async () => {
     await instantiateInstance([
       {
-        request: createRequest([
-          setOp('col/doc1', 'bar'),
-          updateOp('col/doc2', 'bar'),
-        ]),
+        request: joinRequests([setOp('doc1', 'bar'), updateOp('doc2', 'bar')]),
         response: createResponse([successResponse(0), successResponse(1)]),
       },
     ]);
 
-    const doc1 = firestore.doc('col/doc1');
-    const doc2 = firestore.doc('col/doc2');
+    const doc1 = firestore.doc('collectionId/doc1');
+    const doc2 = firestore.doc('collectionId/doc2');
     bulkWriter.set(doc1, {foo: 'bar'}).then(incrementOpCount);
     bulkWriter.update(doc2, {foo: 'bar'}).then(incrementOpCount);
 
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(2);
     });
   });
 
   it('splits into multiple batches after exceeding maximum batch size', async () => {
     const arrayRange = Array.from(new Array(6), (_, i) => i);
-    const requests = arrayRange.map(i => setOp('col/doc' + i, 'bar'));
+    const requests = arrayRange.map(i => setOp('doc' + i, 'bar'));
     const responses = arrayRange.map(i => successResponse(i));
     await instantiateInstance([
       {
-        request: createRequest([requests[0], requests[1]]),
+        request: joinRequests([requests[0], requests[1]]),
         response: createResponse([responses[0], responses[1]]),
       },
       {
-        request: createRequest([requests[2], requests[3]]),
+        request: joinRequests([requests[2], requests[3]]),
         response: createResponse([responses[2], responses[3]]),
       },
       {
-        request: createRequest([requests[4], requests[5]]),
+        request: joinRequests([requests[4], requests[5]]),
         response: createResponse([responses[4], responses[5]]),
       },
     ]);
 
-    bulkWriter.setMaxBatchSize(2);
+    bulkWriter._setMaxBatchSize(2);
     for (let i = 0; i < 6; i++) {
       bulkWriter
-        .set(firestore.doc('col/doc' + i), {foo: 'bar'})
+        .set(firestore.doc('collectionId/doc' + i), {foo: 'bar'})
         .then(incrementOpCount);
     }
 
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(6);
     });
   });
@@ -428,25 +394,25 @@ describe.only('BulkWriter', () => {
   it('sends existing batches when a new batch is created', async () => {
     await instantiateInstance([
       {
-        request: createRequest([setOp('col/doc', 'bar')]),
+        request: setOp('doc', 'bar'),
         response: createResponse([successResponse(0)]),
       },
       {
-        request: createRequest([
-          updateOp('col/doc', 'bar1'),
-          createOp('col/doc2', 'bar1'),
+        request: joinRequests([
+          updateOp('doc', 'bar1'),
+          createOp('doc2', 'bar1'),
         ]),
         response: createResponse([successResponse(1), successResponse(2)]),
       },
     ]);
 
-    bulkWriter.setMaxBatchSize(2);
+    bulkWriter._setMaxBatchSize(2);
 
-    const doc = firestore.doc('col/doc');
-    const doc2 = firestore.doc('col/doc2');
-    const setPromise = bulkWriter.set(doc, {foo: 'bar'}).then(incrementOpCount);
+    const doc = firestore.doc('collectionId/doc');
+    const doc2 = firestore.doc('collectionId/doc2');
 
     // Create a new batch by writing to the same document.
+    const setPromise = bulkWriter.set(doc, {foo: 'bar'}).then(incrementOpCount);
     const updatePromise = bulkWriter
       .update(doc, {foo: 'bar1'})
       .then(incrementOpCount);
@@ -457,18 +423,19 @@ describe.only('BulkWriter', () => {
       .create(doc2, {foo: 'bar1'})
       .then(incrementOpCount);
 
-    return Promise.all([updatePromise, createPromise]).then(async () => {
-      verifyOpCount(3);
-    });
+    await updatePromise;
+    await createPromise;
+    verifyOpCount(3);
+    return bulkWriter.close();
   });
 
   it('sends batches automatically when the batch size limit is reached', async () => {
     await instantiateInstance([
       {
-        request: createRequest([
-          setOp('col/doc1', 'bar'),
-          updateOp('col/doc2', 'bar'),
-          createOp('col/doc3', 'bar'),
+        request: joinRequests([
+          setOp('doc1', 'bar'),
+          updateOp('doc2', 'bar'),
+          createOp('doc3', 'bar'),
         ]),
         response: createResponse([
           successResponse(0),
@@ -477,30 +444,32 @@ describe.only('BulkWriter', () => {
         ]),
       },
       {
-        request: createRequest([deleteOp('col/doc4')]),
+        request: deleteOp('doc4'),
         response: createResponse([successResponse(3)]),
       },
     ]);
 
-    bulkWriter.setMaxBatchSize(3);
+    bulkWriter._setMaxBatchSize(3);
     const promise1 = bulkWriter
-      .set(firestore.doc('col/doc1'), {foo: 'bar'})
+      .set(firestore.doc('collectionId/doc1'), {foo: 'bar'})
       .then(incrementOpCount);
     const promise2 = bulkWriter
-      .update(firestore.doc('col/doc2'), {foo: 'bar'})
+      .update(firestore.doc('collectionId/doc2'), {foo: 'bar'})
       .then(incrementOpCount);
     const promise3 = bulkWriter
-      .create(firestore.doc('col/doc3'), {foo: 'bar'})
+      .create(firestore.doc('collectionId/doc3'), {foo: 'bar'})
       .then(incrementOpCount);
 
     // The 4th write should not sent because it should be in a new batch.
-    bulkWriter.delete(firestore.doc('col/doc4')).then(incrementOpCount);
+    bulkWriter
+      .delete(firestore.doc('collectionId/doc4'))
+      .then(incrementOpCount);
 
     await Promise.all([promise1, promise2, promise3]).then(() => {
       verifyOpCount(3);
     });
 
-    return bulkWriter.flush().then(async () => {
+    return bulkWriter.close().then(async () => {
       verifyOpCount(4);
     });
   });
@@ -509,27 +478,25 @@ describe.only('BulkWriter', () => {
     await instantiateInstance(
       [
         {
-          request: createRequest([
-            setOp('col/doc1', 'bar'),
-            setOp('col/doc2', 'bar'),
-          ]),
+          request: joinRequests([setOp('doc1', 'bar'), setOp('doc2', 'bar')]),
           response: createResponse([successResponse(1), successResponse(2)]),
         },
         {
-          request: createRequest([setOp('col/doc1', 'bar')]),
+          request: setOp('doc1', 'bar'),
           response: createResponse([successResponse(3)]),
         },
       ],
       /** manualFlush= */ true
     );
-    bulkWriter.set(firestore.doc('col/doc1'), {foo: 'bar'});
-    bulkWriter.set(firestore.doc('col/doc2'), {foo: 'bar'});
+    bulkWriter.set(firestore.doc('collectionId/doc1'), {foo: 'bar'});
+    bulkWriter.set(firestore.doc('collectionId/doc2'), {foo: 'bar'});
     const flush1 = bulkWriter.flush();
     // The third write will be placed in a new batch
-    bulkWriter.set(firestore.doc('col/doc1'), {foo: 'bar'});
+    bulkWriter.set(firestore.doc('collectionId/doc1'), {foo: 'bar'});
     const flush2 = bulkWriter.flush();
     flushDeferred.resolve();
     await flush1;
     await flush2;
+    return bulkWriter.close();
   });
 });

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -1,0 +1,492 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {expect} from 'chai';
+import {Status} from 'google-gax';
+
+import {Firestore, setLogFunction, Timestamp, WriteResult} from '../src';
+import {BulkWriter} from '../src/bulk-writer';
+import {Deferred} from '../src/util';
+import {
+  ApiOverride,
+  createInstance,
+  response,
+  verifyInstance,
+} from './util/helpers';
+
+// Change the argument to 'console.log' to enable debug output.
+setLogFunction(() => {});
+
+const PROJECT_ID = 'test-project';
+
+interface BulkWriterRequest {
+  writes: Array<{[key: string]: {} | undefined}>;
+}
+
+interface BulkWriterResponse {
+  writeResults: Array<{[key: string]: {} | null}>;
+  status: Array<{[key: string]: {}}>;
+}
+
+interface RequestResponse {
+  request: BulkWriterRequest;
+  response: BulkWriterResponse;
+}
+
+describe('BulkWriter', () => {
+  const documentNameRoot = `projects/${PROJECT_ID}/databases/(default)/documents/`;
+
+  let firestore: Firestore;
+  let bulkWriter: BulkWriter;
+  let requestCounter: number;
+  let opCount: number;
+  let flushDeferred = new Deferred<void>();
+
+  beforeEach(() => {
+    requestCounter = -1;
+    opCount = 0;
+  });
+
+  function incrementOpCount(): void {
+    opCount++;
+  }
+
+  function verifyOpCount(expected: number): void {
+    expect(opCount).to.equal(expected);
+  }
+
+  function setOp(doc: string, value: string): {[key: string]: {}} {
+    return {
+      update: {
+        fields: {
+          foo: {
+            stringValue: value,
+          },
+        },
+        name: documentNameRoot + doc,
+      },
+    };
+  }
+
+  function createOp(doc: string, value: string): {[key: string]: {}} {
+    return {
+      currentDocument: {
+        exists: false,
+      },
+      update: {
+        fields: {
+          foo: {
+            stringValue: value,
+          },
+        },
+        name: documentNameRoot + doc,
+      },
+    };
+  }
+
+  function updateOp(doc: string, value: string): {[key: string]: {}} {
+    return {
+      update: {
+        fields: {
+          foo: {
+            stringValue: value,
+          },
+        },
+        name: documentNameRoot + doc,
+      },
+      updateMask: {
+        fieldPaths: ['foo'],
+      },
+    };
+  }
+
+  function deleteOp(doc: string): {[key: string]: {}} {
+    return {
+      delete: documentNameRoot + doc,
+    };
+  }
+
+  function createRequest(
+    requests: Array<{[key: string]: {}}>
+  ): BulkWriterRequest {
+    return {
+      writes: requests,
+    };
+  }
+
+  function successResponse(seconds: number): {[key: string]: {}} {
+    return {
+      updateTime: {
+        nanos: 0,
+        seconds,
+      },
+      code: Status.OK,
+    };
+  }
+
+  function failResponse(): {[key: string]: {} | null} {
+    return {
+      updateTime: null,
+      code: Status.UNAVAILABLE,
+    };
+  }
+
+  function createResponse(
+    responses: Array<{[key: string]: {} | null}>
+  ): BulkWriterResponse {
+    const writeResults = responses.map(response => ({
+      updateTime: response.updateTime,
+    }));
+    const status = responses.map(response => ({code: response.code!}));
+    return {
+      writeResults,
+      status,
+    };
+  }
+
+  function instantiateInstance(
+    mock: RequestResponse[],
+    manualFlush = false
+  ): Promise<void> {
+    const overrides: ApiOverride = {
+      batchWrite: async request => {
+        requestCounter++;
+        expect(request).to.deep.eq({
+          database: `projects/${PROJECT_ID}/databases/(default)`,
+          writes: mock[requestCounter].request.writes,
+        });
+        if (manualFlush) {
+          return Promise.resolve().then(async () => {
+            await flushDeferred.promise;
+            flushDeferred = new Deferred<void>();
+            return response({
+              writeResults: mock[requestCounter].response.writeResults,
+              status: mock[requestCounter].response.status,
+            });
+          });
+        }
+        return response({
+          writeResults: mock[requestCounter].response.writeResults,
+          status: mock[requestCounter].response.status,
+        });
+      },
+    };
+    return createInstance(overrides).then(firestoreClient => {
+      firestore = firestoreClient;
+      bulkWriter = firestore.bulkWriter();
+    });
+  }
+
+  afterEach(() => verifyInstance(firestore));
+
+  it('has a set() method', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([setOp('col/doc', 'bar')]),
+        response: createResponse([successResponse(2)]),
+      },
+    ]);
+    const doc = firestore.doc('col/doc');
+    let writeResult: WriteResult;
+    bulkWriter.set(doc, {foo: 'bar'}).then(result => {
+      incrementOpCount();
+      writeResult = result;
+    });
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(1);
+      expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
+    });
+  });
+
+  it('has an update() method', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([updateOp('col/doc', 'bar')]),
+        response: createResponse([successResponse(2)]),
+      },
+    ]);
+    const doc = firestore.doc('col/doc');
+    let writeResult: WriteResult;
+    bulkWriter.update(doc, {foo: 'bar'}).then(result => {
+      incrementOpCount();
+      writeResult = result;
+    });
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(1);
+      expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
+    });
+  });
+
+  it('has a delete() method', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([deleteOp('col/doc')]),
+        response: createResponse([successResponse(2)]),
+      },
+    ]);
+    const doc = firestore.doc('col/doc');
+    let writeResult: WriteResult;
+    bulkWriter.delete(doc).then(result => {
+      incrementOpCount();
+      writeResult = result;
+    });
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(1);
+      expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
+    });
+  });
+
+  it('has a create() method', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([createOp('col/doc', 'bar')]),
+        response: createResponse([successResponse(2)]),
+      },
+    ]);
+    const doc = firestore.doc('col/doc');
+    let writeResult: WriteResult;
+    bulkWriter.create(doc, {foo: 'bar'}).then(result => {
+      incrementOpCount();
+      writeResult = result;
+    });
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(1);
+      expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
+    });
+  });
+
+  // TODO: Do I need to include other tests similar to the ones in WriteBatch
+  // that check for adding preconditions, passing in null values, etc? OR can I
+  // assume that WriteBatch will handle them?
+
+  it('surfaces errors', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([setOp('col/doc', 'bar')]),
+        response: createResponse([failResponse()]),
+      },
+    ]);
+
+    const doc = firestore.doc('col/doc');
+    bulkWriter.set(doc, {foo: 'bar'}).catch(err => {
+      incrementOpCount();
+      expect(err.code).to.equal(Status.UNAVAILABLE);
+    });
+
+    return bulkWriter.flush().then(async () => verifyOpCount(1));
+  });
+
+  it('flush() resolves immediately if there are no writes', async () => {
+    await instantiateInstance([]);
+    return bulkWriter.flush().then(() => verifyOpCount(0));
+  });
+
+  it('close() sends all writes', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([createOp('col/doc', 'bar')]),
+        response: createResponse([successResponse(2)]),
+      },
+    ]);
+    const doc = firestore.doc('col/doc');
+    let writeResult: WriteResult;
+    bulkWriter.create(doc, {foo: 'bar'}).then(result => {
+      incrementOpCount();
+      writeResult = result;
+    });
+    return bulkWriter.close().then(async () => {
+      verifyOpCount(1);
+      expect(writeResult.writeTime.isEqual(new Timestamp(2, 0))).to.be.true;
+    });
+  });
+
+  it('close() resolves immediately if there are no writes', async () => {
+    await instantiateInstance([]);
+    return bulkWriter.close().then(() => verifyOpCount(0));
+  });
+
+  it('cannot call methods after close() is called', async () => {
+    await instantiateInstance([]);
+
+    const expected = 'BulkWriter has already been closed.';
+    await bulkWriter.close();
+    expect(() => bulkWriter.set(firestore.doc('col/doc'), {})).to.throw(
+      expected
+    );
+    expect(() => bulkWriter.create(firestore.doc('col/doc'), {})).to.throw(
+      expected
+    );
+    expect(() => bulkWriter.update(firestore.doc('col/doc'), {})).to.throw(
+      expected
+    );
+    expect(() => bulkWriter.delete(firestore.doc('col/doc'))).to.throw(
+      expected
+    );
+    expect(bulkWriter.flush()).to.eventually.be.rejectedWith(expected);
+    expect(bulkWriter.close()).to.eventually.be.rejectedWith(expected);
+  });
+
+  it('sends writes to the same document in separate batches', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([setOp('col/doc', 'bar')]),
+        response: createResponse([successResponse(0)]),
+      },
+      {
+        request: createRequest([updateOp('col/doc', 'bar1')]),
+        response: createResponse([successResponse(1)]),
+      },
+    ]);
+
+    const doc = firestore.doc('col/doc');
+    bulkWriter.set(doc, {foo: 'bar'}).then(incrementOpCount);
+    bulkWriter.update(doc, {foo: 'bar1'}).then(incrementOpCount);
+
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(2);
+    });
+  });
+
+  it('sends writes to different documents in the same batch', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([
+          setOp('col/doc1', 'bar'),
+          updateOp('col/doc2', 'bar'),
+        ]),
+        response: createResponse([successResponse(0), successResponse(1)]),
+      },
+    ]);
+
+    const doc1 = firestore.doc('col/doc1');
+    const doc2 = firestore.doc('col/doc2');
+    bulkWriter.set(doc1, {foo: 'bar'}).then(incrementOpCount);
+    bulkWriter.update(doc2, {foo: 'bar'}).then(incrementOpCount);
+
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(2);
+    });
+  });
+
+  it('splits into multiple batches after exceeding maximum batch size', async () => {
+    const arrayRange = Array.from(new Array(6), (_, i) => i);
+    const requests = arrayRange.map(i => setOp('col/doc' + i, 'bar'));
+    const responses = arrayRange.map(i => successResponse(i));
+    await instantiateInstance([
+      {
+        request: createRequest([requests[0], requests[1]]),
+        response: createResponse([responses[0], responses[1]]),
+      },
+      {
+        request: createRequest([requests[2], requests[3]]),
+        response: createResponse([responses[2], responses[3]]),
+      },
+      {
+        request: createRequest([requests[4], requests[5]]),
+        response: createResponse([responses[4], responses[5]]),
+      },
+    ]);
+
+    bulkWriter.setMaxBatchSize(2);
+    for (let i = 0; i < 6; i++) {
+      bulkWriter
+        .set(firestore.doc('col/doc' + i), {foo: 'bar'})
+        .then(incrementOpCount);
+    }
+
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(6);
+    });
+  });
+
+  it('sends existing batches when a new batch is created', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([setOp('col/doc', 'bar')]),
+        response: createResponse([successResponse(0)]),
+      },
+      {
+        request: createRequest([
+          updateOp('col/doc', 'bar1'),
+          createOp('col/doc2', 'bar1'),
+        ]),
+        response: createResponse([successResponse(1), successResponse(2)]),
+      },
+    ]);
+
+    bulkWriter.setMaxBatchSize(2);
+
+    const doc = firestore.doc('col/doc');
+    const doc2 = firestore.doc('col/doc2');
+    const setPromise = bulkWriter.set(doc, {foo: 'bar'}).then(incrementOpCount);
+
+    // Create a new batch by writing to the same document.
+    const updatePromise = bulkWriter
+      .update(doc, {foo: 'bar1'})
+      .then(incrementOpCount);
+    await setPromise;
+
+    // Create a new batch by reaching the batch size limit.
+    const createPromise = bulkWriter
+      .create(doc2, {foo: 'bar1'})
+      .then(incrementOpCount);
+
+    return Promise.all([updatePromise, createPromise]).then(async () => {
+      verifyOpCount(3);
+    });
+  });
+
+  it('sends batches automatically when the batch size limit is reached', async () => {
+    await instantiateInstance([
+      {
+        request: createRequest([
+          setOp('col/doc1', 'bar'),
+          updateOp('col/doc2', 'bar'),
+          createOp('col/doc3', 'bar'),
+        ]),
+        response: createResponse([
+          successResponse(0),
+          successResponse(1),
+          successResponse(2),
+        ]),
+      },
+      {
+        request: createRequest([deleteOp('col/doc4')]),
+        response: createResponse([successResponse(3)]),
+      },
+    ]);
+
+    bulkWriter.setMaxBatchSize(3);
+    const promise1 = bulkWriter
+      .set(firestore.doc('col/doc1'), {foo: 'bar'})
+      .then(incrementOpCount);
+    const promise2 = bulkWriter
+      .update(firestore.doc('col/doc2'), {foo: 'bar'})
+      .then(incrementOpCount);
+    const promise3 = bulkWriter
+      .create(firestore.doc('col/doc3'), {foo: 'bar'})
+      .then(incrementOpCount);
+
+    // The 4th write should not sent because it should be in a new batch.
+    bulkWriter.delete(firestore.doc('col/doc4')).then(incrementOpCount);
+
+    await Promise.all([promise1, promise2, promise3]).then(() => {
+      verifyOpCount(3);
+    });
+
+    return bulkWriter.flush().then(async () => {
+      verifyOpCount(4);
+    });
+  });
+});

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -411,214 +411,137 @@ declare namespace FirebaseFirestore {
   }
 
   /**
- * A Firestore BulkWriter than can be used to perform large amounts of writes in
- * parallel. Writes to the same document will be executed sequentially.
- *
- * @class
- */
-export class BulkWriter {
-  private constructor();
-
-  /**
-   * Create a document with the provided data. This single operation will fail
-   * if a document exists at its location.
+   * A Firestore BulkWriter than can be used to perform a large number of writes
+   * in parallel. Writes to the same document will be executed sequentially.
    *
-   * @param {DocumentReference} documentRef A reference to the document to be
-   * created.
-   * @param {T} data The object to serialize as the document.
-   * @returns {Promise<WriteResult>} A promise that resolves with the result of
-   * the write. Throws an error if the write fails.
-   *
-   * @example
-   * let bulkWriter = firestore.bulkWriter();
-   * let documentRef = firestore.collection('col').doc();
-   *
-   * bulkWriter
-   *  .create(documentRef, {foo: 'bar'})
-   *  .then(result => {
-   *    console.log('Successfully executed write at: ', result);
-   *  })
-   *  .catch(err => {
-   *    console.log('Write failed with: ', err);
-   *  });
-   * });
+   * @class
    */
-  create(
-    documentRef: DocumentReference,
-    data: DocumentData
-  ): Promise<WriteResult>;
+  export class BulkWriter {
+    private constructor();
 
-  /**
-   * Delete a document from the database.
-   *
-   * @param {DocumentReference} documentRef A reference to the document to be
-   * deleted.
-   * @param {Precondition=} precondition A precondition to enforce for this
-   * delete.
-   * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
-   * document was last updated at lastUpdateTime. Fails the batch if the
-   * document doesn't exist or was last updated at a different time.
-   * @returns {Promise<WriteResult>} A promise that resolves with the result of
-   * the write. Throws an error if the write fails.
-   *
-   * @example
-   * let bulkWriter = firestore.bulkWriter();
-   * let documentRef = firestore.doc('col/doc');
-   *
-   * bulkWriter
-   *  .delete(documentRef)
-   *  .then(result => {
-   *    console.log('Successfully deleted document at: ', result);
-   *  })
-   *  .catch(err => {
-   *    console.log('Delete failed with: ', err);
-   *  });
-   * });
-   */
-  delete(
-    documentRef: DocumentReference,
-    precondition?: Precondition
-  ): Promise<WriteResult>;
+    /**
+     * Create a document with the provided data. This single operation will fail
+     * if a document exists at its location.
+     *
+     * @param {DocumentReference} documentRef A reference to the document to be
+     * created.
+     * @param {T} data The object to serialize as the document.
+     * @returns {Promise<WriteResult>} A promise that resolves with the result of
+     * the write. Throws an error if the write fails.
+     */
+    create(
+      documentRef: DocumentReference,
+      data: DocumentData
+    ): Promise<WriteResult>;
 
-  /**
-   * Write to the document referred to by the provided
-   * [DocumentReference]{@link DocumentReference}. If the document does not
-   * exist yet, it will be created. If you pass [SetOptions]{@link SetOptions}.,
-   * the provided data can be merged into the existing document.
-   *
-   * @param {DocumentReference} documentRef A reference to the document to be
-   * set.
-   * @param {T} data The object to serialize as the document.
-   * @param {SetOptions=} options An object to configure the set behavior.
-   * @param {boolean=} options.merge - If true, set() merges the values
-   * specified in its data argument. Fields omitted from this set() call remain
-   * untouched.
-   * @param {Array.<string|FieldPath>=} options.mergeFields - If provided, set()
-   * only replaces the specified field paths. Any field path that is not
-   * specified is ignored and remains untouched.
-   * @returns {Promise<WriteResult>} A promise that resolves with the result of
-   * the write. Throws an error if the write fails.
-   *
-   *
-   * @example
-   * let bulkWriter = firestore.bulkWriter();
-   * let documentRef = firestore.collection('col').doc();
-   *
-   * bulkWriter
-   *  .set(documentRef, {foo: 'bar'})
-   *  .then(result => {
-   *    console.log('Successfully executed write at: ', result);
-   *  })
-   *  .catch(err => {
-   *    console.log('Write failed with: ', err);
-   *  });
-   * });
-   */
-  set(
-    documentRef: DocumentReference,
-    data: DocumentData,
-    options?: SetOptions
-  ): Promise<WriteResult>;
+    /**
+     * Delete a document from the database.
+     *
+     * @param {DocumentReference} documentRef A reference to the document to be
+     * deleted.
+     * @param {Precondition=} precondition A precondition to enforce for this
+     * delete.
+     * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
+     * document was last updated at lastUpdateTime. Fails the batch if the
+     * document doesn't exist or was last updated at a different time.
+     * @returns {Promise<WriteResult>} A promise that resolves with the result of
+     * the write. Throws an error if the write fails.
+     */
+    delete(
+      documentRef: DocumentReference,
+      precondition?: Precondition
+    ): Promise<WriteResult>;
 
-  /**
-   * Update fields of the document referred to by the provided
-   * [DocumentReference]{@link DocumentReference}. If the document doesn't yet
-   * exist, the update fails and the entire batch will be rejected.
-   *
-   * The update() method accepts either an object with field paths encoded as
-   * keys and field values encoded as values, or a variable number of arguments
-   * that alternate between field paths and field values. Nested fields can be
-   * updated by providing dot-separated field path strings or by providing
-   * FieldPath objects.
-   *
-   *
-   * A Precondition restricting this update can be specified as the last
-   * argument.
-   *
-   * @param {DocumentReference} documentRef A reference to the document to be
-   * updated.
-   * @param {UpdateData|string|FieldPath} dataOrField An object containing the
-   * fields and values with which to update the document or the path of the
-   * first field to update.
-   * @param {...(Precondition|*|string|FieldPath)} preconditionOrValues - An
-   * alternating list of field paths and values to update or a Precondition to
-   * restrict this update
-   * @returns {Promise<WriteResult>} A promise that resolves with the result of
-   * the write. Throws an error if the write fails.
-   *
-   *
-   * @example
-   * let bulkWriter = firestore.bulkWriter();
-   * let documentRef = firestore.doc('col/doc');
-   *
-   * bulkWriter
-   *  .update(documentRef, {foo: 'bar'})
-   *  .then(result => {
-   *    console.log('Successfully executed write at: ', result);
-   *  })
-   *  .catch(err => {
-   *    console.log('Write failed with: ', err);
-   *  });
-   * });
-   */
-  update(
-    documentRef: DocumentReference,
-    dataOrField: UpdateData | string | FieldPath,
-    ...preconditionOrValues: Array<
-      {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
-    >
-  ): Promise<WriteResult>;
+    /**
+     * Write to the document referred to by the provided
+     * [DocumentReference]{@link DocumentReference}. If the document does not
+     * exist yet, it will be created. If you pass [SetOptions]{@link SetOptions}.,
+     * the provided data can be merged into the existing document.
+     *
+     * @param {DocumentReference} documentRef A reference to the document to be
+     * set.
+     * @param {T} data The object to serialize as the document.
+     * @param {SetOptions=} options An object to configure the set behavior.
+     * @param {boolean=} options.merge - If true, set() merges the values
+     * specified in its data argument. Fields omitted from this set() call remain
+     * untouched.
+     * @param {Array.<string|FieldPath>=} options.mergeFields - If provided, set()
+     * only replaces the specified field paths. Any field path that is not
+     * specified is ignored and remains untouched.
+     * @returns {Promise<WriteResult>} A promise that resolves with the result of
+     * the write. Throws an error if the write fails.
+     */
+    set(
+      documentRef: DocumentReference,
+      data: DocumentData,
+      options?: SetOptions
+    ): Promise<WriteResult>;
 
-  /**
-   * Commits all writes that have been enqueued up to this point in parallel.
-   *
-   * Returns a Promise that resolves when there are no more pending writes. It
-   * never fails.
-   *
-   * The promise resolves immediately if there are no pending writes. Otherwise,
-   * the Promise waits for all previously issued writes, but it does not wait
-   * for writes that were added after the method is called. If you want to wait
-   * for additional writes, call `flush()` again.
-   *
-   * @return {Promise<void>} A promise that resolves when there are no more
-   * pending writes.
-   *
-   * @example
-   * let bulkWriter = firestore.bulkWriter();
-   *
-   * bulkWriter.create(documentRef, {foo: 'bar'});
-   * bulkWriter.update(documentRef2, {foo: 'bar'});
-   * bulkWriter.delete(documentRef3);
-   * await flush().then(() => {
-   *   console.log('Executed all writes');
-   * });
-   */
-  flush(): Promise<void>;
+    /**
+     * Update fields of the document referred to by the provided
+     * [DocumentReference]{@link DocumentReference}. If the document doesn't yet
+     * exist, the update fails and the entire batch will be rejected.
+     *
+     * The update() method accepts either an object with field paths encoded as
+     * keys and field values encoded as values, or a variable number of arguments
+     * that alternate between field paths and field values. Nested fields can be
+     * updated by providing dot-separated field path strings or by providing
+     * FieldPath objects.
+     *
+     *
+     * A Precondition restricting this update can be specified as the last
+     * argument.
+     *
+     * @param {DocumentReference} documentRef A reference to the document to be
+     * updated.
+     * @param {UpdateData|string|FieldPath} dataOrField An object containing the
+     * fields and values with which to update the document or the path of the
+     * first field to update.
+     * @param {...(Precondition|*|string|FieldPath)} preconditionOrValues - An
+     * alternating list of field paths and values to update or a Precondition to
+     * restrict this update
+     * @returns {Promise<WriteResult>} A promise that resolves with the result of
+     * the write. Throws an error if the write fails.
+     */
+    update(
+      documentRef: DocumentReference,
+      dataOrField: UpdateData | string | FieldPath,
+      ...preconditionOrValues: Array<
+        {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
+      >
+    ): Promise<WriteResult>;
 
-  /**
-   * Commits all enqueued writes and marks the BulkWriter instance as closed.
-   *
-   * After calling `close()`, calling any method wil throw an error.
-   *
-   * Returns a Promise that resolves when there are no more pending writes. It
-   * never fails. Calling this method will send all requests. The promise
-   * resolves immediately if there are no pending writes.
-   *
-   * @return {Promise<void>} A promise that resolves when there are no more
-   * pending writes.
-   *
-   * @example
-   * let bulkWriter = firestore.bulkWriter();
-   *
-   * bulkWriter.create(documentRef, {foo: 'bar'});
-   * bulkWriter.update(documentRef2, {foo: 'bar'});
-   * bulkWriter.delete(documentRef3);
-   * await close().then(() => {
-   *   console.log('Executed all writes');
-   * });
-   */
-  close(): Promise<void>;
-}
+    /**
+     * Commits all writes that have been enqueued up to this point in parallel.
+     *
+     * Returns a Promise that resolves when all writes have been committed.
+     * The Promise will never be rejected.
+     *
+     * The Promise resolves immediately if there are no pending writes. Otherwise,
+     * the Promise waits for all previously issued writes, but it does not wait
+     * for writes that were added after the method is called. If you want to wait
+     * for additional writes, call `flush()` again.
+     *
+     * @return {Promise<void>} A promise that resolves when all writes have
+     * been committed.
+     */
+    flush(): Promise<void>;
+
+    /**
+     * Commits all enqueued writes and marks the BulkWriter instance as closed.
+     *
+     * After calling `close()`, calling any method wil throw an error.
+     *
+     * Returns a Promise that resolves when all writes have been committed.
+     * The Promise will never be rejected. Calling this method will send all
+     * requests. The promise resolves immediately if there are no pending
+     * writes.
+     *
+     * @return {Promise<void>} A promise that resolves when all writes have
+     * been committed.
+     */
+    close(): Promise<void>;
+  }
 
   /**
    * A write batch, used to perform multiple writes as a single atomic unit.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -301,7 +301,6 @@ declare namespace FirebaseFirestore {
   export class Transaction {
     private constructor();
 
-
     /**
      * Retrieves a query result. Holds a pessimistic lock on all returned
      * documents.
@@ -410,6 +409,216 @@ declare namespace FirebaseFirestore {
     delete(documentRef: DocumentReference<any>,
            precondition?: Precondition): Transaction;
   }
+
+  /**
+ * A Firestore BulkWriter than can be used to perform large amounts of writes in
+ * parallel. Writes to the same document will be executed sequentially.
+ *
+ * @class
+ */
+export class BulkWriter {
+  private constructor();
+
+  /**
+   * Create a document with the provided data. This single operation will fail
+   * if a document exists at its location.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * created.
+   * @param {T} data The object to serialize as the document.
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.collection('col').doc();
+   *
+   * bulkWriter
+   *  .create(documentRef, {foo: 'bar'})
+   *  .then(result => {
+   *    console.log('Successfully executed write at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Write failed with: ', err);
+   *  });
+   * });
+   */
+  create(
+    documentRef: DocumentReference,
+    data: DocumentData
+  ): Promise<WriteResult>;
+
+  /**
+   * Delete a document from the database.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * deleted.
+   * @param {Precondition=} precondition A precondition to enforce for this
+   * delete.
+   * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
+   * document was last updated at lastUpdateTime. Fails the batch if the
+   * document doesn't exist or was last updated at a different time.
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.doc('col/doc');
+   *
+   * bulkWriter
+   *  .delete(documentRef)
+   *  .then(result => {
+   *    console.log('Successfully deleted document at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Delete failed with: ', err);
+   *  });
+   * });
+   */
+  delete(
+    documentRef: DocumentReference,
+    precondition?: Precondition
+  ): Promise<WriteResult>;
+
+  /**
+   * Write to the document referred to by the provided
+   * [DocumentReference]{@link DocumentReference}. If the document does not
+   * exist yet, it will be created. If you pass [SetOptions]{@link SetOptions}.,
+   * the provided data can be merged into the existing document.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * set.
+   * @param {T} data The object to serialize as the document.
+   * @param {SetOptions=} options An object to configure the set behavior.
+   * @param {boolean=} options.merge - If true, set() merges the values
+   * specified in its data argument. Fields omitted from this set() call remain
+   * untouched.
+   * @param {Array.<string|FieldPath>=} options.mergeFields - If provided, set()
+   * only replaces the specified field paths. Any field path that is not
+   * specified is ignored and remains untouched.
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.collection('col').doc();
+   *
+   * bulkWriter
+   *  .set(documentRef, {foo: 'bar'})
+   *  .then(result => {
+   *    console.log('Successfully executed write at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Write failed with: ', err);
+   *  });
+   * });
+   */
+  set(
+    documentRef: DocumentReference,
+    data: DocumentData,
+    options?: SetOptions
+  ): Promise<WriteResult>;
+
+  /**
+   * Update fields of the document referred to by the provided
+   * [DocumentReference]{@link DocumentReference}. If the document doesn't yet
+   * exist, the update fails and the entire batch will be rejected.
+   *
+   * The update() method accepts either an object with field paths encoded as
+   * keys and field values encoded as values, or a variable number of arguments
+   * that alternate between field paths and field values. Nested fields can be
+   * updated by providing dot-separated field path strings or by providing
+   * FieldPath objects.
+   *
+   *
+   * A Precondition restricting this update can be specified as the last
+   * argument.
+   *
+   * @param {DocumentReference} documentRef A reference to the document to be
+   * updated.
+   * @param {UpdateData|string|FieldPath} dataOrField An object containing the
+   * fields and values with which to update the document or the path of the
+   * first field to update.
+   * @param {...(Precondition|*|string|FieldPath)} preconditionOrValues - An
+   * alternating list of field paths and values to update or a Precondition to
+   * restrict this update
+   * @returns {Promise<WriteResult>} A promise that resolves with the result of
+   * the write. Throws an error if the write fails.
+   *
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   * let documentRef = firestore.doc('col/doc');
+   *
+   * bulkWriter
+   *  .update(documentRef, {foo: 'bar'})
+   *  .then(result => {
+   *    console.log('Successfully executed write at: ', result);
+   *  })
+   *  .catch(err => {
+   *    console.log('Write failed with: ', err);
+   *  });
+   * });
+   */
+  update(
+    documentRef: DocumentReference,
+    dataOrField: UpdateData | string | FieldPath,
+    ...preconditionOrValues: Array<
+      {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
+    >
+  ): Promise<WriteResult>;
+
+  /**
+   * Commits all writes that have been enqueued up to this point in parallel.
+   *
+   * Returns a Promise that resolves when there are no more pending writes. It
+   * never fails.
+   *
+   * The promise resolves immediately if there are no pending writes. Otherwise,
+   * the Promise waits for all previously issued writes, but it does not wait
+   * for writes that were added after the method is called. If you want to wait
+   * for additional writes, call `flush()` again.
+   *
+   * @return {Promise<void>} A promise that resolves when there are no more
+   * pending writes.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   *
+   * bulkWriter.create(documentRef, {foo: 'bar'});
+   * bulkWriter.update(documentRef2, {foo: 'bar'});
+   * bulkWriter.delete(documentRef3);
+   * await flush().then(() => {
+   *   console.log('Executed all writes');
+   * });
+   */
+  flush(): Promise<void>;
+
+  /**
+   * Commits all enqueued writes and marks the BulkWriter instance as closed.
+   *
+   * After calling `close()`, calling any method wil throw an error.
+   *
+   * Returns a Promise that resolves when there are no more pending writes. It
+   * never fails. Calling this method will send all requests. The promise
+   * resolves immediately if there are no pending writes.
+   *
+   * @return {Promise<void>} A promise that resolves when there are no more
+   * pending writes.
+   *
+   * @example
+   * let bulkWriter = firestore.bulkWriter();
+   *
+   * bulkWriter.create(documentRef, {foo: 'bar'});
+   * bulkWriter.update(documentRef2, {foo: 'bar'});
+   * bulkWriter.delete(documentRef3);
+   * await close().then(() => {
+   *   console.log('Executed all writes');
+   * });
+   */
+  close(): Promise<void>;
+}
 
   /**
    * A write batch, used to perform multiple writes as a single atomic unit.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -426,8 +426,8 @@ declare namespace FirebaseFirestore {
      * @param {DocumentReference} documentRef A reference to the document to be
      * created.
      * @param {T} data The object to serialize as the document.
-     * @returns {Promise<WriteResult>} A promise that resolves with the result of
-     * the write. Throws an error if the write fails.
+     * @returns {Promise<WriteResult>} A promise that resolves with the result
+     * of the write. Throws an error if the write fails.
      */
     create(
       documentRef: DocumentReference,
@@ -444,8 +444,8 @@ declare namespace FirebaseFirestore {
      * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
      * document was last updated at lastUpdateTime. Fails the batch if the
      * document doesn't exist or was last updated at a different time.
-     * @returns {Promise<WriteResult>} A promise that resolves with the result of
-     * the write. Throws an error if the write fails.
+     * @returns {Promise<WriteResult>} A promise that resolves with the result
+     * of the write. Throws an error if the write fails.
      */
     delete(
       documentRef: DocumentReference,
@@ -455,21 +455,22 @@ declare namespace FirebaseFirestore {
     /**
      * Write to the document referred to by the provided
      * [DocumentReference]{@link DocumentReference}. If the document does not
-     * exist yet, it will be created. If you pass [SetOptions]{@link SetOptions}.,
-     * the provided data can be merged into the existing document.
+     * exist yet, it will be created. If you pass
+     * [SetOptions]{@link SetOptions}., the provided data can be merged into the
+     * existing document.
      *
      * @param {DocumentReference} documentRef A reference to the document to be
      * set.
      * @param {T} data The object to serialize as the document.
      * @param {SetOptions=} options An object to configure the set behavior.
      * @param {boolean=} options.merge - If true, set() merges the values
-     * specified in its data argument. Fields omitted from this set() call remain
-     * untouched.
-     * @param {Array.<string|FieldPath>=} options.mergeFields - If provided, set()
-     * only replaces the specified field paths. Any field path that is not
+     * specified in its data argument. Fields omitted from this set() call
+     * remain untouched.
+     * @param {Array.<string|FieldPath>=} options.mergeFields - If provided,
+     * set() only replaces the specified field paths. Any field path that is not
      * specified is ignored and remains untouched.
-     * @returns {Promise<WriteResult>} A promise that resolves with the result of
-     * the write. Throws an error if the write fails.
+     * @returns {Promise<WriteResult>} A promise that resolves with the result
+     * of the write. Throws an error if the write fails.
      */
     set(
       documentRef: DocumentReference,
@@ -483,10 +484,10 @@ declare namespace FirebaseFirestore {
      * exist, the update fails and the entire batch will be rejected.
      *
      * The update() method accepts either an object with field paths encoded as
-     * keys and field values encoded as values, or a variable number of arguments
-     * that alternate between field paths and field values. Nested fields can be
-     * updated by providing dot-separated field path strings or by providing
-     * FieldPath objects.
+     * keys and field values encoded as values, or a variable number of
+     * arguments that alternate between field paths and field values. Nested
+     * fields can be updated by providing dot-separated field path strings or by
+     * providing FieldPath objects.
      *
      *
      * A Precondition restricting this update can be specified as the last
@@ -500,8 +501,8 @@ declare namespace FirebaseFirestore {
      * @param {...(Precondition|*|string|FieldPath)} preconditionOrValues - An
      * alternating list of field paths and values to update or a Precondition to
      * restrict this update
-     * @returns {Promise<WriteResult>} A promise that resolves with the result of
-     * the write. Throws an error if the write fails.
+     * @returns {Promise<WriteResult>} A promise that resolves with the result
+     * of the write. Throws an error if the write fails.
      */
     update(
       documentRef: DocumentReference,
@@ -514,16 +515,17 @@ declare namespace FirebaseFirestore {
     /**
      * Commits all writes that have been enqueued up to this point in parallel.
      *
-     * Returns a Promise that resolves when all writes have been committed.
-     * The Promise will never be rejected.
+     * Returns a Promise that resolves when all currently queued operations have
+     * been committed. The Promise will never be rejected since the results for
+     * each individual operation are conveyed via their individual Promises.
      *
-     * The Promise resolves immediately if there are no pending writes. Otherwise,
-     * the Promise waits for all previously issued writes, but it does not wait
-     * for writes that were added after the method is called. If you want to wait
-     * for additional writes, call `flush()` again.
+     * The Promise resolves immediately if there are no pending writes.
+     * Otherwise, the Promise waits for all previously issued writes, but it
+     * does not wait for writes that were added after the method is called. If
+     * you want to wait for additional writes, call `flush()` again.
      *
-     * @return {Promise<void>} A promise that resolves when all writes have
-     * been committed.
+     * @return {Promise<void>} A promise that resolves when all enqueued writes
+     * up to this point have been committed.
      */
     flush(): Promise<void>;
 
@@ -532,13 +534,13 @@ declare namespace FirebaseFirestore {
      *
      * After calling `close()`, calling any method wil throw an error.
      *
-     * Returns a Promise that resolves when all writes have been committed.
-     * The Promise will never be rejected. Calling this method will send all
+     * Returns a Promise that resolves when all writes have been committed. The
+     * Promise will never be rejected. Calling this method will send all
      * requests. The promise resolves immediately if there are no pending
      * writes.
      *
-     * @return {Promise<void>} A promise that resolves when all writes have
-     * been committed.
+     * @return {Promise<void>} A promise that resolves when all enqueued writes
+     * up to this point have been committed.
      */
     close(): Promise<void>;
   }


### PR DESCRIPTION
Moving from the old [PR](https://github.com/googleapis/nodejs-firestore/pull/988) to create a base version without bin packing of writes or the 555 throttling.