### PR TITLE
feat: allow `Settings.host` to be used when `Settings.servicePath` is set

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -504,14 +504,24 @@ export class Firestore implements firestore.Firestore {
 
     if (settings.host !== undefined) {
       validateHost('settings.host', settings.host);
-      if (settings.servicePath !== undefined) {
-        throw new Error(
-          'Cannot set both "settings.host" and "settings.servicePath".'
+      if (
+        settings.servicePath !== undefined &&
+        settings.servicePath !== settings.host
+      ) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '"settings.servicePath" does not match "settings.host". ' +
+            'Using "settings.host" as host.'
         );
       }
-      if (settings.apiEndpoint !== undefined) {
-        throw new Error(
-          'Cannot set both "settings.host" and "settings.apiEndpoint".'
+      if (
+        settings.apiEndpoint !== undefined &&
+        settings.apiEndpoint !== settings.host
+      ) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '"settings.apiEndpoint" does not match "settings.host". ' +
+            'Using "settings.host" as host.'
         );
       }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -500,6 +500,10 @@ export class Firestore implements firestore.Firestore {
     } else if (settings.host !== undefined) {
       validateHost('settings.host', settings.host);
       url = new URL(`http://${settings.host}`);
+    }
+
+    // Only store the host if a valid value was provided in `host`.
+    if (url !== null) {
       if (
         (settings.servicePath !== undefined &&
           settings.servicePath !== url.hostname) ||
@@ -514,21 +518,18 @@ export class Firestore implements firestore.Firestore {
             }). Using the provided host.`
         );
       }
-    }
 
-    // Only store the host if a valid value was provided in `host`.
-    if (url !== null) {
       settings.servicePath = url.hostname;
       if (url.port !== '' && settings.port === undefined) {
         settings.port = Number(url.port);
       }
-    }
 
-    // We need to remove the `host` and `apiEndpoint` setting, in case a user
-    // calls `settings()`, which will compare the the provided `host` to the
-    // existing hostname stored on `servicePath`.
-    delete settings.host;
-    delete settings.apiEndpoint;
+      // We need to remove the `host` and `apiEndpoint` setting, in case a user
+      // calls `settings()`, which will compare the the provided `host` to the
+      // existing hostname stored on `servicePath`.
+      delete settings.host;
+      delete settings.apiEndpoint;
+    }
 
     if (settings.ssl !== undefined) {
       validateBoolean('settings.ssl', settings.ssl);

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -489,7 +489,7 @@ export class Firestore implements firestore.Firestore {
     this._settingsFrozen = true;
   }
 
-  private validateAndApplySettings(settings: FirebaseFirestore.Settings): void {
+  private validateAndApplySettings(settings: firestore.Settings): void {
     if (settings.projectId !== undefined) {
       validateString('settings.projectId', settings.projectId);
       this._projectId = settings.projectId;
@@ -507,13 +507,10 @@ export class Firestore implements firestore.Firestore {
       ) {
         // eslint-disable-next-line no-console
         console.warn(
-          `The provided host (${settings.host}) in "settings" does not match the ` +
-            `existing host (${
-              settings.servicePath !== undefined
-                ? settings.servicePath
-                : settings.apiEndpoint
-            }). ` +
-            'Using the provided host.'
+          `The provided host (${settings.host}) in "settings" does not ` +
+            `match the existing host (${
+              settings.servicePath ?? settings.apiEndpoint
+            }). Using the provided host.`
         );
       }
     }

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -505,23 +505,20 @@ export class Firestore implements firestore.Firestore {
     if (settings.host !== undefined) {
       validateHost('settings.host', settings.host);
       if (
-        settings.servicePath !== undefined &&
-        settings.servicePath !== settings.host
+        (settings.servicePath !== undefined &&
+          settings.servicePath !== settings.host) ||
+        (settings.apiEndpoint !== undefined &&
+          settings.apiEndpoint !== settings.host)
       ) {
         // eslint-disable-next-line no-console
         console.warn(
-          '"settings.servicePath" does not match "settings.host". ' +
-            'Using "settings.host" as host.'
-        );
-      }
-      if (
-        settings.apiEndpoint !== undefined &&
-        settings.apiEndpoint !== settings.host
-      ) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          '"settings.apiEndpoint" does not match "settings.host". ' +
-            'Using "settings.host" as host.'
+          `The provided host (${settings.host}) in "settings" does not match the ` +
+            `existing host (${
+              settings.servicePath !== undefined
+                ? settings.servicePath
+                : settings.apiEndpoint
+            }). ` +
+            'Using the provided host.'
         );
       }
 
@@ -530,10 +527,11 @@ export class Firestore implements firestore.Firestore {
       if (url.port !== '' && settings.port === undefined) {
         settings.port = Number(url.port);
       }
-      // We need to remove the `host` setting, in case a user calls `settings()`,
-      // which will again enforce that `host` and `servicePath` are not both
-      // specified.
+      // We need to remove the `host` and `apiEndpoint` setting, in case a user
+      // calls `settings()`, which will compare the the provided `host` to the
+      // existing host stored on `servicePath`.
       delete settings.host;
+      delete settings.apiEndpoint;
     }
 
     if (settings.ssl !== undefined) {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -469,9 +469,7 @@ describe('instantiation', () => {
     try {
       process.env.FIRESTORE_EMULATOR_HOST = 'foo';
       const firestore = new Firestore.Firestore({servicePath: 'bar'});
-      // The call to `settings()` used to throw ("Cannot set both 'settings.host' and 'settings.servicePath'").
-      // See https://github.com/googleapis/nodejs-firestore/pull/696#issuecomment-505822099
-      firestore.settings({});
+      expect(firestore._settings.servicePath).to.equal('foo');
     } finally {
       if (oldValue) {
         process.env.FIRESTORE_EMULATOR_HOST = oldValue;
@@ -488,7 +486,7 @@ describe('instantiation', () => {
       process.env.FIRESTORE_EMULATOR_HOST = 'new';
       const firestore = new Firestore.Firestore({servicePath: 'old'});
       firestore['validateAndApplySettings'] = settings => {
-        expect(settings!.servicePath).to.equal('new');
+        expect(settings.servicePath).to.equal('new');
         done();
       };
       firestore.settings({});
@@ -508,7 +506,7 @@ describe('instantiation', () => {
       process.env.FIRESTORE_EMULATOR_HOST = 'new';
       const firestore = new Firestore.Firestore({customHeaders: {foo: 'bar'}});
       firestore['validateAndApplySettings'] = settings => {
-        expect(settings!.customHeaders.foo).to.equal('bar');
+        expect(settings.customHeaders.foo).to.equal('bar');
         done();
       };
       firestore.settings({});

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -424,7 +424,7 @@ describe('instantiation', () => {
     }
   });
 
-  it('uses "settings.host" takes precedence without FIRESTORE_EMULATOR_HOST', () => {
+  it('"settings.host" takes precedence without FIRESTORE_EMULATOR_HOST', () => {
     const oldValue = process.env.FIRESTORE_EMULATOR_HOST;
 
     try {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -424,14 +424,25 @@ describe('instantiation', () => {
     }
   });
 
-  it('validates only one endpoint is provided', () => {
-    expect(() => {
-      new Firestore.Firestore({host: 'foo', apiEndpoint: 'foo'});
-    }).to.throw('Cannot set both "settings.host" and "settings.apiEndpoint".');
+  it('uses "settings.host" when more than one option is provided', () => {
+    let firestore = new Firestore.Firestore({
+      apiEndpoint: 'foo',
+    });
+    firestore.settings({host: 'bar'});
+    expect(firestore._settings.servicePath).to.equal('bar');
 
-    expect(() => {
-      new Firestore.Firestore({host: 'foo', servicePath: 'foo'});
-    }).to.throw('Cannot set both "settings.host" and "settings.servicePath".');
+    firestore = new Firestore.Firestore({
+      servicePath: 'foo',
+    });
+    firestore.settings({host: 'bar'});
+    expect(firestore._settings.servicePath).to.equal('bar');
+
+    firestore = new Firestore.Firestore({
+      apiEndpoint: 'boo',
+      servicePath: 'foo',
+    });
+    firestore.settings({host: 'bar'});
+    expect(firestore._settings.servicePath).to.equal('bar');
   });
 
   it('FIRESTORE_EMULATOR_HOST ignores servicePath', () => {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -424,25 +424,37 @@ describe('instantiation', () => {
     }
   });
 
-  it('uses "settings.host" when more than one option is provided', () => {
-    let firestore = new Firestore.Firestore({
-      apiEndpoint: 'api-host',
-    });
-    firestore.settings({host: 'new-host:100'});
-    expect(firestore._settings.servicePath).to.equal('new-host');
+  it('uses "settings.host" takes precedence without FIRESTORE_EMULATOR_HOST', () => {
+    const oldValue = process.env.FIRESTORE_EMULATOR_HOST;
 
-    firestore = new Firestore.Firestore({
-      servicePath: 'service-host',
-    });
-    firestore.settings({host: 'new-host:100'});
-    expect(firestore._settings.servicePath).to.equal('new-host');
+    try {
+      delete process.env.FIRESTORE_EMULATOR_HOST;
 
-    firestore = new Firestore.Firestore({
-      apiEndpoint: 'api-host',
-      servicePath: 'service-host',
-    });
-    firestore.settings({host: 'new-host:100'});
-    expect(firestore._settings.servicePath).to.equal('new-host');
+      let firestore = new Firestore.Firestore({
+        apiEndpoint: 'api-host',
+      });
+      firestore.settings({host: 'new-host:100'});
+      expect(firestore._settings.servicePath).to.equal('new-host');
+
+      firestore = new Firestore.Firestore({
+        servicePath: 'service-host',
+      });
+      firestore.settings({host: 'new-host:100'});
+      expect(firestore._settings.servicePath).to.equal('new-host');
+
+      firestore = new Firestore.Firestore({
+        apiEndpoint: 'api-host',
+        servicePath: 'service-host',
+      });
+      firestore.settings({host: 'new-host:100'});
+      expect(firestore._settings.servicePath).to.equal('new-host');
+    } finally {
+      if (oldValue) {
+        process.env.FIRESTORE_EMULATOR_HOST = oldValue;
+      } else {
+        delete process.env.FIRESTORE_EMULATOR_HOST;
+      }
+    }
   });
 
   it('FIRESTORE_EMULATOR_HOST ignores host', () => {
@@ -453,6 +465,8 @@ describe('instantiation', () => {
       const firestore = new Firestore.Firestore({
         host: 'localhost:8080',
       });
+      expect(firestore._settings.servicePath).to.equal('env-host');
+      firestore.settings({host: 'localhost:8080'});
       expect(firestore._settings.servicePath).to.equal('env-host');
     } finally {
       if (oldValue) {
@@ -469,6 +483,8 @@ describe('instantiation', () => {
     try {
       process.env.FIRESTORE_EMULATOR_HOST = 'foo';
       const firestore = new Firestore.Firestore({servicePath: 'bar'});
+      expect(firestore._settings.servicePath).to.equal('foo');
+      firestore.settings({servicePath: 'bar'});
       expect(firestore._settings.servicePath).to.equal('foo');
     } finally {
       if (oldValue) {

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -426,23 +426,41 @@ describe('instantiation', () => {
 
   it('uses "settings.host" when more than one option is provided', () => {
     let firestore = new Firestore.Firestore({
-      apiEndpoint: 'foo',
+      apiEndpoint: 'api-host',
     });
-    firestore.settings({host: 'bar'});
-    expect(firestore._settings.servicePath).to.equal('bar');
+    firestore.settings({host: 'new-host:100'});
+    expect(firestore._settings.servicePath).to.equal('new-host');
 
     firestore = new Firestore.Firestore({
-      servicePath: 'foo',
+      servicePath: 'service-host',
     });
-    firestore.settings({host: 'bar'});
-    expect(firestore._settings.servicePath).to.equal('bar');
+    firestore.settings({host: 'new-host:100'});
+    expect(firestore._settings.servicePath).to.equal('new-host');
 
     firestore = new Firestore.Firestore({
-      apiEndpoint: 'boo',
-      servicePath: 'foo',
+      apiEndpoint: 'api-host',
+      servicePath: 'service-host',
     });
-    firestore.settings({host: 'bar'});
-    expect(firestore._settings.servicePath).to.equal('bar');
+    firestore.settings({host: 'new-host:100'});
+    expect(firestore._settings.servicePath).to.equal('new-host');
+  });
+
+  it('FIRESTORE_EMULATOR_HOST ignores host', () => {
+    const oldValue = process.env.FIRESTORE_EMULATOR_HOST;
+
+    try {
+      process.env.FIRESTORE_EMULATOR_HOST = 'env-host:8080';
+      const firestore = new Firestore.Firestore({
+        host: 'localhost:8080',
+      });
+      expect(firestore._settings.servicePath).to.equal('env-host');
+    } finally {
+      if (oldValue) {
+        process.env.FIRESTORE_EMULATOR_HOST = oldValue;
+      } else {
+        delete process.env.FIRESTORE_EMULATOR_HOST;
+      }
+    }
   });
 
   it('FIRESTORE_EMULATOR_HOST ignores servicePath', () => {
@@ -470,7 +488,7 @@ describe('instantiation', () => {
       process.env.FIRESTORE_EMULATOR_HOST = 'new';
       const firestore = new Firestore.Firestore({servicePath: 'old'});
       firestore['validateAndApplySettings'] = settings => {
-        expect(settings.servicePath).to.equal('new');
+        expect(settings!.servicePath).to.equal('new');
         done();
       };
       firestore.settings({});
@@ -490,7 +508,7 @@ describe('instantiation', () => {
       process.env.FIRESTORE_EMULATOR_HOST = 'new';
       const firestore = new Firestore.Firestore({customHeaders: {foo: 'bar'}});
       firestore['validateAndApplySettings'] = settings => {
-        expect(settings.customHeaders.foo).to.equal('bar');
+        expect(settings!.customHeaders.foo).to.equal('bar');
         done();
       };
       firestore.settings({});


### PR DESCRIPTION
Fixes #1265.

The existing behavior prioritized `FIRESTORE_EMULATOR_HOST` over any user-specified host when set, and prohibits setting the host more than once. This PR allows `Settings.host` to take precedence over `Settings.servicePath` and `Settings.apiEndpoint` if `FIRESTORE_EMULATOR_HOST` is not set and logs a warning when the host is overridden. Otherwise, `FIRESTORE_EMULATOR_HOST` is used as the host, regardless of any values that are passed via `Settings`.