### PR TITLE
fix: retry ABORTED writes in bulkCommit

### DIFF
--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -24,7 +24,6 @@ import {DocumentReference} from './reference';
 import {Timestamp} from './timestamp';
 import {Deferred, wrapError} from './util';
 import {BatchWriteResult, WriteBatch, WriteResult} from './write-batch';
-import {Status} from 'google-gax';
 
 /*!
  * The maximum number of writes that can be in a single batch.
@@ -193,9 +192,6 @@ class BulkCommitBatch {
       if (result.writeTime) {
         return new WriteResult(result.writeTime);
       } else {
-        if (result.status.code === Status.ABORTED) {
-          console.error('STATUS' + result.status.note);
-        }
         throw result.status;
       }
     });
@@ -628,6 +624,7 @@ export class BulkWriter {
       if (delayMs === 0) {
         this.sendBatch(batch);
       } else {
+        console.warn('throttling');
         delayExecution(() => this.sendReadyBatches(), delayMs);
         break;
       }

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -24,6 +24,7 @@ import {DocumentReference} from './reference';
 import {Timestamp} from './timestamp';
 import {Deferred, wrapError} from './util';
 import {BatchWriteResult, WriteBatch, WriteResult} from './write-batch';
+import {Status} from 'google-gax';
 
 /*!
  * The maximum number of writes that can be in a single batch.
@@ -192,6 +193,9 @@ class BulkCommitBatch {
       if (result.writeTime) {
         return new WriteResult(result.writeTime);
       } else {
+        if (result.status.code === Status.ABORTED) {
+          console.error('STATUS' + result.status.note);
+        }
         throw result.status;
       }
     });

--- a/dev/src/v1/firestore_client_config.json
+++ b/dev/src/v1/firestore_client_config.json
@@ -11,6 +11,10 @@
           "DEADLINE_EXCEEDED",
           "INTERNAL",
           "UNAVAILABLE"
+        ],
+        "aborted_unavailable": [
+          "ABORTED",
+          "UNAVAILABLE"
         ]
       },
       "retry_params": {
@@ -90,7 +94,8 @@
           "retry_params_name": "default"
         },
         "BatchWrite": {
-          "retry_codes_name": "non_idempotent",
+          "timeout_millis": 60000,
+          "retry_codes_name": "aborted_unavailable",
           "retry_params_name": "default"
         },
         "CreateDocument": {

--- a/dev/src/v1/firestore_client_config.json
+++ b/dev/src/v1/firestore_client_config.json
@@ -11,10 +11,6 @@
           "DEADLINE_EXCEEDED",
           "INTERNAL",
           "UNAVAILABLE"
-        ],
-        "aborted_unavailable": [
-          "ABORTED",
-          "UNAVAILABLE"
         ]
       },
       "retry_params": {
@@ -94,8 +90,7 @@
           "retry_params_name": "default"
         },
         "BatchWrite": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "aborted_unavailable",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "CreateDocument": {

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -605,7 +605,7 @@ export class WriteBatch implements firestore.WriteBatch {
       logger(
         'WriteBatch.bulkCommit',
         tag,
-        'current batch failed at retry #' +
+        'Current batch failed at retry #' +
           retryCount +
           '. Num failures: ' +
           abortedIndexes.length +

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -579,59 +579,19 @@ export class WriteBatch implements firestore.WriteBatch {
       writes: this._ops.map(op => op()),
     };
 
-    const retryCodes = [Status.ABORTED, ...getRetryCodes('commit')];
+    const retryCodes = getRetryCodes('batchWrite');
 
-    const response = await this._firestore.request<
+    let response = await this._firestore.request<
       api.IBatchWriteRequest,
       api.BatchWriteResponse
     >('batchWrite', request, tag, retryCodes);
 
-    let retryCount = 0;
-    while (retryCount < MAX_BATCH_WRITE_RETRY_ATTEMPTS) {
-      // Find the indexes of all writes that failed with ABORTED.
-      const abortedIndexes = response.status.reduce(
-        (arr: number[], status, i) => {
-          if (status.code === Status.ABORTED) {
-            arr.push(i);
-          }
-          return arr;
-        },
-        []
-      );
-
-      if (abortedIndexes.length === 0) {
-        break;
-      }
-      logger(
-        'WriteBatch.bulkCommit',
-        tag,
-        'Current batch failed at retry #' +
-          retryCount +
-          '. Num failures: ' +
-          abortedIndexes.length +
-          '/' +
-          response.status.length
-      );
-
-      // Retry the failed writes in a new request.
-      const retryRequest = {...request};
-      retryRequest.writes = retryRequest.writes?.filter((write, i) => {
-        return abortedIndexes.includes(i);
-      });
-      const retriedResponse = await this._firestore.request<
-        api.IBatchWriteRequest,
-        api.BatchWriteResponse
-      >('batchWrite', retryRequest, tag, retryCodes);
-
-      // Map the results of the retried request back to the original response.
-      for (let i = 0; i < abortedIndexes.length; i++) {
-        const originalIndex = abortedIndexes[i];
-        response.writeResults[originalIndex] = retriedResponse.writeResults[i];
-        response.status[originalIndex] = retriedResponse.status[i];
-      }
-      await this._backoff.backoffAndWait();
-      retryCount++;
-    }
+    response = await this.validateAndRetryResponse(
+      request,
+      response,
+      tag,
+      retryCodes
+    );
 
     return response.writeResults.map((result, i) => {
       const status = response.status[i];
@@ -648,6 +608,65 @@ export class WriteBatch implements firestore.WriteBatch {
           : null;
       return new BatchWriteResult(updateTime, error);
     });
+  }
+
+  /**
+   * Validates the individual statuses of the provided response and retries
+   * any failed writes with retryable error codes. Maps the retried responses
+   * back to the original response.
+   *
+   * @private
+   */
+  async validateAndRetryResponse(
+    request: api.IBatchWriteRequest,
+    response: api.BatchWriteResponse,
+    tag: string,
+    retryCodes: number[]
+  ): Promise<api.BatchWriteResponse> {
+    let retryAttempts = 0;
+    while (retryAttempts < MAX_BATCH_WRITE_RETRY_ATTEMPTS) {
+      // Find all writes that failed with retryable errors.
+      const abortedIndexes: number[] = [];
+      const writesToRetry = response.status.reduce(
+        (writesToRetry: api.IWrite[], status, i) => {
+          if (status.code && retryCodes.includes(status.code)) {
+            writesToRetry.push(request.writes![i]);
+            abortedIndexes.push(i);
+          }
+          return writesToRetry;
+        },
+        []
+      );
+
+      if (abortedIndexes.length === 0) {
+        break;
+      }
+
+      await this._backoff.backoffAndWait();
+      logger(
+        'WriteBatch.bulkCommit',
+        tag,
+        `Current batch failed at retry #${retryAttempts}. Num failures: ` +
+          `${abortedIndexes.length}]/${response.status.length}`
+      );
+
+      // Retry the failed writes in a new request.
+      const retryRequest = {...request};
+      retryRequest.writes = writesToRetry;
+      const retriedResponse = await this._firestore.request<
+        api.IBatchWriteRequest,
+        api.BatchWriteResponse
+      >('batchWrite', retryRequest, tag, retryCodes);
+
+      // Map the results of the retried request back to the original response.
+      for (let i = 0; i < abortedIndexes.length; i++) {
+        const originalIndex = abortedIndexes[i];
+        response.writeResults[originalIndex] = retriedResponse.writeResults[i];
+        response.status[originalIndex] = retriedResponse.status[i];
+      }
+      retryAttempts++;
+    }
+    return response;
   }
 
   /**

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -594,26 +594,18 @@ export class WriteBatch implements firestore.WriteBatch {
   }
 
   /**
-   * Removes all operations from the WriteBatch except for the ones located
-   * at the provided indexes.
+   * Creates a new WriteBatch containing only the operations located at the
+   * provided indexes.
    *
    * @param indexes List of operation indexes to keep
    * @private
    */
-  _sliceIndexes(indexes: number[]): void {
-    this._ops = this._ops.filter((_, i) => {
+  _sliceIndexes(indexes: number[]): WriteBatch {
+    const writeBatch = new WriteBatch(this._firestore);
+    writeBatch._ops = this._ops.filter((_, i) => {
       return indexes.includes(i);
     });
-  }
-
-  /**
-   * Marks the WriteBatch as not committed, allowing it to be committed again.
-   *
-   * Used primarily for facilitating retry logic in BulkWriter.
-   * @private
-   */
-  _markNotCommitted(): void {
-    this._committed = false;
+    return writeBatch;
   }
 
   /**

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -560,8 +560,6 @@ describe('BulkWriter', () => {
 
   it('retries writes that fail with ABORTED errors', async () => {
     setTimeoutHandler(setImmediate);
-
-<<<<<<< HEAD
     // Create mock responses that simulate one successful write followed by
     // failed responses.
     const bulkWriter = await instantiateInstance([
@@ -573,7 +571,7 @@ describe('BulkWriter', () => {
         ]),
         response: mergeResponses([
           successResponse(1),
-          failedResponse(Status.ABORTED),
+          failedResponse(Status.UNAVAILABLE),
           failedResponse(Status.ABORTED),
         ]),
       },
@@ -590,55 +588,20 @@ describe('BulkWriter', () => {
       },
     ]);
 
-    bulkWriter.set(firestore.doc('collectionId/doc1'), {foo: 'bar'});
-    bulkWriter.set(firestore.doc('collectionId/doc2'), {foo: 'bar'});
-    bulkWriter.set(firestore.doc('collectionId/doc3'), {foo: 'bar'});
-    await bulkWriter.close();
-  });
-=======
-      // Create mock responses that simulate one successful write followed by
-      // failed responses.
-      const bulkWriter = await instantiateInstance([
-        {
-          request: createRequest([
-            setOp('doc1', 'bar'),
-            setOp('doc2', 'bar'),
-            setOp('doc3', 'bar'),
-          ]),
-          response: mergeResponses([
-            successResponse(1),
-            failedResponse(Status.UNAVAILABLE),
-            failedResponse(Status.ABORTED),
-          ]),
-        },
-        {
-          request: createRequest([setOp('doc2', 'bar'), setOp('doc3', 'bar')]),
-          response: mergeResponses([
-            successResponse(2),
-            failedResponse(Status.ABORTED),
-          ]),
-        },
-        {
-          request: createRequest([setOp('doc3', 'bar')]),
-          response: mergeResponses([successResponse(3)]),
-        },
-      ]);
-
-      const set1 = bulkWriter.set(firestore.doc('collectionId/doc1'), {
-        foo: 'bar',
-      });
-      const set2 = bulkWriter.set(firestore.doc('collectionId/doc2'), {
-        foo: 'bar',
-      });
-      const set3 = bulkWriter.set(firestore.doc('collectionId/doc3'), {
-        foo: 'bar',
-      });
-      await bulkWriter.close();
-      expect((await set1).writeTime).to.deep.equal(new Timestamp(1, 0));
-      expect((await set2).writeTime).to.deep.equal(new Timestamp(2, 0));
-      expect((await set3).writeTime).to.deep.equal(new Timestamp(3, 0));
+    const set1 = bulkWriter.set(firestore.doc('collectionId/doc1'), {
+      foo: 'bar',
     });
->>>>>>> b8ce703... resolve comments rd.1
+    const set2 = bulkWriter.set(firestore.doc('collectionId/doc2'), {
+      foo: 'bar',
+    });
+    const set3 = bulkWriter.set(firestore.doc('collectionId/doc3'), {
+      foo: 'bar',
+    });
+    await bulkWriter.close();
+    expect((await set1).writeTime).to.deep.equal(new Timestamp(1, 0));
+    expect((await set2).writeTime).to.deep.equal(new Timestamp(2, 0));
+    expect((await set3).writeTime).to.deep.equal(new Timestamp(3, 0));
+  });
 
   describe('Timeout handler tests', () => {
     // Return success responses for all requests.

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -491,7 +491,7 @@ describe('bulkCommit support', () => {
               updateTime: null,
             },
           ],
-          status: [{code: 0}, {code: 14}],
+          status: [{code: 0}, {code: 4}],
         });
       },
     };
@@ -507,7 +507,7 @@ describe('bulkCommit support', () => {
     expect(writeResults[0].writeTime!.isEqual(new Timestamp(0, 0))).to.be.true;
     expect(writeResults[1].writeTime).to.be.null;
     expect(writeResults[0].status.code).to.equal(Status.OK);
-    expect(writeResults[1].status.code).to.equal(Status.UNAVAILABLE);
+    expect(writeResults[1].status.code).to.equal(Status.DEADLINE_EXCEEDED);
   }
 
   it('bulkCommit', () => {


### PR DESCRIPTION
With throttling enabled in the current state (no retries on backend), this implementation successfully gets all ABORTED writes to eventually succeed.