### PR TITLE
chore: use public API types internally

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {DocumentData} from '@google-cloud/firestore';
+
 import * as duplexify from 'duplexify';
 
 import {it, xit, describe} from 'mocha';
@@ -24,7 +26,6 @@ import * as proto from '../protos/firestore_v1_proto_api';
 
 import {
   DocumentChange,
-  DocumentData,
   DocumentSnapshot,
   FieldPath,
   FieldValue,

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -124,13 +124,13 @@ class BulkCommitBatch {
   }
 
   set<T>(
-    documentRef: DocumentReference<T>,
+    documentRef: firestore.DocumentReference<T>,
     data: Partial<T>,
     options: firestore.SetOptions
   ): Promise<WriteResult>;
-  set<T>(documentRef: DocumentReference<T>, data: T): Promise<WriteResult>;
+  set<T>(documentRef: firestore.DocumentReference<T>, data: T): Promise<WriteResult>;
   set<T>(
-    documentRef: DocumentReference<T>,
+    documentRef: firestore.DocumentReference<T>,
     data: T | Partial<T>,
     options?: firestore.SetOptions
   ): Promise<WriteResult>;
@@ -139,7 +139,7 @@ class BulkCommitBatch {
    * resolves with the result of the write.
    */
   set<T>(
-    documentRef: DocumentReference<T>,
+    documentRef: firestore.DocumentReference<T>,
     data: T | Partial<T>,
     options?: firestore.SetOptions
   ): Promise<WriteResult> {
@@ -319,7 +319,7 @@ export class BulkWriter {
    *  });
    * });
    */
-  create<T>(documentRef: DocumentReference<T>, data: T): Promise<WriteResult> {
+  create<T>(documentRef: firestore.DocumentReference<T>, data: T): Promise<WriteResult> {
     this.verifyNotClosed();
     const bulkCommitBatch = this.getEligibleBatch(documentRef);
     const resultPromise = bulkCommitBatch.create(documentRef, data);
@@ -355,7 +355,7 @@ export class BulkWriter {
    * });
    */
   delete<T>(
-    documentRef: DocumentReference<T>,
+    documentRef: firestore.DocumentReference<T>,
     precondition?: firestore.Precondition
   ): Promise<WriteResult> {
     this.verifyNotClosed();
@@ -366,11 +366,11 @@ export class BulkWriter {
   }
 
   set<T>(
-    documentRef: DocumentReference<T>,
+    documentRef: firestore.DocumentReference<T>,
     data: Partial<T>,
     options: firestore.SetOptions
   ): Promise<WriteResult>;
-  set<T>(documentRef: DocumentReference<T>, data: T): Promise<WriteResult>;
+  set<T>(documentRef: firestore.DocumentReference<T>, data: T): Promise<WriteResult>;
   /**
    * Write to the document referred to by the provided
    * [DocumentReference]{@link DocumentReference}. If the document does not
@@ -406,7 +406,7 @@ export class BulkWriter {
    * });
    */
   set<T>(
-    documentRef: DocumentReference<T>,
+    documentRef: firestore.DocumentReference<T>,
     data: T | Partial<T>,
     options?: firestore.SetOptions
   ): Promise<WriteResult> {
@@ -459,7 +459,7 @@ export class BulkWriter {
    * });
    */
   update<T>(
-    documentRef: DocumentReference,
+    documentRef: firestore.DocumentReference,
     dataOrField: firestore.UpdateData | string | FieldPath,
     ...preconditionOrValues: Array<
       {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
@@ -551,7 +551,7 @@ export class BulkWriter {
    *
    * @private
    */
-  private getEligibleBatch<T>(ref: DocumentReference<T>): BulkCommitBatch {
+  private getEligibleBatch<T>(ref: firestore.DocumentReference<T>): BulkCommitBatch {
     if (this.batchQueue.length > 0) {
       const lastBatch = this.batchQueue[this.batchQueue.length - 1];
       if (

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -128,7 +128,10 @@ class BulkCommitBatch {
     data: Partial<T>,
     options: firestore.SetOptions
   ): Promise<WriteResult>;
-  set<T>(documentRef: firestore.DocumentReference<T>, data: T): Promise<WriteResult>;
+  set<T>(
+    documentRef: firestore.DocumentReference<T>,
+    data: T
+  ): Promise<WriteResult>;
   set<T>(
     documentRef: firestore.DocumentReference<T>,
     data: T | Partial<T>,
@@ -319,7 +322,10 @@ export class BulkWriter {
    *  });
    * });
    */
-  create<T>(documentRef: firestore.DocumentReference<T>, data: T): Promise<WriteResult> {
+  create<T>(
+    documentRef: firestore.DocumentReference<T>,
+    data: T
+  ): Promise<WriteResult> {
     this.verifyNotClosed();
     const bulkCommitBatch = this.getEligibleBatch(documentRef);
     const resultPromise = bulkCommitBatch.create(documentRef, data);
@@ -370,7 +376,10 @@ export class BulkWriter {
     data: Partial<T>,
     options: firestore.SetOptions
   ): Promise<WriteResult>;
-  set<T>(documentRef: firestore.DocumentReference<T>, data: T): Promise<WriteResult>;
+  set<T>(
+    documentRef: firestore.DocumentReference<T>,
+    data: T
+  ): Promise<WriteResult>;
   /**
    * Write to the document referred to by the provided
    * [DocumentReference]{@link DocumentReference}. If the document does not
@@ -551,7 +560,9 @@ export class BulkWriter {
    *
    * @private
    */
-  private getEligibleBatch<T>(ref: firestore.DocumentReference<T>): BulkCommitBatch {
+  private getEligibleBatch<T>(
+    ref: firestore.DocumentReference<T>
+  ): BulkCommitBatch {
     if (this.batchQueue.length > 0) {
       const lastBatch = this.batchQueue[this.batchQueue.length - 1];
       if (

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as firestore from '@google-cloud/firestore';
+
 import * as assert from 'assert';
 
 import {FieldPath, Firestore} from '.';
@@ -20,7 +22,6 @@ import {delayExecution} from './backoff';
 import {RateLimiter} from './rate-limiter';
 import {DocumentReference} from './reference';
 import {Timestamp} from './timestamp';
-import {Precondition, SetOptions, UpdateData} from './types';
 import {Deferred, wrapError} from './util';
 import {BatchWriteResult, WriteBatch, WriteResult} from './write-batch';
 
@@ -102,7 +103,10 @@ class BulkCommitBatch {
    * Adds a `create` operation to the WriteBatch. Returns a promise that
    * resolves with the result of the write.
    */
-  create<T>(documentRef: DocumentReference<T>, data: T): Promise<WriteResult> {
+  create<T>(
+    documentRef: firestore.DocumentReference<T>,
+    data: T
+  ): Promise<WriteResult> {
     this.writeBatch.create(documentRef, data);
     return this.processOperation(documentRef);
   }
@@ -112,8 +116,8 @@ class BulkCommitBatch {
    * resolves with the result of the delete.
    */
   delete<T>(
-    documentRef: DocumentReference<T>,
-    precondition?: Precondition
+    documentRef: firestore.DocumentReference<T>,
+    precondition?: firestore.Precondition
   ): Promise<WriteResult> {
     this.writeBatch.delete(documentRef, precondition);
     return this.processOperation(documentRef);
@@ -122,13 +126,13 @@ class BulkCommitBatch {
   set<T>(
     documentRef: DocumentReference<T>,
     data: Partial<T>,
-    options: SetOptions
+    options: firestore.SetOptions
   ): Promise<WriteResult>;
   set<T>(documentRef: DocumentReference<T>, data: T): Promise<WriteResult>;
   set<T>(
     documentRef: DocumentReference<T>,
     data: T | Partial<T>,
-    options?: SetOptions
+    options?: firestore.SetOptions
   ): Promise<WriteResult>;
   /**
    * Adds a `set` operation to the WriteBatch. Returns a promise that
@@ -137,7 +141,7 @@ class BulkCommitBatch {
   set<T>(
     documentRef: DocumentReference<T>,
     data: T | Partial<T>,
-    options?: SetOptions
+    options?: firestore.SetOptions
   ): Promise<WriteResult> {
     this.writeBatch.set(documentRef, data, options);
     return this.processOperation(documentRef);
@@ -148,8 +152,8 @@ class BulkCommitBatch {
    * resolves with the result of the write.
    */
   update<T>(
-    documentRef: DocumentReference<T>,
-    dataOrField: UpdateData | string | FieldPath,
+    documentRef: firestore.DocumentReference<T>,
+    dataOrField: firestore.UpdateData | string | firestore.FieldPath,
     ...preconditionOrValues: Array<
       {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
     >
@@ -163,7 +167,7 @@ class BulkCommitBatch {
    * return the result.
    */
   private processOperation<T>(
-    documentRef: DocumentReference<T>
+    documentRef: firestore.DocumentReference<T>
   ): Promise<WriteResult> {
     assert(
       !this.docPaths.has(documentRef.path),
@@ -352,7 +356,7 @@ export class BulkWriter {
    */
   delete<T>(
     documentRef: DocumentReference<T>,
-    precondition?: Precondition
+    precondition?: firestore.Precondition
   ): Promise<WriteResult> {
     this.verifyNotClosed();
     const bulkCommitBatch = this.getEligibleBatch(documentRef);
@@ -364,7 +368,7 @@ export class BulkWriter {
   set<T>(
     documentRef: DocumentReference<T>,
     data: Partial<T>,
-    options: SetOptions
+    options: firestore.SetOptions
   ): Promise<WriteResult>;
   set<T>(documentRef: DocumentReference<T>, data: T): Promise<WriteResult>;
   /**
@@ -404,7 +408,7 @@ export class BulkWriter {
   set<T>(
     documentRef: DocumentReference<T>,
     data: T | Partial<T>,
-    options?: SetOptions
+    options?: firestore.SetOptions
   ): Promise<WriteResult> {
     this.verifyNotClosed();
     const bulkCommitBatch = this.getEligibleBatch(documentRef);
@@ -456,7 +460,7 @@ export class BulkWriter {
    */
   update<T>(
     documentRef: DocumentReference,
-    dataOrField: UpdateData | string | FieldPath,
+    dataOrField: firestore.UpdateData | string | FieldPath,
     ...preconditionOrValues: Array<
       {lastUpdateTime?: Timestamp} | unknown | string | FieldPath
     >

--- a/dev/src/document-change.ts
+++ b/dev/src/document-change.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+import * as firestore from '@google-cloud/firestore';
+
 import {QueryDocumentSnapshot} from './document';
-import {DocumentData} from './types';
 
 export type DocumentChangeType = 'added' | 'removed' | 'modified';
 
@@ -25,7 +26,8 @@ export type DocumentChangeType = 'added' | 'removed' | 'modified';
  *
  * @class
  */
-export class DocumentChange<T = DocumentData> {
+export class DocumentChange<T = firestore.DocumentData>
+  implements firestore.DocumentChange {
   private readonly _type: DocumentChangeType;
   private readonly _document: QueryDocumentSnapshot<T>;
   private readonly _oldIndex: number;
@@ -170,7 +172,7 @@ export class DocumentChange<T = DocumentData> {
    * @param {*} other The value to compare against.
    * @return true if this `DocumentChange` is equal to the provided value.
    */
-  isEqual(other: DocumentChange<T>): boolean {
+  isEqual(other: firestore.DocumentChange<T>): boolean {
     if (this === other) {
       return true;
     }

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as firestore from '@google-cloud/firestore';
+
 import * as deepEqual from 'fast-deep-equal';
 
 import * as proto from '../protos/firestore_v1_proto_api';
@@ -34,7 +36,7 @@ import api = proto.google.firestore.v1;
  *
  * @class
  */
-export class FieldValue {
+export class FieldValue implements firestore.FieldValue {
   /**
    * @hideconstructor
    */

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -201,7 +201,7 @@ export class FieldValue implements firestore.FieldValue {
    * }
    * console.log(`Found ${equal} equalities.`);
    */
-  isEqual(other: FieldValue): boolean {
+  isEqual(other: firestore.FieldValue): boolean {
     return this === other;
   }
 }
@@ -390,7 +390,7 @@ class NumericIncrementTransform extends FieldTransform {
     return {fieldPath: fieldPath.formattedName, increment: encodedOperand};
   }
 
-  isEqual(other: FieldValue): boolean {
+  isEqual(other: firestore.FieldValue): boolean {
     return (
       this === other ||
       (other instanceof NumericIncrementTransform &&
@@ -446,7 +446,7 @@ class ArrayUnionTransform extends FieldTransform {
     };
   }
 
-  isEqual(other: FieldValue): boolean {
+  isEqual(other: firestore.FieldValue): boolean {
     return (
       this === other ||
       (other instanceof ArrayUnionTransform &&
@@ -502,7 +502,7 @@ class ArrayRemoveTransform extends FieldTransform {
     };
   }
 
-  isEqual(other: FieldValue): boolean {
+  isEqual(other: firestore.FieldValue): boolean {
     return (
       this === other ||
       (other instanceof ArrayRemoveTransform &&

--- a/dev/src/geo-point.ts
+++ b/dev/src/geo-point.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as firestore from '@google-cloud/firestore';
+
 import {google} from '../protos/firestore_v1_proto_api';
 import {Serializable} from './serializer';
 import {validateNumber} from './validate';
@@ -26,7 +28,7 @@ import api = google.firestore.v1;
  *
  * @class
  */
-export class GeoPoint implements Serializable {
+export class GeoPoint implements Serializable, firestore.GeoPoint {
   private readonly _latitude: number;
   private readonly _longitude: number;
 
@@ -82,7 +84,7 @@ export class GeoPoint implements Serializable {
    * @param {*} other The value to compare against.
    * @return {boolean} true if this `GeoPoint` is equal to the provided value.
    */
-  isEqual(other: GeoPoint): boolean {
+  isEqual(other: firestore.GeoPoint): boolean {
     return (
       this === other ||
       (other instanceof GeoPoint &&

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as firestore from '@google-cloud/firestore';
+
 import {google} from '../protos/firestore_v1_proto_api';
 
 import {isObject} from './util';
@@ -494,7 +496,7 @@ export function validateResourcePath(
  *
  * @class
  */
-export class FieldPath extends Path<FieldPath> {
+export class FieldPath extends Path<FieldPath> implements firestore.FieldPath {
   /**
    * A special sentinel value to refer to the ID of a document.
    *
@@ -556,12 +558,12 @@ export class FieldPath extends Path<FieldPath> {
    * @param {string|FieldPath} fieldPath The FieldPath to create.
    * @returns {FieldPath} A field path representation.
    */
-  static fromArgument(fieldPath: string | FieldPath): FieldPath {
+  static fromArgument(fieldPath: string | firestore.FieldPath): FieldPath {
     // validateFieldPath() is used in all public API entry points to validate
     // that fromArgument() is only called with a Field Path or a string.
     return fieldPath instanceof FieldPath
       ? fieldPath
-      : new FieldPath(...fieldPath.split('.'));
+      : new FieldPath(...(fieldPath as string).split('.'));
   }
 
   /**

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {DocumentData} from '@google-cloud/firestore';
+
 import * as proto from '../protos/firestore_v1_proto_api';
 
 import {detectValueType} from './convert';
@@ -22,7 +24,7 @@ import {GeoPoint} from './geo-point';
 import {DocumentReference, Firestore} from './index';
 import {FieldPath, QualifiedResourcePath} from './path';
 import {Timestamp} from './timestamp';
-import {ApiMapValue, DocumentData, ValidationOptions} from './types';
+import {ApiMapValue, ValidationOptions} from './types';
 import {isEmpty, isObject, isPlainObject} from './util';
 import {customObjectMessage, invalidArgumentMessage} from './validate';
 

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as firestore from '@google-cloud/firestore';
+
 import {google} from '../protos/firestore_v1_proto_api';
 import {validateInteger} from './validate';
 
@@ -55,7 +57,7 @@ const MAX_SECONDS = 253402300799;
  *
  * @see https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto
  */
-export class Timestamp {
+export class Timestamp implements firestore.Timestamp {
   private readonly _seconds: number;
   private readonly _nanoseconds: number;
 
@@ -238,7 +240,7 @@ export class Timestamp {
    * @param {any} other The `Timestamp` to compare against.
    * @return {boolean} 'true' if this `Timestamp` is equal to the provided one.
    */
-  isEqual(other: Timestamp): boolean {
+  isEqual(other: firestore.Timestamp): boolean {
     return (
       this === other ||
       (other instanceof Timestamp &&

--- a/dev/src/types.ts
+++ b/dev/src/types.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import {FirestoreDataConverter, DocumentData} from '@google-cloud/firestore';
+
 import {CallOptions} from 'google-gax';
 import {Duplex} from 'stream';
 
 import {google} from '../protos/firestore_v1_proto_api';
 import {FieldPath} from './path';
-import {Timestamp} from './timestamp';
 
 import api = google.firestore.v1;
 import {QueryDocumentSnapshot} from './document';
@@ -99,62 +100,6 @@ export type UnaryMethod<Req, Resp> = (
 export type RBTree = any;
 
 /**
- * Converter used by `withConverter()` to transform user objects of type T
- * into Firestore data.
- *
- * Using the converter allows you to specify generic type arguments when
- * storing and retrieving objects from Firestore.
- *
- * @example
- * class Post {
- *   constructor(readonly title: string, readonly author: string) {}
- *
- *   toString(): string {
- *     return this.title + ', by ' + this.author;
- *   }
- * }
- *
- * const postConverter = {
- *   toFirestore(post: Post): FirebaseFirestore.DocumentData {
- *     return {title: post.title, author: post.author};
- *   },
- *   fromFirestore(
- *     snapshot: FirebaseFirestore.QueryDocumentSnapshot
- *   ): Post {
- *     return new Post(data.title, data.author);
- *   }
- * };
- *
- * const postSnap = await Firestore()
- *   .collection('posts')
- *   .withConverter(postConverter)
- *   .doc().get();
- * const post = postSnap.data();
- * if (post !== undefined) {
- *   post.title; // string
- *   post.toString(); // Should be defined
- *   post.someNonExistentProperty; // TS error
- * }
- */
-export interface FirestoreDataConverter<T> {
-  /**
-   * Called by the Firestore SDK to convert a custom model object of type T
-   * into a plain Javascript object (suitable for writing directly to the
-   * Firestore database). To use set() with `merge` and `mergeFields`,
-   * toFirestore() must be defined with `Partial<T>`.
-   */
-  toFirestore:
-    | ((modelObject: T) => DocumentData)
-    | ((modelObject: Partial<T>, options?: SetOptions) => DocumentData);
-
-  /**
-   * Called by the Firestore SDK to convert Firestore data into an object of
-   * type T.
-   */
-  fromFirestore: (snapshot: QueryDocumentSnapshot) => T;
-}
-
-/**
  * A default converter to use when none is provided.
  *
  * By declaring the converter as a variable instead of creating the object
@@ -162,7 +107,7 @@ export interface FirestoreDataConverter<T> {
  * is preserved.
  * @private
  */
-const defaultConverterObj = {
+const defaultConverterObj: FirestoreDataConverter<DocumentData> = {
   toFirestore(modelObject: DocumentData): DocumentData {
     return modelObject;
   },
@@ -180,162 +125,9 @@ export function defaultConverter<T>(): FirestoreDataConverter<T> {
 }
 
 /**
- * Settings used to directly configure a `Firestore` instance.
- */
-export interface Settings {
-  /**
-   * The Firestore Project ID. Can be omitted in environments that support
-   * `Application Default Credentials` {@see https://cloud.google.com/docs/authentication}
-   */
-  projectId?: string;
-
-  /** The host to connect to. */
-  host?: string;
-
-  /**
-   * Local file containing the Service Account credentials. Can be omitted
-   * in environments that support `Application Default Credentials`
-   * {@see https://cloud.google.com/docs/authentication}
-   */
-  keyFilename?: string;
-
-  /**
-   * The 'client_email' and 'private_key' properties of the service account
-   * to use with your Firestore project. Can be omitted in environments that
-   * support {@link https://cloud.google.com/docs/authentication Application
-   * Default Credentials}. If your credentials are stored in a JSON file, you
-   * can specify a `keyFilename` instead.
-   */
-  credentials?: {client_email?: string; private_key?: string};
-
-  /** Whether to use SSL when connecting. */
-  ssl?: boolean;
-
-  /**
-   * The maximum number of idle GRPC channels to keep. A smaller number of idle
-   * channels reduces memory usage but increases request latency for clients
-   * with fluctuating request rates. If set to 0, shuts down all GRPC channels
-   * when the client becomes idle. Defaults to 1.
-   */
-  maxIdleChannels?: number;
-
-  /**
-   * Whether to use `BigInt` for integer types when deserializing Firestore
-   * Documents. Regardless of magnitude, all integer values are returned as
-   * `BigInt` to match the precision of the Firestore backend. Floating point
-   * numbers continue to use JavaScript's `number` type.
-   */
-  useBigInt?: boolean;
-
-  /**
-   * Whether to skip nested properties that are set to `undefined` during
-   * object serialization. If set to `true`, these properties are skipped
-   * and not written to Firestore. If set `false` or omitted, the SDK throws
-   * an exception when it encounters properties of type `undefined`.
-   */
-  ignoreUndefinedProperties?: boolean;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any; // Accept other properties, such as GRPC settings.
-}
-
-/**
- * Document data (for use with `DocumentReference.set()`) consists of fields
- * mapped to values.
- */
-export interface DocumentData {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [field: string]: any;
-}
-
-/**
- * Update data (for use with `DocumentReference.update()`) consists of field
- * paths (e.g. 'foo' or 'foo.baz') mapped to values. Fields that contain dots
- * reference nested fields within the document.
- */
-export interface UpdateData {
-  [fieldPath: string]: unknown;
-}
-
-/**
  * Update data that has been resolved to a mapping of FieldPaths to values.
  */
 export type UpdateMap = Map<FieldPath, unknown>;
-
-/**
- * The direction of a `Query.orderBy()` clause is specified as 'desc' or 'asc'
- * (descending or ascending).
- */
-export type OrderByDirection = 'desc' | 'asc';
-
-/**
- * Filter conditions in a `Query.where()` clause are specified using the
- * strings '<', '<=', '==', '>=', '>','array-contains', 'in', and
- * 'array-contains-any'.
- */
-export type WhereFilterOp =
-  | '<'
-  | '<='
-  | '=='
-  | '>='
-  | '>'
-  | 'array-contains'
-  | 'in'
-  | 'array-contains-any';
-
-/**
- * An options object that configures conditional behavior of `update()` and
- * `delete()` calls in `DocumentReference`, `WriteBatch`, and `Transaction`.
- * Using Preconditions, these calls can be restricted to only apply to
- * documents that match the specified restrictions.
- */
-export interface Precondition {
-  /**
-   * If set, the last update time to enforce.
-   */
-  readonly lastUpdateTime?: Timestamp;
-}
-
-/**
- * An options object that configures the behavior of `set()` calls in
- * `DocumentReference`, `WriteBatch` and `Transaction`. These calls can be
- * configured to perform granular merges instead of overwriting the target
- * documents in their entirety.
- */
-export interface SetOptions {
-  /**
-   * Changes the behavior of a set() call to only replace the values specified
-   * in its data argument. Fields omitted from the set() call remain
-   * untouched.
-   */
-  readonly merge?: boolean;
-
-  /**
-   * Changes the behavior of set() calls to only replace the specified field
-   * paths. Any field path that is not specified is ignored and remains
-   * untouched.
-   *
-   * It is an error to pass a SetOptions object to a set() call that is
-   * missing a value for any of the fields specified here.
-   */
-  readonly mergeFields?: Array<string | FieldPath>;
-}
-
-/**
- * An options object that can be used to configure the behavior of `getAll()`
- * calls. By providing a `fieldMask`, these calls can be configured to only
- * return a subset of fields.
- */
-export interface ReadOptions {
-  /**
-   * Specifies the set of fields to return and reduces the amount of data
-   * transmitted by the backend.
-   *
-   * Adding a field mask does not filter results. Documents do not need to
-   * contain values for all the fields in the mask to be part of the result set.
-   */
-  readonly fieldMask?: Array<string | FieldPath>;
-}
 
 /**
  * Internal user data validation options.
@@ -353,15 +145,6 @@ export interface ValidationOptions {
    * the root.
    */
   allowUndefined: boolean;
-}
-
-/**
- * An options object that can be used to disable request throttling in
- * BulkWriter.
- */
-export interface BulkWriterOptions {
-  /** Whether to disable throttling. */
-  readonly disableThrottling?: boolean;
 }
 
 /**

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import {DocumentData} from '@google-cloud/firestore';
+
 import {randomBytes} from 'crypto';
 import {GoogleError, ServiceConfig, Status} from 'google-gax';
-
-import {DocumentData} from './types';
 
 /**
  * A Promise implementation that supports deferred resolution.

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as firestore from '@google-cloud/firestore';
+
 import * as assert from 'assert';
 import * as rbtree from 'functional-red-black-tree';
 import {GoogleError, Status} from 'google-gax';
@@ -27,12 +29,7 @@ import {DocumentReference, Firestore, Query} from './index';
 import {logger} from './logger';
 import {QualifiedResourcePath} from './path';
 import {Timestamp} from './timestamp';
-import {
-  defaultConverter,
-  DocumentData,
-  FirestoreDataConverter,
-  RBTree,
-} from './types';
+import {defaultConverter, RBTree} from './types';
 import {requestTag} from './util';
 
 import api = google.firestore.v1;
@@ -105,7 +102,7 @@ type DocumentComparator<T> = (
   r: QueryDocumentSnapshot<T>
 ) => number;
 
-interface DocumentChangeSet<T = DocumentData> {
+interface DocumentChangeSet<T = firestore.DocumentData> {
   deletes: string[];
   adds: Array<QueryDocumentSnapshot<T>>;
   updates: Array<QueryDocumentSnapshot<T>>;
@@ -118,7 +115,7 @@ interface DocumentChangeSet<T = DocumentData> {
  * @class
  * @private
  */
-abstract class Watch<T = DocumentData> {
+abstract class Watch<T = firestore.DocumentData> {
   protected readonly firestore: Firestore;
   private readonly backoff: ExponentialBackoff;
   private readonly requestTag: string;
@@ -765,7 +762,7 @@ abstract class Watch<T = DocumentData> {
  *
  * @private
  */
-export class DocumentWatch<T = DocumentData> extends Watch<T> {
+export class DocumentWatch<T = firestore.DocumentData> extends Watch<T> {
   constructor(
     firestore: Firestore,
     private readonly ref: DocumentReference<T>
@@ -794,13 +791,13 @@ export class DocumentWatch<T = DocumentData> extends Watch<T> {
  *
  * @private
  */
-export class QueryWatch<T = DocumentData> extends Watch<T> {
+export class QueryWatch<T = firestore.DocumentData> extends Watch<T> {
   private comparator: DocumentComparator<T>;
 
   constructor(
     firestore: Firestore,
     private readonly query: Query<T>,
-    converter?: FirestoreDataConverter<T>
+    converter?: firestore.FirestoreDataConverter<T>
   ) {
     super(firestore, converter);
     this.comparator = query.comparator();

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {QuerySnapshot, DocumentData} from '@google-cloud/firestore';
+
 import {describe, it, beforeEach, afterEach} from 'mocha';
 import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
@@ -20,7 +22,6 @@ import {firestore} from '../protos/firestore_v1_proto_api';
 
 import {
   CollectionReference,
-  DocumentData,
   DocumentReference,
   DocumentSnapshot,
   FieldPath,
@@ -29,7 +30,6 @@ import {
   GeoPoint,
   Query,
   QueryDocumentSnapshot,
-  QuerySnapshot,
   setLogFunction,
   Timestamp,
   WriteResult,

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {DocumentData} from '@google-cloud/firestore';
+
 import {describe, it, beforeEach, afterEach} from 'mocha';
 import {expect} from 'chai';
 import {Status} from 'google-gax';
 
 import * as proto from '../protos/firestore_v1_proto_api';
-import {
-  DocumentData,
-  Firestore,
-  setLogFunction,
-  Timestamp,
-  WriteResult,
-} from '../src';
+import {Firestore, setLogFunction, Timestamp, WriteResult} from '../src';
 import {BulkWriter} from '../src/bulk-writer';
 import {Deferred} from '../src/util';
 import {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {DocumentData} from '@google-cloud/firestore';
+
 import {describe, it, beforeEach, afterEach} from 'mocha';
 import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
@@ -25,7 +27,7 @@ import {
   QueryDocumentSnapshot,
   setLogFunction,
 } from '../src';
-import {DocumentData, DocumentReference, Query, Timestamp} from '../src';
+import {DocumentReference, Query, Timestamp} from '../src';
 import {setTimeoutHandler} from '../src/backoff';
 import {DocumentSnapshot, DocumentSnapshotBuilder} from '../src/document';
 import {QualifiedResourcePath} from '../src/path';

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {DocumentData, Settings, SetOptions} from '@google-cloud/firestore';
+
 import {expect} from 'chai';
 import * as extend from 'extend';
 import {grpc} from 'google-gax';
@@ -22,14 +24,9 @@ import {firestore} from '../../protos/firestore_v1_proto_api';
 
 import * as proto from '../../protos/firestore_v1_proto_api';
 import * as v1 from '../../src/v1';
-import {
-  Firestore,
-  Settings,
-  QueryDocumentSnapshot,
-  SetOptions,
-} from '../../src';
+import {Firestore, QueryDocumentSnapshot} from '../../src';
 import {ClientPool} from '../../src/pool';
-import {DocumentData, GapicClient} from '../../src/types';
+import {GapicClient} from '../../src/types';
 
 import api = proto.google.firestore.v1;
 

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {DocumentData} from '@google-cloud/firestore';
+
 import * as duplexify from 'duplexify';
 import {describe, it, beforeEach, afterEach} from 'mocha';
 import {expect} from 'chai';
@@ -24,7 +26,6 @@ import {google} from '../protos/firestore_v1_proto_api';
 
 import {
   CollectionReference,
-  DocumentData,
   DocumentReference,
   DocumentSnapshot,
   FieldPath,

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {DocumentData} from '@google-cloud/firestore';
+
 import {describe, it, beforeEach, afterEach} from 'mocha';
 import {expect} from 'chai';
 
@@ -23,7 +25,6 @@ import {
   Timestamp,
   WriteBatch,
   WriteResult,
-  DocumentData,
   QueryDocumentSnapshot,
 } from '../src';
 import {BatchWriteResult} from '../src/write-batch';


### PR DESCRIPTION
This PR updates the code to implement the interfaces for all public types, which should ensure that our API matches our types. It also removes the duplication that we had in `types.ts`, since w can directly depend on the interface types that are defined in our `.d.ts` file.