### PR TITLE
fix: return null for 'parent' call on root collection

### DIFF
--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -183,10 +183,7 @@ abstract class Path<T> {
    * @return true if this `Path` is equal to the provided value.
    */
   isEqual(other: Path<T>): boolean {
-    return (
-      this === other ||
-      (other instanceof this.constructor && this.compareTo(other) === 0)
-    );
+    return this === other || this.compareTo(other) === 0;
   }
 }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2265,8 +2265,15 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
    * let documentRef = collectionRef.parent;
    * console.log(`Parent name: ${documentRef.path}`);
    */
-  get parent(): DocumentReference<DocumentData> {
-    return new DocumentReference(this.firestore, this._queryOptions.parentPath);
+  get parent(): DocumentReference<DocumentData> | null {
+    if (this._queryOptions.parentPath.isDocument) {
+      return new DocumentReference(
+        this.firestore,
+        this._queryOptions.parentPath
+      );
+    }
+
+    return null;
   }
 
   /**

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2256,7 +2256,7 @@ export class CollectionReference<T = DocumentData> extends Query<T> {
    * A reference to the containing Document if this is a subcollection, else
    * null.
    *
-   * @type {DocumentReference}
+   * @type {DocumentReference|null}
    * @name CollectionReference#parent
    * @readonly
    *

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -197,7 +197,7 @@ describe('CollectionReference class', () => {
 
   it('has parent property', () => {
     const ref = firestore.collection('col/doc/col');
-    expect(ref.parent.id).to.equal('doc');
+    expect(ref.parent!.id).to.equal('doc');
   });
 
   it('has path property', () => {

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -78,7 +78,12 @@ describe('Collection interface', () => {
     const collection = firestore.collection('col1/doc/col2');
     expect(collection.path).to.equal('col1/doc/col2');
     const document = collection.parent;
-    expect(document.path).to.equal('col1/doc');
+    expect(document!.path).to.equal('col1/doc');
+  });
+
+  it('parent() returns null for root', () => {
+    const collection = firestore.collection('col1');
+    expect(collection.parent).to.equal(null);
   });
 
   it('supports auto-generated ids', () => {


### PR DESCRIPTION
We need to return "null" for the parent call in a root collection.

Also noticed that our Path.isEqual doesn't work correctly since it considers QualifiedResourcePaths and ResourcePaths as non-equal. Our typings already ensure that a FieldPath and a ResourcePath can never be compared for equality.

Fixes https://github.com/googleapis/nodejs-firestore/issues/1098