### PR TITLE
fix: allow running source with ts-node

### DIFF
--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -155,14 +155,10 @@ export interface FirestoreDataConverter<T> {
  * @private
  */
 export const defaultConverter: FirestoreDataConverter<DocumentData> = {
-  toFirestore(
-    modelObject: FirebaseFirestore.DocumentData
-  ): FirebaseFirestore.DocumentData {
+  toFirestore(modelObject: DocumentData): DocumentData {
     return modelObject;
   },
-  fromFirestore(
-    data: FirebaseFirestore.DocumentData
-  ): FirebaseFirestore.DocumentData {
+  fromFirestore(data: DocumentData): DocumentData {
     return data;
   },
 };


### PR DESCRIPTION
ts-node is not able to resolve the FirebaseFirestore namespace. It only exists in our types.

