### PR TITLE
fix: ignore 'undefined' in update() with UpdateMap

### DIFF
--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -348,7 +348,7 @@ export function validateUserInput(
         `${invalidArgumentMessage(
           arg,
           desc
-        )} "undefined" values are only ignored in object properties.`
+        )} "undefined" values are only ignored inside of objects.`
       );
     } else if (!options.allowUndefined) {
       throw new Error(
@@ -366,15 +366,26 @@ export function validateUserInput(
           value.methodName
         }() cannot be used inside of an array${fieldPathMessage}.`
       );
-    } else if (
-      (options.allowDeletes === 'root' && level !== 0) ||
-      options.allowDeletes === 'none'
-    ) {
+    } else if (options.allowDeletes === 'none') {
       throw new Error(
         `${invalidArgumentMessage(arg, desc)} ${
           value.methodName
-        }() must appear at the top-level and can only be used in update() or set() with {merge:true}${fieldPathMessage}.`
+        }() must appear at the top-level and can only be used in update() ` +
+          `or set() with {merge:true}${fieldPathMessage}.`
       );
+    } else if (options.allowDeletes === 'root') {
+      if (level === 0) {
+        // Ok (update() with UpdateData).
+      } else if (level === 1 && path?.size === 1) {
+        // Ok (update with varargs).
+      } else {
+        throw new Error(
+          `${invalidArgumentMessage(arg, desc)} ${
+            value.methodName
+          }() must appear at the top-level and can only be used in update() ` +
+            `or set() with {merge:true}${fieldPathMessage}.`
+        );
+      }
     }
   } else if (value instanceof FieldTransform) {
     if (inArray) {

--- a/dev/test/ignore-undefined.ts
+++ b/dev/test/ignore-undefined.ts
@@ -114,6 +114,30 @@ describe('ignores undefined values', () => {
     );
   });
 
+  it('with top-level field in update()', () => {
+    const overrides: ApiOverride = {
+      commit: request => {
+        requestEquals(
+          request,
+          update({
+            document: document('documentId', 'foo', 'bar'),
+            mask: updateMask('foo'),
+          })
+        );
+        return response(writeResult(1));
+      },
+    };
+
+    return createInstance(overrides, {ignoreUndefinedProperties: true}).then(
+      async firestore => {
+        await firestore.doc('collectionId/documentId').update({
+          foo: 'bar',
+          ignored: undefined,
+        });
+      }
+    );
+  });
+
   it('in query filters', () => {
     const overrides: ApiOverride = {
       runQuery: request => {
@@ -191,9 +215,7 @@ describe('rejects undefined values', () => {
         firestore => {
           expect(() => {
             firestore.doc('collectionId/documentId').update('foo', undefined);
-          }).to.throw(
-            '"undefined" values are only ignored in object properties.'
-          );
+          }).to.throw('"undefined" values are only ignored inside of objects.');
         }
       );
     });
@@ -206,9 +228,7 @@ describe('rejects undefined values', () => {
               .doc('collectionId/documentId')
               .collection('collectionId')
               .where('foo', '==', undefined);
-          }).to.throw(
-            '"undefined" values are only ignored in object properties.'
-          );
+          }).to.throw('"undefined" values are only ignored inside of objects.');
         }
       );
     });
@@ -222,9 +242,7 @@ describe('rejects undefined values', () => {
               .collection('collectionId')
               .orderBy('foo')
               .startAt(undefined);
-          }).to.throw(
-            '"undefined" values are only ignored in object properties.'
-          );
+          }).to.throw('"undefined" values are only ignored inside of objects.');
         }
       );
     });


### PR DESCRIPTION
When `ignoreUndefinedProperties` is set, `docRef.update({"foo": undefined})` should not be an error. This PR fixes this by passing the correct level to the validator, and then updating the validator to still work for deletes. 

Fixes https://github.com/googleapis/nodejs-firestore/issues/1359 