### PR TITLE
feat: add ability to specify custom headers for individual RPC types

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1224,6 +1224,7 @@ export class Firestore implements firestore.Firestore {
         headers: {
           [CLOUD_RESOURCE_HEADER]: this.formattedName,
           ...this._settings.customHeaders,
+          ...this._settings[methodName]?.customHeaders,
         },
       },
     };


### PR DESCRIPTION
This makes it possible to specify custom headers for a single RPC type as such:

```
 firestore = new Firestore({commit: {customHeaders: {'X-Header: 'Value'}}});
```