### PR TITLE
fix: incomplete expect in rate-limiter test

### DIFF
--- a/dev/src/rate-limiter.ts
+++ b/dev/src/rate-limiter.ts
@@ -110,7 +110,7 @@ export class RateLimiter {
    * tokens. Used for testing the limiter.
    * @private
    */
-  private refillTokens(requestTimeMillis = Date.now()): void {
+  private refillTokens(requestTimeMillis: number): void {
     if (requestTimeMillis >= this.lastRefillTimeMillis) {
       const elapsedTime = requestTimeMillis - this.lastRefillTimeMillis;
       const capacity = this.calculateCapacity(requestTimeMillis);

--- a/dev/src/rate-limiter.ts
+++ b/dev/src/rate-limiter.ts
@@ -58,7 +58,7 @@ export class RateLimiter {
    * Tries to make the number of operations. Returns true if the request
    * succeeded and false otherwise.
    *
-   * @param requestTimeMillis The date used to calculate the number of available
+   * @param requestTimeMillis The time used to calculate the number of available
    * tokens. Used for testing the limiter.
    * @private
    */
@@ -80,7 +80,7 @@ export class RateLimiter {
    * capacity. Returns -1 if the request is not possible with the current
    * capacity.
    *
-   * @param requestTimeMillis The date used to calculate the number of available
+   * @param requestTimeMillis The time used to calculate the number of available
    * tokens. Used for testing the limiter.
    * @private
    */
@@ -106,7 +106,7 @@ export class RateLimiter {
    * Refills the number of available tokens based on how much time has elapsed
    * since the last time the tokens were refilled.
    *
-   * @param requestTimeMillis The date used to calculate the number of available
+   * @param requestTimeMillis The time used to calculate the number of available
    * tokens. Used for testing the limiter.
    * @private
    */

--- a/dev/test/rate-limiter.ts
+++ b/dev/test/rate-limiter.ts
@@ -72,7 +72,7 @@ describe('RateLimiter', () => {
     expect(limiter.getNextRequestDelayMs(500, timestamp)).to.equal(0);
 
     // Should factor in remaining tokens when calculating the time.
-    expect(limiter.tryMakeRequest(250, timestamp));
+    expect(limiter.tryMakeRequest(250, timestamp)).to.be.true;
     expect(limiter.getNextRequestDelayMs(500, timestamp)).to.equal(500);
 
     // Once tokens have been used, should calculate time before next request.


### PR DESCRIPTION
Oops. Ran into this while porting rate limiter.