### PR TITLE
feat: add implicit ordering for startAt(DocumentReference) calls

### DIFF
--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -271,8 +271,7 @@ describe('CollectionGroup class', () => {
 
     const documents: QueryDocumentSnapshot<DocumentData>[] = [];
     for (const partition of partitions) {
-      // TODO(mrschmidt); Remove the need to add an `orderBy` here
-      let partitionedQuery = collectionGroup.orderBy(FieldPath.documentId());
+      let partitionedQuery: Query = collectionGroup;
       if (partition.startAt) {
         partitionedQuery = partitionedQuery.startAt(...partition.startAt);
       }
@@ -1620,6 +1619,12 @@ describe('Query class', () => {
   it('has startAt() method', async () => {
     await addDocs({foo: 'a'}, {foo: 'b'});
     const res = await randomCol.orderBy('foo').startAt('b').get();
+    expectDocs(res, {foo: 'b'});
+  });
+
+  it('startAt() adds implicit order by for DocumentReference', async () => {
+    const references = await addDocs({foo: 'a'}, {foo: 'b'});
+    const res = await randomCol.startAt(references[1]).get();
     expectDocs(res, {foo: 'b'});
   });
 

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -1852,6 +1852,32 @@ describe('startAt() interface', () => {
     });
   });
 
+  it('appends orderBy for DocumentReference cursors', () => {
+    const overrides: ApiOverride = {
+      runQuery: request => {
+        queryEquals(
+          request,
+          orderBy('__name__', 'ASCENDING'),
+          startAt(true, {
+            referenceValue:
+              `projects/${PROJECT_ID}/databases/(default)/` +
+              'documents/collectionId/doc',
+          })
+        );
+
+        return stream();
+      },
+    };
+
+    return createInstance(overrides).then(firestore => {
+      return snapshot('collectionId/doc', {foo: 'bar'}).then(doc => {
+        let query: Query = firestore.collection('collectionId');
+        query = query.startAt(doc.ref);
+        return query.get();
+      });
+    });
+  });
+
   it('can extract implicit direction for document snapshot', () => {
     const overrides: ApiOverride = {
       runQuery: request => {


### PR DESCRIPTION
The backend orders every query implicitly by document name, but if a cursor is specified, the order constraint has to be made explicit. This makes the Partition API harder to use, since the user needs to manually "prepend" and orderBy before they can use the cursor values in a QueryPartition.

This PR adds an implicit orderBy if the only cursor value is a DocumentReference. This is based on existing logic for DocumentSnapshots.