### PR TITLE
fix: return errors from Query.stream()

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1883,7 +1883,7 @@ export class Query<T = DocumentData> {
     });
 
     responseStream.pipe(transform);
-    responseStream.on('error', transform.destroy);
+    responseStream.on('error', e => transform.destroy(e));
     return transform;
   }
 


### PR DESCRIPTION
This makes sure that we return an error from the Query stream() even if we were able to deliver an initial set of query results.

Fixes  https://github.com/googleapis/nodejs-firestore/issues/964