### PR TITLE
fix: fix flaky BulkWriter rate limiter test

### DIFF
--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -388,6 +388,12 @@ export class BulkWriter {
         if (maxRate < startingRate) {
           startingRate = maxRate;
         }
+
+        // Ensure that the batch size is not larger than the number of allowed
+        // operations per second.
+        if (maxRate < this.maxBatchSize || startingRate < this.maxBatchSize) {
+          this.maxBatchSize = Math.min(startingRate, maxRate);
+        }
       }
 
       this.rateLimiter = new RateLimiter(

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -391,8 +391,8 @@ export class BulkWriter {
 
         // Ensure that the batch size is not larger than the number of allowed
         // operations per second.
-        if (maxRate < this.maxBatchSize || startingRate < this.maxBatchSize) {
-          this.maxBatchSize = Math.min(startingRate, maxRate);
+        if (startingRate < this.maxBatchSize) {
+          this.maxBatchSize = startingRate;
         }
       }
 

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DocumentData} from '@google-cloud/firestore';
+import {BulkWriterOptions, DocumentData} from '@google-cloud/firestore';
 
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import {expect} from 'chai';
@@ -27,7 +27,6 @@ import {
   WriteResult,
 } from '../src';
 import {setTimeoutHandler} from '../src/backoff';
-import {RateLimiter} from '../src/rate-limiter';
 import {
   ApiOverride,
   create,
@@ -642,7 +641,9 @@ describe('BulkWriter', () => {
 
   describe('Timeout handler tests', () => {
     // Return success responses for all requests.
-    function instantiateInstance(): Promise<BulkWriter> {
+    function instantiateInstance(
+      options?: BulkWriterOptions
+    ): Promise<BulkWriter> {
       const overrides: ApiOverride = {
         batchWrite: request => {
           const requestLength = request.writes?.length || 0;
@@ -657,40 +658,30 @@ describe('BulkWriter', () => {
       };
       return createInstance(overrides).then(firestoreClient => {
         firestore = firestoreClient;
-        return firestore.bulkWriter();
+        return firestore.bulkWriter(options);
       });
     }
 
     it('does not send batches if doing so exceeds the rate limit', done => {
-      // Create a mock RateLimiter that marks every request as over the rate
-      // limit rather than calculating by timestamps.
-      const mockLimiter: RateLimiter = ({
-        getNextRequestDelayMs: () => {
-          return 100;
-        },
-        tryMakeRequest: () => {
-          return true;
-        },
-      } as unknown) as RateLimiter;
-
-      instantiateInstance().then(bulkWriter => {
-        bulkWriter._setRateLimiter(mockLimiter);
-        let timeoutCalled = false;
-        setTimeoutHandler((_, timeout) => {
-          if (!timeoutCalled && timeout > 0) {
-            timeoutCalled = true;
-            done();
+      instantiateInstance({throttling: {maxOpsPerSecond: 5}}).then(
+        bulkWriter => {
+          let timeoutCalled = false;
+          setTimeoutHandler((_, timeout) => {
+            if (!timeoutCalled && timeout > 0) {
+              timeoutCalled = true;
+              done();
+            }
+          });
+          for (let i = 0; i < 500; i++) {
+            bulkWriter.set(firestore.doc('collectionId/doc' + i), {foo: 'bar'});
           }
-        });
-        for (let i = 0; i < 25; i++) {
-          bulkWriter.set(firestore.doc('collectionId/doc' + i), {foo: 'bar'});
+          // The close() promise will never resolve. Since we do not call the
+          // callback function in the overridden handler, subsequent requests
+          // after the timeout will not be made. The close() call is used to
+          // ensure that the final batch is sent.
+          bulkWriter.close();
         }
-        // The close() promise will never resolve. Since we do not call the
-        // callback function in the overridden handler, subsequent requests
-        // after the timeout will not be made. The close() call is used to
-        // ensure that the final batch is sent.
-        bulkWriter.close();
-      });
+      );
     });
   });
 


### PR DESCRIPTION
The test flakes when the CI slows down, which allows enough time to pass such that the test's writes can be made without exceeding the rate limit. To fix this, I created a mock rate limiter that always rejects any request, which makes this test timing-agnostic.