### PR TITLE
fix: add Firestore.bulkWriter to firestore.d.ts

### DIFF
--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -286,6 +286,13 @@ declare namespace FirebaseFirestore {
      * atomic operation.
      */
     batch(): WriteBatch;
+
+    /**
+     * Creates a [BulkWriter]{@link BulkWriter}, used for performing
+     * multiple writes in parallel. Gradually ramps up writes as specified
+     * by the 500/50/5 rule.
+     */
+    bulkWriter(options?: BulkWriterOptions): BulkWriter;
   }
 
   /**


### PR DESCRIPTION
This method was missing in PR https://github.com/googleapis/nodejs-firestore/pull/1252

Fixes #1271
