### PR TITLE
feat: add 555 rule support

### DIFF
--- a/dev/src/backoff.ts
+++ b/dev/src/backoff.ts
@@ -55,9 +55,9 @@ const DEFAULT_JITTER_FACTOR = 1.0;
 export const MAX_RETRY_ATTEMPTS = 10;
 
 /*!
- * The timeout handler used by `ExponentialBackoff`.
+ * The timeout handler used by `ExponentialBackoff` and `BulkWriter`.
  */
-let delayExecution: (f: () => void, ms: number) => void = setTimeout;
+export let delayExecution: (f: () => void, ms: number) => void = setTimeout;
 
 /**
  * Allows overriding of the timeout handler used by the exponential backoff

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -649,7 +649,7 @@ export class Firestore {
    * multiple writes in parallel. Automatically throttles writes as specified
    * by the 500/50/5 rule.
    *
-   * https://cloud.google.com/datastore/docs/best-practices#ramping_up_traffic.
+   * @see [500/50/5 Documentation]{@link https://cloud.google.com/datastore/docs/best-practices#ramping_up_traffic}
    *
    * @param {object=} options BulkWriter options.
    * @param {boolean=} options.disableThrottling Whether to disable throttling

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -44,6 +44,7 @@ import {Timestamp} from './timestamp';
 import {parseGetAllArguments, Transaction} from './transaction';
 import {
   ApiMapValue,
+  BulkWriterOptions,
   DocumentData,
   FirestoreStreamingMethod,
   FirestoreUnaryMethod,
@@ -86,6 +87,7 @@ export {FieldPath} from './path';
 export {GeoPoint} from './geo-point';
 export {setLogFunction} from './logger';
 export {
+  BulkWriterOptions,
   FirestoreDataConverter,
   UpdateData,
   DocumentData,
@@ -644,8 +646,14 @@ export class Firestore {
 
   /**
    * Creates a [BulkWriter]{@link BulkWriter}, used for performing
-   * multiple writes in parallel.
+   * multiple writes in parallel. Automatically throttles writes as specified
+   * by the 500/50/5 rule.
    *
+   * https://cloud.google.com/datastore/docs/best-practices#ramping_up_traffic.
+   *
+   * @param {object=} options BulkWriter options.
+   * @param {boolean=} options.disableThrottling Whether to disable throttling
+   * as specified by the 500/50/5 rule.
    * @returns {WriteBatch} A BulkWriter that operates on this Firestore
    * client.
    *
@@ -669,8 +677,8 @@ export class Firestore {
    * });
    * bulkWriter.close();
    */
-  bulkWriter(): BulkWriter {
-    return new BulkWriter(this);
+  bulkWriter(options?: BulkWriterOptions): BulkWriter {
+    return new BulkWriter(this, !options?.disableThrottling);
   }
 
   /**

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -646,7 +646,7 @@ export class Firestore {
 
   /**
    * Creates a [BulkWriter]{@link BulkWriter}, used for performing
-   * multiple writes in parallel. Automatically throttles writes as specified
+   * multiple writes in parallel. Gradually ramps up writes as specified
    * by the 500/50/5 rule.
    *
    * @see [500/50/5 Documentation]{@link https://cloud.google.com/datastore/docs/best-practices#ramping_up_traffic}

--- a/dev/src/rate-limiter.ts
+++ b/dev/src/rate-limiter.ts
@@ -90,6 +90,7 @@ export class RateLimiter {
     numOperations: number,
     requestTimeMillis = Date.now()
   ): number {
+    this.refillTokens(requestTimeMillis);
     if (numOperations < this.availableTokens) {
       return 0;
     }

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -322,6 +322,15 @@ export interface ValidationOptions {
 }
 
 /**
+ * An options object that can be used to toggle the default rate limit
+ * throttling implemented by BulkWriter.
+ */
+export interface BulkWriterOptions {
+  /** Whether to disable throttling as specified by the 500/50/5 rule. */
+  readonly disableThrottling?: boolean;
+}
+
+/**
  * A Firestore Proto value in ProtoJs format.
  * @private
  */

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -322,11 +322,11 @@ export interface ValidationOptions {
 }
 
 /**
- * An options object that can be used to toggle the default rate limit
- * throttling implemented by BulkWriter.
+ * An options object that can be used to disable request throttling in
+ * BulkWriter.
  */
 export interface BulkWriterOptions {
-  /** Whether to disable throttling as specified by the 500/50/5 rule. */
+  /** Whether to disable throttling. */
   readonly disableThrottling?: boolean;
 }
 

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -546,6 +546,15 @@ declare namespace FirebaseFirestore {
   }
 
   /**
+   * An options object that can be used to toggle the default rate limit
+   * throttling implemented by BulkWriter.
+   */
+  export interface BulkWriterOptions {
+    /** Whether to disable throttling as specified by the 500/50/5 rule. */
+    readonly disableThrottling?: boolean;
+  }
+
+  /**
    * A write batch, used to perform multiple writes as a single atomic unit.
    *
    * A `WriteBatch` object can be acquired by calling `Firestore.batch()`. It

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -546,11 +546,11 @@ declare namespace FirebaseFirestore {
   }
 
   /**
-   * An options object that can be used to toggle the default rate limit
-   * throttling implemented by BulkWriter.
+   * An options object that can be used to disable request throttling in
+   * BulkWriter.
    */
   export interface BulkWriterOptions {
-    /** Whether to disable throttling as specified by the 500/50/5 rule. */
+    /** Whether to disable throttling. */
     readonly disableThrottling?: boolean;
   }
 


### PR DESCRIPTION
Adding throttling. 

I tried to write the tests as cleanly as I could without overriding too much. Since `RateLimiter` already has tests, I only tested that the timeout handler in BulkWriter was being called. The test will fail with an assertion if throttling is not in place. However, I fear that this test can be brittle if another part of the SDK calls a timeout. Any ideas/tips on how to improve this test? Thanks!