### PR TITLE
feat: add starting/max rates to BulkWriterOptions

### DIFF
--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -357,7 +357,7 @@ export class BulkWriter {
     this.firestore._incrementBulkWritersCount();
     validateBulkWriterOptions('options', options);
 
-    if (options && !options.disableThrottling) {
+    if (options?.disableThrottling !== false) {
       this.rateLimiter = new RateLimiter(
         Number.POSITIVE_INFINITY,
         Number.POSITIVE_INFINITY,

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -366,7 +366,7 @@ export class BulkWriter {
       );
     } else {
       this.rateLimiter = new RateLimiter(
-        options?.initialOpsPerSecond || STARTING_MAXIMUM_OPS_PER_SECOND,
+        options?.initialOpsPerSecond ?? STARTING_MAXIMUM_OPS_PER_SECOND,
         RATE_LIMITER_MULTIPLIER,
         RATE_LIMITER_MULTIPLIER_MILLIS,
         options?.maxOpsPerSecond || Number.POSITIVE_INFINITY

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -356,7 +356,7 @@ export class BulkWriter {
 
   constructor(
     private readonly firestore: Firestore,
-    private readonly options?: firestore.BulkWriterOptions
+    options?: firestore.BulkWriterOptions
   ) {
     this.firestore._incrementBulkWritersCount();
     validateBulkWriterOptions(options);

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -712,7 +712,7 @@ export class Firestore implements firestore.Firestore {
    * });
    */
   bulkWriter(options?: firestore.BulkWriterOptions): BulkWriter {
-    return new BulkWriter(this, !options?.disableThrottling);
+    return new BulkWriter(this, options);
   }
 
   /**

--- a/dev/src/rate-limiter.ts
+++ b/dev/src/rate-limiter.ts
@@ -55,7 +55,7 @@ export class RateLimiter {
     private readonly initialCapacity: number,
     private readonly multiplier: number,
     private readonly multiplierMillis: number,
-    private readonly maximumCapacity: number,
+    readonly maximumCapacity: number,
     private readonly startTimeMillis = Date.now()
   ) {
     this.availableTokens = initialCapacity;

--- a/dev/src/rate-limiter.ts
+++ b/dev/src/rate-limiter.ts
@@ -46,6 +46,8 @@ export class RateLimiter {
    * @param multiplier Rate by which to increase the capacity.
    * @param multiplierMillis How often the capacity should increase in
    * milliseconds.
+   * @param maximumCapacity Maximum number of allowed operations per second.
+   * The number of tokens added per second will never exceed this number.
    * @param startTimeMillis The starting time in epoch milliseconds that the
    * rate limit is based on. Used for testing the limiter.
    */
@@ -53,6 +55,7 @@ export class RateLimiter {
     private readonly initialCapacity: number,
     private readonly multiplier: number,
     private readonly multiplierMillis: number,
+    private readonly maximumCapacity: number,
     private readonly startTimeMillis = Date.now()
   ) {
     this.availableTokens = initialCapacity;
@@ -147,11 +150,14 @@ export class RateLimiter {
       'startTime cannot be after currentTime'
     );
     const millisElapsed = requestTimeMillis - this.startTimeMillis;
-    const operationsPerSecond = Math.floor(
-      Math.pow(
-        this.multiplier,
-        Math.floor(millisElapsed / this.multiplierMillis)
-      ) * this.initialCapacity
+    const operationsPerSecond = Math.min(
+      Math.floor(
+        Math.pow(
+          this.multiplier,
+          Math.floor(millisElapsed / this.multiplierMillis)
+        ) * this.initialCapacity
+      ),
+      this.maximumCapacity
     );
 
     if (operationsPerSecond !== this.previousCapacity) {

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -187,54 +187,48 @@ describe('BulkWriter', () => {
       );
     });
 
-    it('disableThrottling used with op rates', async () => {
-      const firestore = await createInstance();
-      expect(() =>
-        firestore.bulkWriter({
-          disableThrottling: true,
-          initialOpsPerSecond: 100,
-        })
-      ).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "disableThrottling" cannot be set with "initialOpsPerSecond" or "maxOpsPerSecond".'
-      );
-
-      expect(() =>
-        firestore.bulkWriter({disableThrottling: true, maxOpsPerSecond: 100})
-      ).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "disableThrottling" cannot be set with "initialOpsPerSecond" or "maxOpsPerSecond".'
-      );
-    });
-
     it('initialOpsPerSecond requires positive integer', async () => {
       const firestore = await createInstance();
-      expect(() => firestore.bulkWriter({initialOpsPerSecond: -1})).to.throw(
+      expect(() =>
+        firestore.bulkWriter({throttling: {initialOpsPerSecond: -1}})
+      ).to.throw(
         'Value for argument "initialOpsPerSecond" must be within [0, Infinity] inclusive, but was: -1'
       );
 
-      expect(() => firestore.bulkWriter({initialOpsPerSecond: 500.5})).to.throw(
+      expect(() =>
+        firestore.bulkWriter({throttling: {initialOpsPerSecond: 500.5}})
+      ).to.throw(
         'Value for argument "initialOpsPerSecond" is not a valid integer.'
       );
     });
 
     it('maxOpsPerSecond requires positive integer', async () => {
       const firestore = await createInstance();
-      expect(() => firestore.bulkWriter({maxOpsPerSecond: -1})).to.throw(
+      expect(() =>
+        firestore.bulkWriter({throttling: {maxOpsPerSecond: -1}})
+      ).to.throw(
         'Value for argument "maxOpsPerSecond" must be within [0, Infinity] inclusive, but was: -1'
       );
 
-      expect(() => firestore.bulkWriter({maxOpsPerSecond: 500.5})).to.throw(
+      expect(() =>
+        firestore.bulkWriter({throttling: {maxOpsPerSecond: 500.5}})
+      ).to.throw(
         'Value for argument "maxOpsPerSecond" is not a valid integer.'
       );
     });
 
     it('maxOpsPerSecond must be greater than initial ops per second', async () => {
       const firestore = await createInstance();
-      expect(() => firestore.bulkWriter({maxOpsPerSecond: 80})).to.throw(
+      expect(() =>
+        firestore.bulkWriter({throttling: {maxOpsPerSecond: 80}})
+      ).to.throw(
         'Value for argument "options" is not a valid bulkWriter() options argument. "maxOpsPerSecond" must be greater than the default value of 500.'
       );
 
       expect(() =>
-        firestore.bulkWriter({initialOpsPerSecond: 550, maxOpsPerSecond: 500})
+        firestore.bulkWriter({
+          throttling: {initialOpsPerSecond: 550, maxOpsPerSecond: 500},
+        })
       ).to.throw(
         'Value for argument "options" is not a valid bulkWriter() options argument. "maxOpsPerSecond" cannot be less than "initialOpsPerSecond".'
       );

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -187,15 +187,6 @@ describe('BulkWriter', () => {
       );
     });
 
-    it('disableThrottling requires boolean', async () => {
-      const firestore = await createInstance();
-      expect(() =>
-        firestore.bulkWriter({disableThrottling: 42 as InvalidApiUsage})
-      ).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "disableThrottling" is not a boolean.'
-      );
-    });
-
     it('disableThrottling used with op rates', async () => {
       const firestore = await createInstance();
       expect(() =>
@@ -216,35 +207,23 @@ describe('BulkWriter', () => {
 
     it('initialOpsPerSecond requires positive integer', async () => {
       const firestore = await createInstance();
-      expect(() =>
-        firestore.bulkWriter({initialOpsPerSecond: '42' as InvalidApiUsage})
-      ).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "initialOpsPerSecond" is not a positive integer.'
-      );
-
       expect(() => firestore.bulkWriter({initialOpsPerSecond: -1})).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "initialOpsPerSecond" is not a positive integer.'
+        'Value for argument "initialOpsPerSecond" must be within [0, Infinity] inclusive, but was: -1'
       );
 
       expect(() => firestore.bulkWriter({initialOpsPerSecond: 500.5})).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "initialOpsPerSecond" is not a positive integer.'
+        'Value for argument "initialOpsPerSecond" is not a valid integer.'
       );
     });
 
     it('maxOpsPerSecond requires positive integer', async () => {
       const firestore = await createInstance();
-      expect(() =>
-        firestore.bulkWriter({maxOpsPerSecond: '42' as InvalidApiUsage})
-      ).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "maxOpsPerSecond" is not a positive integer.'
-      );
-
       expect(() => firestore.bulkWriter({maxOpsPerSecond: -1})).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "maxOpsPerSecond" is not a positive integer.'
+        'Value for argument "maxOpsPerSecond" must be within [0, Infinity] inclusive, but was: -1'
       );
 
       expect(() => firestore.bulkWriter({maxOpsPerSecond: 500.5})).to.throw(
-        'Value for argument "options" is not a valid bulkWriter() options argument. "maxOpsPerSecond" is not a positive integer.'
+        'Value for argument "maxOpsPerSecond" is not a valid integer.'
       );
     });
 

--- a/dev/test/rate-limiter.ts
+++ b/dev/test/rate-limiter.ts
@@ -25,6 +25,7 @@ describe('RateLimiter', () => {
       /* initialCapacity= */ 500,
       /* multiplier= */ 1.5,
       /* multiplierMillis= */ 5 * 60 * 1000,
+      /* maximumCapacity= */ 1000000,
       /* startTime= */ new Date(0).getTime()
     );
   });
@@ -106,5 +107,10 @@ describe('RateLimiter', () => {
     expect(
       limiter.calculateCapacity(new Date(90 * 60 * 1000).getTime())
     ).to.equal(738945);
+
+    // Check that maximum rate limit is enforced.
+    expect(
+      limiter.calculateCapacity(new Date(1000 * 60 * 1000).getTime())
+    ).to.equal(1000000);
   });
 });

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -621,7 +621,8 @@ declare namespace FirebaseFirestore {
   export interface BulkWriterOptions {
     /**
      * Whether to disable or configure throttling. By default, throttling is
-     * enabled.
+     * enabled. Setting the configuration values in throttling will enable
+     * throttling with the provided values.
      *
      * @param initialOpsPerSecond The initial maximum number of operations per
      * second allowed by the throttler. If this field is not set, the default

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -291,6 +291,9 @@ declare namespace FirebaseFirestore {
      * Creates a [BulkWriter]{@link BulkWriter}, used for performing
      * multiple writes in parallel. Gradually ramps up writes as specified
      * by the 500/50/5 rule.
+     *
+     * @param options An options object used to configure the throttling
+     * behavior for the underlying BulkWriter.
      */
     bulkWriter(options?: BulkWriterOptions): BulkWriter;
   }
@@ -613,12 +616,28 @@ declare namespace FirebaseFirestore {
   }
 
   /**
-   * An options object that can be used to disable request throttling in
-   * BulkWriter.
+   * An options object to configure throttling on BulkWriter.
    */
   export interface BulkWriterOptions {
-    /** Whether to disable throttling. */
+    /**
+     * Whether to disable throttling. If set, initialOpsPerSecond and
+     * maxOpsPerSecond cannot be set.
+     */
     readonly disableThrottling?: boolean;
+
+    /**
+     * The initial maximum number of operations per second allowed by the
+     * throttler. If this field is not set, the default is 500 operations per
+     * second.
+     */
+    readonly initialOpsPerSecond?: number;
+
+    /**
+     * The maximum number of operations per second allowed by the
+     * throttler. If this field is set, the throttler's allowed operations per
+     * second does not ramp up past the specified operations per second.
+     */
+    readonly maxOpsPerSecond?: number;
   }
 
   /**

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -620,24 +620,20 @@ declare namespace FirebaseFirestore {
    */
   export interface BulkWriterOptions {
     /**
-     * Whether to disable throttling. If set, initialOpsPerSecond and
-     * maxOpsPerSecond cannot be set.
-     */
-    readonly disableThrottling?: boolean;
-
-    /**
-     * The initial maximum number of operations per second allowed by the
-     * throttler. If this field is not set, the default is 500 operations per
+     * Whether to disable or configure throttling. By default, throttling is
+     * enabled.
+     *
+     * @param initialOpsPerSecond The initial maximum number of operations per
+     * second allowed by the throttler. If this field is not set, the default
+     * is 500 operations per second.
+     * @param maxOpsPerSecond The maximum number of operations per second
+     * allowed by the throttler. If this field is set, the throttler's allowed
+     * operations per second does not ramp up past the specified operations per
      * second.
      */
-    readonly initialOpsPerSecond?: number;
-
-    /**
-     * The maximum number of operations per second allowed by the
-     * throttler. If this field is set, the throttler's allowed operations per
-     * second does not ramp up past the specified operations per second.
-     */
-    readonly maxOpsPerSecond?: number;
+    readonly throttling?:
+      | boolean
+      | {initialOpsPerSecond?: number; maxOpsPerSecond?: number};
   }
 
   /**

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -621,8 +621,9 @@ declare namespace FirebaseFirestore {
   export interface BulkWriterOptions {
     /**
      * Whether to disable or configure throttling. By default, throttling is
-     * enabled. Setting the configuration values in throttling will enable
-     * throttling with the provided values.
+     * enabled. This field can be set to either a boolean or a config
+     * object. Setting it to `false` disables throttling, and setting the config
+     * values in throttling will enable throttling with the provided values.
      *
      * @param initialOpsPerSecond The initial maximum number of operations per
      * second allowed by the throttler. If this field is not set, the default

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -622,8 +622,9 @@ declare namespace FirebaseFirestore {
     /**
      * Whether to disable or configure throttling. By default, throttling is
      * enabled. This field can be set to either a boolean or a config
-     * object. Setting it to `false` disables throttling, and setting the config
-     * values in throttling will enable throttling with the provided values.
+     * object. Setting it to `true` will use default values. You can override
+     * the defaults by setting it to `false` to disable throttling, or by
+     * setting the config values to enable throttling with the provided values.
      *
      * @param initialOpsPerSecond The initial maximum number of operations per
      * second allowed by the throttler. If this field is not set, the default


### PR DESCRIPTION
Following up from the 555 discussion by adding option to set the initial and maximum rate of the throttler in BulkWriter.