### PR TITLE
fix: restart onSnapshot() listeners that stop receiving updates

### DIFF
--- a/dev/src/backoff.ts
+++ b/dev/src/backoff.ts
@@ -95,18 +95,6 @@ export function setTimeoutHandler(
 }
 
 /**
- * Resets the timeout handler back to `setTimeout`. To be used in conjunction
- * with `setTimeoutHandler()`.
- *
- * Used only in testing.
- *
- * @private
- */
-export function resetTimeoutHandler(): void {
-  delayExecution = setTimeout;
-}
-
-/**
  * Configuration object to adjust the delays of the exponential backoff
  * algorithm.
  *

--- a/dev/src/backoff.ts
+++ b/dev/src/backoff.ts
@@ -57,7 +57,10 @@ export const MAX_RETRY_ATTEMPTS = 10;
 /*!
  * The timeout handler used by `ExponentialBackoff` and `BulkWriter`.
  */
-export let delayExecution: (f: () => void, ms: number) => void = setTimeout;
+export let delayExecution: (
+  f: () => void,
+  ms: number
+) => NodeJS.Timeout = setTimeout;
 
 /**
  * Allows overriding of the timeout handler used by the exponential backoff
@@ -71,7 +74,36 @@ export let delayExecution: (f: () => void, ms: number) => void = setTimeout;
 export function setTimeoutHandler(
   handler: (f: () => void, ms: number) => void
 ): void {
-  delayExecution = handler;
+  delayExecution = (f: () => void, ms: number) => {
+    handler(f, ms);
+    const timeout: NodeJS.Timeout = {
+      hasRef: () => {
+        throw new Error('For tests only. Not Implemented');
+      },
+      ref: () => {
+        throw new Error('For tests only. Not Implemented');
+      },
+      refresh: () => {
+        throw new Error('For tests only. Not Implemented');
+      },
+      unref: () => {
+        throw new Error('For tests only. Not Implemented');
+      },
+    };
+    return timeout;
+  };
+}
+
+/**
+ * Resets the timeout handler back to `setTimeout`. To be used in conjunction
+ * with `setTimeoutHandler()`.
+ *
+ * Used only in testing.
+ *
+ * @private
+ */
+export function resetTimeoutHandler(): void {
+  delayExecution = setTimeout;
 }
 
 /**

--- a/dev/test/backoff.ts
+++ b/dev/test/backoff.ts
@@ -15,11 +15,7 @@
 import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
-import {
-  ExponentialBackoff,
-  resetTimeoutHandler,
-  setTimeoutHandler,
-} from '../src/backoff';
+import {ExponentialBackoff, setTimeoutHandler} from '../src/backoff';
 
 use(chaiAsPromised);
 
@@ -39,7 +35,7 @@ describe('ExponentialBackoff', () => {
     observedDelays = [];
   });
 
-  after(() => resetTimeoutHandler());
+  after(() => setTimeoutHandler(setTimeout));
 
   function assertDelayEquals(expected: number) {
     expect(observedDelays.shift()).to.equal(expected);

--- a/dev/test/backoff.ts
+++ b/dev/test/backoff.ts
@@ -15,7 +15,11 @@
 import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
-import {ExponentialBackoff, setTimeoutHandler} from '../src/backoff';
+import {
+  ExponentialBackoff,
+  resetTimeoutHandler,
+  setTimeoutHandler,
+} from '../src/backoff';
 
 use(chaiAsPromised);
 
@@ -35,9 +39,7 @@ describe('ExponentialBackoff', () => {
     observedDelays = [];
   });
 
-  after(() => {
-    setTimeoutHandler(setTimeout);
-  });
+  after(() => resetTimeoutHandler());
 
   function assertDelayEquals(expected: number) {
     expect(observedDelays.shift()).to.equal(expected);

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -39,7 +39,7 @@ import {
 } from './util/helpers';
 
 import api = proto.google.firestore.v1;
-import {setTimeoutHandler} from '../src/backoff';
+import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
 
 // Change the argument to 'console.log' to enable debug output.
 setLogFunction(() => {});
@@ -550,7 +550,7 @@ describe('BulkWriter', () => {
   });
 
   describe('500/50/5 support', () => {
-    afterEach(() => setTimeoutHandler(setTimeout));
+    afterEach(() => resetTimeoutHandler());
 
     it('does not send batches if doing so exceeds the rate limit', async () => {
       // The test is considered a success if BulkWriter tries to send the second

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -23,6 +23,7 @@ import {
   Timestamp,
   WriteResult,
 } from '../src';
+import {setTimeoutHandler} from '../src/backoff';
 import {BulkWriter} from '../src/bulk-writer';
 import {Deferred} from '../src/util';
 import {
@@ -39,7 +40,6 @@ import {
 } from './util/helpers';
 
 import api = proto.google.firestore.v1;
-import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
 
 // Change the argument to 'console.log' to enable debug output.
 setLogFunction(() => {});
@@ -550,7 +550,7 @@ describe('BulkWriter', () => {
   });
 
   describe('500/50/5 support', () => {
-    afterEach(() => resetTimeoutHandler());
+    afterEach(() => setTimeoutHandler(setTimeout));
 
     it('does not send batches if doing so exceeds the rate limit', async () => {
       // The test is considered a success if BulkWriter tries to send the second

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -21,7 +21,7 @@ import {google} from '../protos/firestore_v1_proto_api';
 
 import * as Firestore from '../src';
 import {DocumentSnapshot, FieldPath} from '../src';
-import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
+import {setTimeoutHandler} from '../src/backoff';
 import {QualifiedResourcePath} from '../src/path';
 import {
   ApiOverride,
@@ -899,7 +899,7 @@ describe('getAll() method', () => {
     setTimeoutHandler(setImmediate);
   });
 
-  after(() => resetTimeoutHandler());
+  after(() => setTimeoutHandler(setTimeout));
 
   function resultEquals(
     result: DocumentSnapshot[],

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -21,7 +21,7 @@ import {google} from '../protos/firestore_v1_proto_api';
 
 import * as Firestore from '../src';
 import {DocumentSnapshot, FieldPath} from '../src';
-import {setTimeoutHandler} from '../src/backoff';
+import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
 import {QualifiedResourcePath} from '../src/path';
 import {
   ApiOverride,
@@ -899,9 +899,7 @@ describe('getAll() method', () => {
     setTimeoutHandler(setImmediate);
   });
 
-  after(() => {
-    setTimeoutHandler(setTimeout);
-  });
+  after(() => resetTimeoutHandler());
 
   function resultEquals(
     result: DocumentSnapshot[],

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -25,7 +25,7 @@ import {
   setLogFunction,
 } from '../src';
 import {DocumentData, DocumentReference, Query, Timestamp} from '../src';
-import {setTimeoutHandler} from '../src/backoff';
+import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
 import {DocumentSnapshot, DocumentSnapshotBuilder} from '../src/document';
 import {QualifiedResourcePath} from '../src/path';
 import {
@@ -311,7 +311,7 @@ describe('query interface', () => {
 
   afterEach(() => {
     verifyInstance(firestore);
-    setTimeoutHandler(setTimeout);
+    resetTimeoutHandler();
   });
 
   it('has isEqual() method', () => {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -18,14 +18,17 @@ import * as extend from 'extend';
 
 import {google} from '../protos/firestore_v1_proto_api';
 import {
+  DocumentData,
+  DocumentReference,
   FieldPath,
   FieldValue,
   Firestore,
+  Query,
   QueryDocumentSnapshot,
   setLogFunction,
+  Timestamp,
 } from '../src';
-import {DocumentData, DocumentReference, Query, Timestamp} from '../src';
-import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
+import {setTimeoutHandler} from '../src/backoff';
 import {DocumentSnapshot, DocumentSnapshotBuilder} from '../src/document';
 import {QualifiedResourcePath} from '../src/path';
 import {
@@ -311,7 +314,7 @@ describe('query interface', () => {
 
   afterEach(() => {
     verifyInstance(firestore);
-    resetTimeoutHandler();
+    setTimeoutHandler(setTimeout);
   });
 
   it('has isEqual() method', () => {

--- a/dev/test/transaction.ts
+++ b/dev/test/transaction.ts
@@ -22,7 +22,7 @@ import * as through2 from 'through2';
 import * as proto from '../protos/firestore_v1_proto_api';
 import * as Firestore from '../src';
 import {DocumentReference, FieldPath, Transaction} from '../src';
-import {setTimeoutHandler} from '../src/backoff';
+import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
 import {
   ApiOverride,
   createInstance,
@@ -331,8 +331,6 @@ function runTransaction<T>(
   };
 
   return createInstance(overrides).then(async firestore => {
-    const defaultTimeoutHandler = setTimeout;
-
     try {
       setTimeoutHandler((callback, timeout) => {
         if (timeout > 0) {
@@ -353,7 +351,7 @@ function runTransaction<T>(
       });
     } finally {
       expect(expectedRequests.length).to.equal(0);
-      setTimeoutHandler(defaultTimeoutHandler);
+      resetTimeoutHandler();
     }
   });
 }

--- a/dev/test/transaction.ts
+++ b/dev/test/transaction.ts
@@ -22,7 +22,7 @@ import * as through2 from 'through2';
 import * as proto from '../protos/firestore_v1_proto_api';
 import * as Firestore from '../src';
 import {DocumentReference, FieldPath, Transaction} from '../src';
-import {resetTimeoutHandler, setTimeoutHandler} from '../src/backoff';
+import {setTimeoutHandler} from '../src/backoff';
 import {
   ApiOverride,
   createInstance,
@@ -350,8 +350,8 @@ function runTransaction<T>(
         return transactionCallback(transaction, docRef);
       });
     } finally {
+      setTimeoutHandler(setTimeout);
       expect(expectedRequests.length).to.equal(0);
-      resetTimeoutHandler();
     }
   });
 }

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -38,11 +38,7 @@ import {
   setLogFunction,
   Timestamp,
 } from '../src';
-import {
-  MAX_RETRY_ATTEMPTS,
-  resetTimeoutHandler,
-  setTimeoutHandler,
-} from '../src/backoff';
+import {MAX_RETRY_ATTEMPTS, setTimeoutHandler} from '../src/backoff';
 import {DocumentSnapshotBuilder} from '../src/document';
 import {DocumentChangeType} from '../src/document-change';
 import {Serializer} from '../src/serializer';
@@ -721,7 +717,7 @@ describe('Query watch', () => {
   });
 
   afterEach(() => {
-    resetTimeoutHandler();
+    setTimeoutHandler(setTimeout);
     return verifyInstance(firestore);
   });
 
@@ -850,7 +846,7 @@ describe('Query watch', () => {
     // backoff window during the the stream recovery. We then use this window to
     // unsubscribe from the Watch stream and make sure that we don't
     // re-open the stream once the backoff expires.
-    resetTimeoutHandler();
+    setTimeoutHandler(setTimeout);
 
     const unsubscribe = watchHelper.startWatch();
     return streamHelper
@@ -2307,7 +2303,7 @@ describe('DocumentReference watch', () => {
   });
 
   afterEach(() => {
-    resetTimeoutHandler();
+    setTimeoutHandler(setTimeout);
     return verifyInstance(firestore);
   });
 


### PR DESCRIPTION
https://github.com/googleapis/nodejs-firestore/issues/1057 describes an issue that we haven't been able to resolve on the backend. It seems that for large Watch snapshots (1000+ documents), the backend sometime stops responding and fails to deliver any further Watch updates. This PR adds a 2 minute timeout that automatically restarts the Watch stream and resumes the Query from the last known state.

The 2 minute timeout is many times larger than the 30 second interval at which Watch is expected to send a target change even if no documents have changed. 

Fixes #1057 