### PR TITLE
fix: Extended support for generics on some firestore methods.

### DIFF
--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -32,7 +32,7 @@ declare namespace FirebaseFirestore {
    * paths (e.g. 'foo' or 'foo.baz') mapped to values. Fields that contain dots
    * reference nested fields within the document.
    */
-  export type UpdateData = {[fieldPath: string]: any};
+  export type UpdateData<T = DocumentData> = {[fieldPath in keyof T]: T[fieldPath]};
 
   /**
    * Sets or disables the log function for all active Firestore instances.
@@ -187,7 +187,7 @@ declare namespace FirebaseFirestore {
      * @param collectionPath A slash-separated path to a collection.
      * @return The `CollectionReference` instance.
      */
-    collection<T>(collectionPath: string): CollectionReference<T>;
+    collection<T = DocumentData>(collectionPath: string): CollectionReference<T>;
 
     /**
      * Gets a `DocumentReference` instance that refers to the document at the
@@ -196,7 +196,7 @@ declare namespace FirebaseFirestore {
      * @param documentPath A slash-separated path to a document.
      * @return The `DocumentReference` instance.
      */
-    doc<T>(documentPath: string): DocumentReference<T>;
+    doc<T = DocumentData>(documentPath: string): DocumentReference<T>;
 
     /**
      * Creates and returns a new Query that includes all documents in the
@@ -208,7 +208,7 @@ declare namespace FirebaseFirestore {
      * will be included. Cannot contain a slash.
      * @return The created Query.
      */
-    collectionGroup<T>(collectionId: string): Query<T>;
+    collectionGroup<T = DocumentData>(collectionId: string): Query<T>;
 
     /**
      * Retrieves multiple documents from Firestore.
@@ -223,7 +223,7 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll<T>(...documentRefsOrReadOptions: Array<DocumentReference<T> | ReadOptions>):
+    getAll<T = DocumentData>(...documentRefsOrReadOptions: Array<DocumentReference<T> | ReadOptions>):
         Promise<Array<DocumentSnapshot<T>>>;
 
     /**
@@ -239,7 +239,7 @@ declare namespace FirebaseFirestore {
      *
      * @returns A Promise that resolves with an array of CollectionReferences.
      */
-    listCollections<T>() : Promise<Array<CollectionReference<T>>>;
+    listCollections<T = DocumentData>() : Promise<Array<CollectionReference<T>>>;
 
     /**
      * Executes the given updateFunction and commits the changes applied within
@@ -625,14 +625,14 @@ declare namespace FirebaseFirestore {
      * @param collectionPath A slash-separated path to a collection.
      * @return The `CollectionReference` instance.
      */
-    collection(collectionPath: string): CollectionReference<DocumentData>;
+    collection<V = DocumentData>(collectionPath: string): CollectionReference<V>;
 
     /**
      * Fetches the subcollections that are direct children of this document.
      *
      * @returns A Promise that resolves with an array of CollectionReferences.
      */
-    listCollections() : Promise<Array<CollectionReference<DocumentData>>>;
+    listCollections<V = DocumentData>() : Promise<Array<CollectionReference<V>>>;
 
     /**
      * Creates a document referred to by this `DocumentReference` with the
@@ -666,7 +666,7 @@ declare namespace FirebaseFirestore {
      * @param precondition A Precondition to enforce on this update.
      * @return A Promise resolved with the write time of this update.
      */
-    update(data: UpdateData, precondition?: Precondition): Promise<WriteResult>;
+    update(data: UpdateData<T>, precondition?: Precondition): Promise<WriteResult>;
 
     /**
      * Updates fields in the document referred to by this `DocumentReference`.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -187,7 +187,7 @@ declare namespace FirebaseFirestore {
      * @param collectionPath A slash-separated path to a collection.
      * @return The `CollectionReference` instance.
      */
-    collection(collectionPath: string): CollectionReference<DocumentData>;
+    collection<T>(collectionPath: string): CollectionReference<T>;
 
     /**
      * Gets a `DocumentReference` instance that refers to the document at the
@@ -196,7 +196,7 @@ declare namespace FirebaseFirestore {
      * @param documentPath A slash-separated path to a document.
      * @return The `DocumentReference` instance.
      */
-    doc(documentPath: string): DocumentReference<DocumentData>;
+    doc<T>(documentPath: string): DocumentReference<T>;
 
     /**
      * Creates and returns a new Query that includes all documents in the
@@ -208,7 +208,7 @@ declare namespace FirebaseFirestore {
      * will be included. Cannot contain a slash.
      * @return The created Query.
      */
-    collectionGroup(collectionId: string): Query<DocumentData>;
+    collectionGroup<T>(collectionId: string): Query<T>;
 
     /**
      * Retrieves multiple documents from Firestore.
@@ -223,8 +223,8 @@ declare namespace FirebaseFirestore {
      * @return A Promise that resolves with an array of resulting document
      * snapshots.
      */
-    getAll(...documentRefsOrReadOptions: Array<DocumentReference<DocumentData> | ReadOptions>):
-        Promise<Array<DocumentSnapshot<DocumentData>>>;
+    getAll<T>(...documentRefsOrReadOptions: Array<DocumentReference<T> | ReadOptions>):
+        Promise<Array<DocumentSnapshot<T>>>;
 
     /**
      * Terminates the Firestore client and closes all open streams.
@@ -239,7 +239,7 @@ declare namespace FirebaseFirestore {
      *
      * @returns A Promise that resolves with an array of CollectionReferences.
      */
-    listCollections() : Promise<Array<CollectionReference<DocumentData>>>;
+    listCollections<T>() : Promise<Array<CollectionReference<T>>>;
 
     /**
      * Executes the given updateFunction and commits the changes applied within


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [X] Code coverage does not decrease (only the types were changed, this should be ok)
- [X] Appropriate docs were updated (not necessary)

As for tests: `npm test` and `lint` both work but I can't run `npm run samples-test` because `gcloud` installation fails with the following:
```
node-pre-gyp http 403 https://storage.googleapis.com/grpc-precompiled-binaries/node/grpc/v0.14.1/node-v64-linux-x64.tar.gz
node-pre-gyp ERR! Tried to download: https://storage.googleapis.com/grpc-precompiled-binaries/node/grpc/v0.14.1/node-v64-linux-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for grpc@0.14.1 and node@10.17.0 (node-v64 ABI) (falling back to source compile with node-gyp) 
node-pre-gyp http 403 status code downloading tarball https://storage.googleapis.com/grpc-precompiled-binaries/node/grpc/v0.14.1/node-v64-linux-x64.tar.gz 
n
```
So I can't run `npm run samples-test` and `npm run system-test`.

Fixes #1231 🦕
