### PR TITLE
fix: allow `setLogFunction(null)`

### DIFF
--- a/dev/src/logger.ts
+++ b/dev/src/logger.ts
@@ -55,7 +55,7 @@ export function logger(
  * `null` to turn off logging.
  */
 export function setLogFunction(logger: ((msg: string) => void) | null): void {
-  validateFunction('logger', logger);
+  if (logger !== null) validateFunction('logger', logger);
   logFunction = logger;
 }
 

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -39,7 +39,7 @@ import {
 import api = proto.google.firestore.v1;
 
 // Change the argument to 'console.log' to enable debug output.
-setLogFunction(() => {});
+setLogFunction(null);
 
 const PROJECT_ID = 'test-project';
 

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -33,7 +33,7 @@ import {
 } from './util/helpers';
 
 // Change the argument to 'console.log' to enable debug output.
-setLogFunction(() => {});
+setLogFunction(null);
 
 describe('Collection interface', () => {
   let firestore: Firestore;

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -59,7 +59,7 @@ const INVALID_ARGUMENTS_TO_UPDATE = new RegExp(
 );
 
 // Change the argument to 'console.log' to enable debug output.
-setLogFunction(() => {});
+setLogFunction(null);
 
 describe('DocumentReference interface', () => {
   let firestore: Firestore;

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -51,7 +51,7 @@ const DEFAULT_SETTINGS = {
 };
 
 // Change the argument to 'console.log' to enable debug output.
-Firestore.setLogFunction(() => {});
+Firestore.setLogFunction(null);
 
 const bytesData = Buffer.from('AQI=', 'base64');
 

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -32,7 +32,7 @@ import {createInstance, InvalidApiUsage, verifyInstance} from './util/helpers';
 import api = google.firestore.v1;
 
 // Change the argument to 'console.log' to enable debug output.
-setLogFunction(() => {});
+setLogFunction(null);
 
 describe('Order', () => {
   let firestore: Firestore;

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -53,7 +53,7 @@ const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
 
 // Change the argument to 'console.log' to enable debug output.
-setLogFunction(() => {});
+setLogFunction(null);
 
 use(chaiAsPromised);
 

--- a/dev/test/transaction.ts
+++ b/dev/test/transaction.ts
@@ -45,7 +45,7 @@ const DOCUMENT_ID = 'documentId';
 const DOCUMENT_NAME = `${COLLECTION_ROOT}/${DOCUMENT_ID}`;
 
 // Change the argument to 'console.log' to enable debug output.
-Firestore.setLogFunction(() => {});
+Firestore.setLogFunction(null);
 
 /** Helper to create a transaction ID from either a string or a Uint8Array. */
 function transactionId(transaction?: Uint8Array | string): Uint8Array {

--- a/dev/test/watch.ts
+++ b/dev/test/watch.ts
@@ -46,7 +46,7 @@ import {createInstance, InvalidApiUsage, verifyInstance} from './util/helpers';
 import api = google.firestore.v1;
 
 // Change the argument to 'console.log' to enable debug output.
-setLogFunction(() => {});
+setLogFunction(null);
 
 let PROJECT_ID = process.env.PROJECT_ID;
 if (!PROJECT_ID) {

--- a/dev/test/write-batch.ts
+++ b/dev/test/write-batch.ts
@@ -40,7 +40,7 @@ import {
 const REQUEST_TIME = 'REQUEST_TIME';
 
 // Change the argument to 'console.log' to enable debug output.
-setLogFunction(() => {});
+setLogFunction(null);
 
 const PROJECT_ID = 'test-project';
 


### PR DESCRIPTION
`setLogFunction()` is typed to take a `null` value, but this doesn't actually work since it validates that `logger` is a function.

Change the logic so it only validates when `logger` is not `null`.

Looking at how `setLogFunction()` is used, it seems that it should be called with `null` instead of a no-op function. If this is contentious that commit can be reverted.
