### PR TITLE
fix: reject all promises with errors

### DIFF
--- a/dev/src/pool.ts
+++ b/dev/src/pool.ts
@@ -187,7 +187,9 @@ export class ClientPool<T> {
    */
   run<V>(requestTag: string, op: (client: T) => Promise<V>): Promise<V> {
     if (this.terminated) {
-      return Promise.reject('The client has already been terminated');
+      return Promise.reject(
+        new Error('The client has already been terminated')
+      );
     }
     const client = this.acquire(requestTag);
 

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -180,12 +180,7 @@ export function getRetryParams(methodName: string): BackoffSettings {
  * Used to preserve stack traces across async calls.
  * @private
  */
-export function wrapError(err: Error | string, stack: string): Error {
-  // TODO(b/157506412): Remove `string` type and clean up any string errors
-  // that we are throwing.
-  if (typeof err === 'string') {
-    throw err;
-  }
+export function wrapError(err: Error, stack: string): Error {
   err.stack += '\nCaused by: ' + stack;
   return err;
 }

--- a/dev/src/v1/firestore_admin_client.ts
+++ b/dev/src/v1/firestore_admin_client.ts
@@ -310,7 +310,9 @@ export class FirestoreAdminClient {
       const innerCallPromise = this.firestoreAdminStub.then(
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
-            return Promise.reject('The client has already been closed.');
+            return Promise.reject(
+              new Error('The client has already been closed.')
+            );
           }
           const func = stub[methodName];
           return func.apply(stub, args);

--- a/dev/src/v1/firestore_client.ts
+++ b/dev/src/v1/firestore_client.ts
@@ -253,7 +253,9 @@ export class FirestoreClient {
       const innerCallPromise = this.firestoreStub.then(
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
-            return Promise.reject('The client has already been closed.');
+            return Promise.reject(
+              new Error('The client has already been closed.')
+            );
           }
           const func = stub[methodName];
           return func.apply(stub, args);

--- a/dev/src/v1beta1/firestore_client.ts
+++ b/dev/src/v1beta1/firestore_client.ts
@@ -261,7 +261,9 @@ export class FirestoreClient {
       const innerCallPromise = this.firestoreStub.then(
         stub => (...args: Array<{}>) => {
           if (this._terminated) {
-            return Promise.reject('The client has already been closed.');
+            return Promise.reject(
+              new Error('The client has already been closed.')
+            );
           }
           const func = stub[methodName];
           return func.apply(stub, args);

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -152,7 +152,7 @@ describe('Firestore class', () => {
       })
       .then(() => Promise.reject('set() should have failed'))
       .catch(err => {
-        expect(err).to.equal('The client has already been terminated');
+        expect(err.message).to.equal('The client has already been terminated');
       });
   });
 

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -324,7 +324,7 @@ describe('Client pool', () => {
         );
       })
       .catch((err: Error) => {
-        expect(err).to.equal('The client has already been terminated');
+        expect(err.message).to.equal('The client has already been terminated');
       });
   });
 


### PR DESCRIPTION
Fixes b/157506412. Turns out there weren't that many places where we were throwing strings.