### PR TITLE
docs(sample): normalize sample's region tags

### DIFF
--- a/samples/solution-counters.js
+++ b/samples/solution-counters.js
@@ -17,14 +17,17 @@ const {Firestore, FieldValue} = require('@google-cloud/firestore');
 
 async function main() {
   // [START increment_counter]
+  // [START firestore_solution_sharded_counter_increment]
   function incrementCounter(docRef, numShards) {
     const shardId = Math.floor(Math.random() * numShards);
     const shardRef = docRef.collection('shards').doc(shardId.toString());
     return shardRef.set({count: FieldValue.increment(1)}, {merge: true});
   }
+  // [END firestore_solution_sharded_counter_increment]
   // [END increment_counter]
 
   // [START get_count]
+  // [START firestore_solution_sharded_counter_get]
   async function getCount(docRef) {
     const querySnapshot = await docRef.collection('shards').get();
     const documents = querySnapshot.docs;
@@ -35,9 +38,11 @@ async function main() {
     }
     return count;
   }
+  // [END firestore_solution_sharded_counter_get]
   // [END get_count]
 
   // [START delete_Docs]
+  // [START firestore_data_delete_doc]
   async function deleteDocs(docRef) {
     const shardsCollectionRef = docRef.collection('shards');
     const shardDocs = await shardsCollectionRef.select('id').get();
@@ -47,6 +52,7 @@ async function main() {
     });
     return Promise.all(promises);
   }
+  // [END firestore_data_delete_doc]
   // [END delete_Docs]
 
   // Create a new client


### PR DESCRIPTION
Make sample's region tags consistent across all the languages, [another PR](https://github.com/firebase/snippets-node/pull/170) for other firestore samples.
//cc @crwilcox 