### PR TITLE
chore: add eslint check for console.log statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,8 @@
             "allowExpressions": true,
             "allowTypedFunctionExpressions": true
           }
-        ]
+        ],
+        "no-console": ["error", {"allow": ["error"]}]
       }
     },
     {

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -624,7 +624,6 @@ export class BulkWriter {
       if (delayMs === 0) {
         this.sendBatch(batch);
       } else {
-        console.warn('throttling');
         delayExecution(() => this.sendReadyBatches(), delayMs);
         break;
       }
@@ -678,6 +677,7 @@ export class BulkWriter {
           .filter(batch => batch.state === BatchState.SENT)
           .find(batch => batch.docPaths.has(path)) !== undefined;
       if (isRefInFlight) {
+        // eslint-disable-next-line no-console
         console.warn(
           '[BulkWriter]',
           `Duplicate write to document "${path}" detected.`,


### PR DESCRIPTION
I allowed `console.error` because we pass in `console.error` as the `onError` handler in `Watch.onSnapshot`. 

Should I add this rule to the tests directory as well? If so, should I just c/p the rule, or make another overrides object that includes both `/src` and `/test`?