### PR TITLE
test(conformance): fix invalid operator in where clause test

### DIFF
--- a/dev/conformance/conformance-tests/query-invalid-operator.json
+++ b/dev/conformance/conformance-tests/query-invalid-operator.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "query: invalid operator in Where clause",
-      "comment": "The !=  operator is not supported.",
+      "comment": "The ! operator is not supported.",
       "query": {
         "collPath": "projects/projectID/databases/(default)/documents/C",
         "clauses": [
@@ -13,7 +13,7 @@
                   "a"
                 ]
               },
-              "op": "!=",
+              "op": "!",
               "jsonValue": "4"
             }
           }


### PR DESCRIPTION
Recently added support for `!=` queries in [PR](https://github.com/googleapis/nodejs-firestore/pull/1292).

Fixes #1300 
