### PR TITLE
fix: remove GCF transaction fallback

### DIFF
--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -384,7 +384,7 @@ export class Transaction implements firestore.Transaction {
    */
   commit(): Promise<void> {
     return this._writeBatch
-      .commit_({
+      ._commit({
         transactionId: this._transactionId,
         requestTag: this._requestTag,
       })

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -545,7 +545,7 @@ export class WriteBatch implements firestore.WriteBatch {
     // Capture the error stack to preserve stack tracing across async calls.
     const stack = Error().stack!;
 
-    return this.commit_().catch(err => {
+    return this._commit().catch(err => {
       throw wrapError(err, stack);
     });
   }
@@ -596,7 +596,7 @@ export class WriteBatch implements firestore.WriteBatch {
    * this request.
    * @returns  A Promise that resolves when this batch completes.
    */
-  async commit_(commitOptions?: {
+  async _commit(commitOptions?: {
     transactionId?: Uint8Array;
     requestTag?: string;
   }): Promise<WriteResult[]> {
@@ -607,38 +607,22 @@ export class WriteBatch implements firestore.WriteBatch {
     await this._firestore.initializeIfNeeded(tag);
 
     const database = this._firestore.formattedName;
-
-    // On GCF, we periodically force transactional commits to allow for
-    // request retries in case GCF closes our backend connection.
-    const explicitTransaction = commitOptions && commitOptions.transactionId;
-    if (!explicitTransaction && this._shouldCreateTransaction()) {
-      logger('WriteBatch.commit', tag, 'Using transaction for commit');
-      return this._firestore
-        .request<api.IBeginTransactionRequest, api.IBeginTransactionResponse>(
-          'beginTransaction',
-          {database},
-          tag
-        )
-        .then(resp => {
-          return this.commit_({transactionId: resp.transaction!});
-        });
-    }
-
+    
     const request: api.ICommitRequest = {
       database,
       writes: this._ops.map(op => op()),
     };
-
+    if (commitOptions?.transactionId) {
+      request.transaction = commitOptions.transactionId;
+    }
+    
     logger(
       'WriteBatch.commit',
       tag,
       'Sending %d writes',
       request.writes!.length
     );
-
-    if (explicitTransaction) {
-      request.transaction = explicitTransaction;
-    }
+    
     const response = await this._firestore.request<
       api.ICommitRequest,
       api.CommitResponse
@@ -650,26 +634,6 @@ export class WriteBatch implements firestore.WriteBatch {
           Timestamp.fromProto(writeResult.updateTime || response.commitTime!)
         )
     );
-  }
-
-  /**
-   * Determines whether we should issue a transactional commit. On GCF, this
-   * happens after two minutes of idleness.
-   *
-   * @private
-   * @returns Whether to use a transaction.
-   */
-  private _shouldCreateTransaction(): boolean {
-    if (!this._firestore._preferTransactions) {
-      return false;
-    }
-
-    if (this._firestore._lastSuccessfulRequest) {
-      const now = new Date().getTime();
-      return now - this._firestore._lastSuccessfulRequest > GCF_IDLE_TIMEOUT_MS;
-    }
-
-    return true;
   }
 
   /**

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -607,7 +607,7 @@ export class WriteBatch implements firestore.WriteBatch {
     await this._firestore.initializeIfNeeded(tag);
 
     const database = this._firestore.formattedName;
-    
+
     const request: api.ICommitRequest = {
       database,
       writes: this._ops.map(op => op()),
@@ -615,14 +615,14 @@ export class WriteBatch implements firestore.WriteBatch {
     if (commitOptions?.transactionId) {
       request.transaction = commitOptions.transactionId;
     }
-    
+
     logger(
       'WriteBatch.commit',
       tag,
       'Sending %d writes',
       request.writes!.length
     );
-    
+
     const response = await this._firestore.request<
       api.ICommitRequest,
       api.CommitResponse

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -325,14 +325,14 @@ describe('batch support', () => {
     const documentName = firestore.doc('col/doc');
 
     return writeBatch
-        .set(documentName, {foo: FieldValue.serverTimestamp()})
-        .update(documentName, {foo: 'bar'})
-        .create(documentName, {})
-        .delete(documentName)
-        .commit()
-        .then(resp => {
-          verifyResponse(resp);
-        });
+      .set(documentName, {foo: FieldValue.serverTimestamp()})
+      .update(documentName, {foo: 'bar'})
+      .create(documentName, {})
+      .delete(documentName)
+      .commit()
+      .then(resp => {
+        verifyResponse(resp);
+      });
   });
 
   it('handles exception', () => {
@@ -341,14 +341,14 @@ describe('batch support', () => {
     };
 
     return firestore
-        .batch()
-        .commit()
-        .then(() => {
-          throw new Error('Unexpected success in Promise');
-        })
-        .catch(err => {
-          expect(err.message).to.equal('Expected exception');
-        });
+      .batch()
+      .commit()
+      .then(() => {
+        throw new Error('Unexpected success in Promise');
+      })
+      .catch(err => {
+        expect(err.message).to.equal('Expected exception');
+      });
   });
 
   it('cannot append to committed batch', () => {

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -325,14 +325,14 @@ describe('batch support', () => {
     const documentName = firestore.doc('col/doc');
 
     return writeBatch
-      .set(documentName, {foo: FieldValue.serverTimestamp()})
-      .update(documentName, {foo: 'bar'})
-      .create(documentName, {})
-      .delete(documentName)
-      .commit()
-      .then(resp => {
-        verifyResponse(resp);
-      });
+        .set(documentName, {foo: FieldValue.serverTimestamp()})
+        .update(documentName, {foo: 'bar'})
+        .create(documentName, {})
+        .delete(documentName)
+        .commit()
+        .then(resp => {
+          verifyResponse(resp);
+        });
   });
 
   it('handles exception', () => {
@@ -341,14 +341,14 @@ describe('batch support', () => {
     };
 
     return firestore
-      .batch()
-      .commit()
-      .then(() => {
-        throw new Error('Unexpected success in Promise');
-      })
-      .catch(err => {
-        expect(err.message).to.equal('Expected exception');
-      });
+        .batch()
+        .commit()
+        .then(() => {
+          throw new Error('Unexpected success in Promise');
+        })
+        .catch(err => {
+          expect(err.message).to.equal('Expected exception');
+        });
   });
 
   it('cannot append to committed batch', () => {
@@ -431,59 +431,6 @@ describe('batch support', () => {
       return batch.commit().then(results => {
         expect(results[0].isEqual(results[1])).to.be.true;
       });
-    });
-  });
-
-  it('uses transactions on GCF', () => {
-    // We use this environment variable during initialization to detect whether
-    // we are running on GCF.
-    process.env.FUNCTION_TRIGGER_TYPE = 'http-trigger';
-
-    let beginCalled = 0;
-    let commitCalled = 0;
-
-    const overrides: ApiOverride = {
-      beginTransaction: () => {
-        ++beginCalled;
-        return response({transaction: Buffer.from('foo')});
-      },
-      commit: () => {
-        ++commitCalled;
-        return response({
-          commitTime: {
-            nanos: 0,
-            seconds: 0,
-          },
-        });
-      },
-    };
-
-    return createInstance(overrides).then(firestore => {
-      firestore['_preferTransactions'] = true;
-      firestore['_lastSuccessfulRequest'] = 0;
-
-      return firestore
-        .batch()
-        .commit()
-        .then(() => {
-          // The first commit always uses a transcation.
-          expect(beginCalled).to.equal(1);
-          expect(commitCalled).to.equal(1);
-          return firestore.batch().commit();
-        })
-        .then(() => {
-          // The following commits don't use transactions if they happen
-          // within two minutes.
-          expect(beginCalled).to.equal(1);
-          expect(commitCalled).to.equal(2);
-          firestore['_lastSuccessfulRequest'] = 1337;
-          return firestore.batch().commit();
-        })
-        .then(() => {
-          expect(beginCalled).to.equal(2);
-          expect(commitCalled).to.equal(3);
-          delete process.env.FUNCTION_TRIGGER_TYPE;
-        });
     });
   });
 });


### PR DESCRIPTION
I would like to remove the code to run a transactional commit on GCF periodically. I hope this code is not needed anymore since the socket timeout has been drastically increased since our beta release and GCF should no longer block our outgoing traffic. On top of that, we never used a transaction runner for these commits, so retries with code ABORTED were not possible. This code was also not added to BulkWriter.