### PR TITLE
build: use bazel build in synthtool

### DIFF
--- a/dev/protos/firestore_admin_v1_proto_api.js
+++ b/dev/protos/firestore_admin_v1_proto_api.js
@@ -2109,7 +2109,7 @@
                             /**
                              * Order enum.
                              * @name google.firestore.admin.v1.Index.IndexField.Order
-                             * @enum {string}
+                             * @enum {number}
                              * @property {string} ORDER_UNSPECIFIED=ORDER_UNSPECIFIED ORDER_UNSPECIFIED value
                              * @property {string} ASCENDING=ASCENDING ASCENDING value
                              * @property {string} DESCENDING=DESCENDING DESCENDING value
@@ -2125,7 +2125,7 @@
                             /**
                              * ArrayConfig enum.
                              * @name google.firestore.admin.v1.Index.IndexField.ArrayConfig
-                             * @enum {string}
+                             * @enum {number}
                              * @property {string} ARRAY_CONFIG_UNSPECIFIED=ARRAY_CONFIG_UNSPECIFIED ARRAY_CONFIG_UNSPECIFIED value
                              * @property {string} CONTAINS=CONTAINS CONTAINS value
                              */
@@ -2142,7 +2142,7 @@
                         /**
                          * QueryScope enum.
                          * @name google.firestore.admin.v1.Index.QueryScope
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} QUERY_SCOPE_UNSPECIFIED=QUERY_SCOPE_UNSPECIFIED QUERY_SCOPE_UNSPECIFIED value
                          * @property {string} COLLECTION=COLLECTION COLLECTION value
                          * @property {string} COLLECTION_GROUP=COLLECTION_GROUP COLLECTION_GROUP value
@@ -2158,7 +2158,7 @@
                         /**
                          * State enum.
                          * @name google.firestore.admin.v1.Index.State
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} STATE_UNSPECIFIED=STATE_UNSPECIFIED STATE_UNSPECIFIED value
                          * @property {string} CREATING=CREATING CREATING value
                          * @property {string} READY=READY READY value
@@ -2773,7 +2773,7 @@
                             /**
                              * ChangeType enum.
                              * @name google.firestore.admin.v1.FieldOperationMetadata.IndexConfigDelta.ChangeType
-                             * @enum {string}
+                             * @enum {number}
                              * @property {string} CHANGE_TYPE_UNSPECIFIED=CHANGE_TYPE_UNSPECIFIED CHANGE_TYPE_UNSPECIFIED value
                              * @property {string} ADD=ADD ADD value
                              * @property {string} REMOVE=REMOVE REMOVE value
@@ -3448,7 +3448,7 @@
                     /**
                      * OperationState enum.
                      * @name google.firestore.admin.v1.OperationState
-                     * @enum {string}
+                     * @enum {number}
                      * @property {string} OPERATION_STATE_UNSPECIFIED=OPERATION_STATE_UNSPECIFIED OPERATION_STATE_UNSPECIFIED value
                      * @property {string} INITIALIZING=INITIALIZING INITIALIZING value
                      * @property {string} PROCESSING=PROCESSING PROCESSING value
@@ -3923,7 +3923,7 @@
             /**
              * FieldBehavior enum.
              * @name google.api.FieldBehavior
-             * @enum {string}
+             * @enum {number}
              * @property {string} FIELD_BEHAVIOR_UNSPECIFIED=FIELD_BEHAVIOR_UNSPECIFIED FIELD_BEHAVIOR_UNSPECIFIED value
              * @property {string} OPTIONAL=OPTIONAL OPTIONAL value
              * @property {string} REQUIRED=REQUIRED REQUIRED value
@@ -4118,7 +4118,7 @@
                 /**
                  * History enum.
                  * @name google.api.ResourceDescriptor.History
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} HISTORY_UNSPECIFIED=HISTORY_UNSPECIFIED HISTORY_UNSPECIFIED value
                  * @property {string} ORIGINALLY_SINGLE_PATTERN=ORIGINALLY_SINGLE_PATTERN ORIGINALLY_SINGLE_PATTERN value
                  * @property {string} FUTURE_MULTI_PATTERN=FUTURE_MULTI_PATTERN FUTURE_MULTI_PATTERN value
@@ -5461,7 +5461,7 @@
                 /**
                  * Type enum.
                  * @name google.protobuf.FieldDescriptorProto.Type
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} TYPE_DOUBLE=TYPE_DOUBLE TYPE_DOUBLE value
                  * @property {string} TYPE_FLOAT=TYPE_FLOAT TYPE_FLOAT value
                  * @property {string} TYPE_INT64=TYPE_INT64 TYPE_INT64 value
@@ -5507,7 +5507,7 @@
                 /**
                  * Label enum.
                  * @name google.protobuf.FieldDescriptorProto.Label
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} LABEL_OPTIONAL=LABEL_OPTIONAL LABEL_OPTIONAL value
                  * @property {string} LABEL_REQUIRED=LABEL_REQUIRED LABEL_REQUIRED value
                  * @property {string} LABEL_REPEATED=LABEL_REPEATED LABEL_REPEATED value
@@ -6484,7 +6484,7 @@
                 /**
                  * OptimizeMode enum.
                  * @name google.protobuf.FileOptions.OptimizeMode
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} SPEED=SPEED SPEED value
                  * @property {string} CODE_SIZE=CODE_SIZE CODE_SIZE value
                  * @property {string} LITE_RUNTIME=LITE_RUNTIME LITE_RUNTIME value
@@ -6942,7 +6942,7 @@
                 /**
                  * CType enum.
                  * @name google.protobuf.FieldOptions.CType
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} STRING=STRING STRING value
                  * @property {string} CORD=CORD CORD value
                  * @property {string} STRING_PIECE=STRING_PIECE STRING_PIECE value
@@ -6958,7 +6958,7 @@
                 /**
                  * JSType enum.
                  * @name google.protobuf.FieldOptions.JSType
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} JS_NORMAL=JS_NORMAL JS_NORMAL value
                  * @property {string} JS_STRING=JS_STRING JS_STRING value
                  * @property {string} JS_NUMBER=JS_NUMBER JS_NUMBER value
@@ -9085,7 +9085,7 @@
             /**
              * NullValue enum.
              * @name google.protobuf.NullValue
-             * @enum {string}
+             * @enum {number}
              * @property {string} NULL_VALUE=NULL_VALUE NULL_VALUE value
              */
             protobuf.NullValue = (function() {

--- a/dev/protos/firestore_v1_proto_api.js
+++ b/dev/protos/firestore_v1_proto_api.js
@@ -180,7 +180,7 @@
             /**
              * LimitType enum.
              * @name firestore.BundledQuery.LimitType
-             * @enum {string}
+             * @enum {number}
              * @property {string} FIRST=FIRST FIRST value
              * @property {string} LAST=LAST LAST value
              */
@@ -2092,7 +2092,7 @@
                 /**
                  * Type enum.
                  * @name google.protobuf.FieldDescriptorProto.Type
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} TYPE_DOUBLE=TYPE_DOUBLE TYPE_DOUBLE value
                  * @property {string} TYPE_FLOAT=TYPE_FLOAT TYPE_FLOAT value
                  * @property {string} TYPE_INT64=TYPE_INT64 TYPE_INT64 value
@@ -2138,7 +2138,7 @@
                 /**
                  * Label enum.
                  * @name google.protobuf.FieldDescriptorProto.Label
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} LABEL_OPTIONAL=LABEL_OPTIONAL LABEL_OPTIONAL value
                  * @property {string} LABEL_REQUIRED=LABEL_REQUIRED LABEL_REQUIRED value
                  * @property {string} LABEL_REPEATED=LABEL_REPEATED LABEL_REPEATED value
@@ -3115,7 +3115,7 @@
                 /**
                  * OptimizeMode enum.
                  * @name google.protobuf.FileOptions.OptimizeMode
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} SPEED=SPEED SPEED value
                  * @property {string} CODE_SIZE=CODE_SIZE CODE_SIZE value
                  * @property {string} LITE_RUNTIME=LITE_RUNTIME LITE_RUNTIME value
@@ -3573,7 +3573,7 @@
                 /**
                  * CType enum.
                  * @name google.protobuf.FieldOptions.CType
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} STRING=STRING STRING value
                  * @property {string} CORD=CORD CORD value
                  * @property {string} STRING_PIECE=STRING_PIECE STRING_PIECE value
@@ -3589,7 +3589,7 @@
                 /**
                  * JSType enum.
                  * @name google.protobuf.FieldOptions.JSType
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} JS_NORMAL=JS_NORMAL JS_NORMAL value
                  * @property {string} JS_STRING=JS_STRING JS_STRING value
                  * @property {string} JS_NUMBER=JS_NUMBER JS_NUMBER value
@@ -5341,7 +5341,7 @@
             /**
              * NullValue enum.
              * @name google.protobuf.NullValue
-             * @enum {string}
+             * @enum {number}
              * @property {string} NULL_VALUE=NULL_VALUE NULL_VALUE value
              */
             protobuf.NullValue = (function() {
@@ -11918,7 +11918,7 @@
                     /**
                      * TargetChangeType enum.
                      * @name google.firestore.v1.TargetChange.TargetChangeType
-                     * @enum {string}
+                     * @enum {number}
                      * @property {string} NO_CHANGE=NO_CHANGE NO_CHANGE value
                      * @property {string} ADD=ADD ADD value
                      * @property {string} REMOVE=REMOVE REMOVE value
@@ -12989,7 +12989,7 @@
                         /**
                          * Operator enum.
                          * @name google.firestore.v1.StructuredQuery.CompositeFilter.Operator
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} OPERATOR_UNSPECIFIED=OPERATOR_UNSPECIFIED OPERATOR_UNSPECIFIED value
                          * @property {string} AND=AND AND value
                          */
@@ -13157,7 +13157,7 @@
                         /**
                          * Operator enum.
                          * @name google.firestore.v1.StructuredQuery.FieldFilter.Operator
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} OPERATOR_UNSPECIFIED=OPERATOR_UNSPECIFIED OPERATOR_UNSPECIFIED value
                          * @property {string} LESS_THAN=LESS_THAN LESS_THAN value
                          * @property {string} LESS_THAN_OR_EQUAL=LESS_THAN_OR_EQUAL LESS_THAN_OR_EQUAL value
@@ -13313,7 +13313,7 @@
                         /**
                          * Operator enum.
                          * @name google.firestore.v1.StructuredQuery.UnaryFilter.Operator
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} OPERATOR_UNSPECIFIED=OPERATOR_UNSPECIFIED OPERATOR_UNSPECIFIED value
                          * @property {string} IS_NAN=IS_NAN IS_NAN value
                          * @property {string} IS_NULL=IS_NULL IS_NULL value
@@ -13623,7 +13623,7 @@
                     /**
                      * Direction enum.
                      * @name google.firestore.v1.StructuredQuery.Direction
-                     * @enum {string}
+                     * @enum {number}
                      * @property {string} DIRECTION_UNSPECIFIED=DIRECTION_UNSPECIFIED DIRECTION_UNSPECIFIED value
                      * @property {string} ASCENDING=ASCENDING ASCENDING value
                      * @property {string} DESCENDING=DESCENDING DESCENDING value
@@ -14271,7 +14271,7 @@
                         /**
                          * ServerValue enum.
                          * @name google.firestore.v1.DocumentTransform.FieldTransform.ServerValue
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} SERVER_VALUE_UNSPECIFIED=SERVER_VALUE_UNSPECIFIED SERVER_VALUE_UNSPECIFIED value
                          * @property {string} REQUEST_TIME=REQUEST_TIME REQUEST_TIME value
                          */
@@ -15332,7 +15332,7 @@
             /**
              * FieldBehavior enum.
              * @name google.api.FieldBehavior
-             * @enum {string}
+             * @enum {number}
              * @property {string} FIELD_BEHAVIOR_UNSPECIFIED=FIELD_BEHAVIOR_UNSPECIFIED FIELD_BEHAVIOR_UNSPECIFIED value
              * @property {string} OPTIONAL=OPTIONAL OPTIONAL value
              * @property {string} REQUIRED=REQUIRED REQUIRED value
@@ -15527,7 +15527,7 @@
                 /**
                  * History enum.
                  * @name google.api.ResourceDescriptor.History
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} HISTORY_UNSPECIFIED=HISTORY_UNSPECIFIED HISTORY_UNSPECIFIED value
                  * @property {string} ORIGINALLY_SINGLE_PATTERN=ORIGINALLY_SINGLE_PATTERN ORIGINALLY_SINGLE_PATTERN value
                  * @property {string} FUTURE_MULTI_PATTERN=FUTURE_MULTI_PATTERN FUTURE_MULTI_PATTERN value

--- a/dev/protos/firestore_v1beta1_proto_api.js
+++ b/dev/protos/firestore_v1beta1_proto_api.js
@@ -1379,7 +1379,7 @@
                 /**
                  * Type enum.
                  * @name google.protobuf.FieldDescriptorProto.Type
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} TYPE_DOUBLE=TYPE_DOUBLE TYPE_DOUBLE value
                  * @property {string} TYPE_FLOAT=TYPE_FLOAT TYPE_FLOAT value
                  * @property {string} TYPE_INT64=TYPE_INT64 TYPE_INT64 value
@@ -1425,7 +1425,7 @@
                 /**
                  * Label enum.
                  * @name google.protobuf.FieldDescriptorProto.Label
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} LABEL_OPTIONAL=LABEL_OPTIONAL LABEL_OPTIONAL value
                  * @property {string} LABEL_REQUIRED=LABEL_REQUIRED LABEL_REQUIRED value
                  * @property {string} LABEL_REPEATED=LABEL_REPEATED LABEL_REPEATED value
@@ -2402,7 +2402,7 @@
                 /**
                  * OptimizeMode enum.
                  * @name google.protobuf.FileOptions.OptimizeMode
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} SPEED=SPEED SPEED value
                  * @property {string} CODE_SIZE=CODE_SIZE CODE_SIZE value
                  * @property {string} LITE_RUNTIME=LITE_RUNTIME LITE_RUNTIME value
@@ -2860,7 +2860,7 @@
                 /**
                  * CType enum.
                  * @name google.protobuf.FieldOptions.CType
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} STRING=STRING STRING value
                  * @property {string} CORD=CORD CORD value
                  * @property {string} STRING_PIECE=STRING_PIECE STRING_PIECE value
@@ -2876,7 +2876,7 @@
                 /**
                  * JSType enum.
                  * @name google.protobuf.FieldOptions.JSType
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} JS_NORMAL=JS_NORMAL JS_NORMAL value
                  * @property {string} JS_STRING=JS_STRING JS_STRING value
                  * @property {string} JS_NUMBER=JS_NUMBER JS_NUMBER value
@@ -4628,7 +4628,7 @@
             /**
              * NullValue enum.
              * @name google.protobuf.NullValue
-             * @enum {string}
+             * @enum {number}
              * @property {string} NULL_VALUE=NULL_VALUE NULL_VALUE value
              */
             protobuf.NullValue = (function() {
@@ -10856,7 +10856,7 @@
                     /**
                      * TargetChangeType enum.
                      * @name google.firestore.v1beta1.TargetChange.TargetChangeType
-                     * @enum {string}
+                     * @enum {number}
                      * @property {string} NO_CHANGE=NO_CHANGE NO_CHANGE value
                      * @property {string} ADD=ADD ADD value
                      * @property {string} REMOVE=REMOVE REMOVE value
@@ -11670,7 +11670,7 @@
                         /**
                          * Operator enum.
                          * @name google.firestore.v1beta1.StructuredQuery.CompositeFilter.Operator
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} OPERATOR_UNSPECIFIED=OPERATOR_UNSPECIFIED OPERATOR_UNSPECIFIED value
                          * @property {string} AND=AND AND value
                          */
@@ -11838,7 +11838,7 @@
                         /**
                          * Operator enum.
                          * @name google.firestore.v1beta1.StructuredQuery.FieldFilter.Operator
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} OPERATOR_UNSPECIFIED=OPERATOR_UNSPECIFIED OPERATOR_UNSPECIFIED value
                          * @property {string} LESS_THAN=LESS_THAN LESS_THAN value
                          * @property {string} LESS_THAN_OR_EQUAL=LESS_THAN_OR_EQUAL LESS_THAN_OR_EQUAL value
@@ -11994,7 +11994,7 @@
                         /**
                          * Operator enum.
                          * @name google.firestore.v1beta1.StructuredQuery.UnaryFilter.Operator
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} OPERATOR_UNSPECIFIED=OPERATOR_UNSPECIFIED OPERATOR_UNSPECIFIED value
                          * @property {string} IS_NAN=IS_NAN IS_NAN value
                          * @property {string} IS_NULL=IS_NULL IS_NULL value
@@ -12304,7 +12304,7 @@
                     /**
                      * Direction enum.
                      * @name google.firestore.v1beta1.StructuredQuery.Direction
-                     * @enum {string}
+                     * @enum {number}
                      * @property {string} DIRECTION_UNSPECIFIED=DIRECTION_UNSPECIFIED DIRECTION_UNSPECIFIED value
                      * @property {string} ASCENDING=ASCENDING ASCENDING value
                      * @property {string} DESCENDING=DESCENDING DESCENDING value
@@ -12925,7 +12925,7 @@
                         /**
                          * ServerValue enum.
                          * @name google.firestore.v1beta1.DocumentTransform.FieldTransform.ServerValue
-                         * @enum {string}
+                         * @enum {number}
                          * @property {string} SERVER_VALUE_UNSPECIFIED=SERVER_VALUE_UNSPECIFIED SERVER_VALUE_UNSPECIFIED value
                          * @property {string} REQUEST_TIME=REQUEST_TIME REQUEST_TIME value
                          */
@@ -13986,7 +13986,7 @@
             /**
              * FieldBehavior enum.
              * @name google.api.FieldBehavior
-             * @enum {string}
+             * @enum {number}
              * @property {string} FIELD_BEHAVIOR_UNSPECIFIED=FIELD_BEHAVIOR_UNSPECIFIED FIELD_BEHAVIOR_UNSPECIFIED value
              * @property {string} OPTIONAL=OPTIONAL OPTIONAL value
              * @property {string} REQUIRED=REQUIRED REQUIRED value
@@ -14181,7 +14181,7 @@
                 /**
                  * History enum.
                  * @name google.api.ResourceDescriptor.History
-                 * @enum {string}
+                 * @enum {number}
                  * @property {string} HISTORY_UNSPECIFIED=HISTORY_UNSPECIFIED HISTORY_UNSPECIFIED value
                  * @property {string} ORIGINALLY_SINGLE_PATTERN=ORIGINALLY_SINGLE_PATTERN ORIGINALLY_SINGLE_PATTERN value
                  * @property {string} FUTURE_MULTI_PATTERN=FUTURE_MULTI_PATTERN FUTURE_MULTI_PATTERN value

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,16 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-firestore.git",
-        "sha": "e32198cbee4f2e52954e23a34cd320d143e23b66"
+        "remote": "git@github.com:googleapis/nodejs-firestore.git",
+        "sha": "b02925f44c63b0ac58303fdcd4a2b1f59b5de463"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "0a602be7b3835b51d59daf8f6f5dc2dc22f69d7e",
-        "internalRef": "318331819"
+        "sha": "8500bd52067f0842f56d81369ac36087afe617f8",
+        "internalRef": "320626855"
       }
     },
     {
@@ -29,8 +29,8 @@
         "source": "googleapis",
         "apiName": "firestore-admin",
         "apiVersion": "v1",
-        "language": "typescript",
-        "generator": "gapic-generator-typescript"
+        "language": "nodejs",
+        "generator": "bazel"
       }
     },
     {
@@ -38,8 +38,8 @@
         "source": "googleapis",
         "apiName": "firestore",
         "apiVersion": "v1beta1",
-        "language": "typescript",
-        "generator": "gapic-generator-typescript"
+        "language": "nodejs",
+        "generator": "bazel"
       }
     },
     {
@@ -47,8 +47,8 @@
         "source": "googleapis",
         "apiName": "firestore",
         "apiVersion": "v1",
-        "language": "typescript",
-        "generator": "gapic-generator-typescript"
+        "language": "nodejs",
+        "generator": "bazel"
       }
     }
   ]

--- a/synth.py
+++ b/synth.py
@@ -10,22 +10,16 @@ logging.basicConfig(level=logging.DEBUG)
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
 
-gapic_micro = gcp.GAPICMicrogenerator()
+gapic_bazel = gcp.GAPICBazel()
 
-v1_admin_library = gapic_micro.typescript_library(
-    "firestore-admin", "v1", proto_path="/google/firestore/admin/v1",
-    generator_args={'package-name': '@google-cloud/firestore', 
-    'grpc-service-config': 'google/firestore/admin/v1/firestore_admin_grpc_service_config.json'}
+v1_admin_library = gapic_bazel.node_library(
+    "firestore-admin", "v1", proto_path="/google/firestore/admin/v1"
 )
-v1beta1_library = gapic_micro.typescript_library(
-    "firestore", "v1beta1", proto_path="/google/firestore/v1beta1",
-    generator_args={'package-name': '@google-cloud/firestore', 
-    'grpc-service-config': 'google/firestore/v1beta1/firestore_grpc_service_config.json'}
+v1beta1_library = gapic_bazel.node_library(
+    "firestore", "v1beta1", proto_path="/google/firestore/v1beta1"
 )
-v1_library = gapic_micro.typescript_library(
-    "firestore", "v1", proto_path="/google/firestore/v1",
-    generator_args={'package-name': '@google-cloud/firestore', 
-    'grpc-service-config': 'google/firestore/v1/firestore_grpc_service_config.json'}
+v1_library = gapic_bazel.node_library(
+    "firestore", "v1", proto_path="/google/firestore/v1"
 )
 
 # skip index, protos, package.json, and README.md


### PR DESCRIPTION
This PR moves Firestore client library generation from Docker to Bazel. 

Note: the `synthtool` execution may be slow if you run it for the first time (it will rebuild protobuf sources). The subsequent runs are fast.

I re-ran `synthtool` to make sure everything works. Not sure what is the reason of jsdoc comment change for enums though.