### PR TITLE
chore: simplify Bulk Writer

### DIFF
--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -276,7 +276,7 @@ export class BulkWriter {
 
   /**
    * A pointer to the tail of all active BulkWriter applications. This pointer
-   * is advanced every time a new operation is enqueued.
+   * is advanced every time a new write is enqueued.
    * @private
    */
   private _lastOp: Promise<void> = Promise.resolve();
@@ -442,7 +442,6 @@ export class BulkWriter {
     precondition?: firestore.Precondition
   ): Promise<WriteResult> {
     this._verifyNotClosed();
-
     const op = this._enqueue(documentRef, 'delete', bulkCommitBatch =>
       bulkCommitBatch.delete(documentRef, precondition)
     );
@@ -767,7 +766,7 @@ export class BulkWriter {
    */
   _sendFn(op: BulkWriterOperation): void {
     if (this._bulkCommitBatch.has(op.ref)) {
-      // Create a new batch since the backend doesn't support  a batch with two
+      // Create a new batch since the backend doesn't support batches with two
       // writes to the same document.
       this._sendCurrentBatch();
     }

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -73,10 +73,8 @@ const RATE_LIMITER_MULTIPLIER = 1.5;
 const RATE_LIMITER_MULTIPLIER_MILLIS = 5 * 60 * 1000;
 
 /**
- * Represents a single write for BulkWriter. A write can be in one of four
- * states (READY_TO_SEND, SENT, FAILED, SUCCESS). A SENT write can
- * transition back to READY_TO_SEND if it is scheduled for retry.
- *
+ * Represents a single write for BulkWriter, encapsulating operation dispatch 
+ * and error handling.
  * @private
  */
 class BulkWriterOperation {

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -73,7 +73,7 @@ const RATE_LIMITER_MULTIPLIER = 1.5;
 const RATE_LIMITER_MULTIPLIER_MILLIS = 5 * 60 * 1000;
 
 /**
- * Represents a single write for BulkWriter, encapsulating operation dispatch 
+ * Represents a single write for BulkWriter, encapsulating operation dispatch
  * and error handling.
  * @private
  */
@@ -81,6 +81,15 @@ class BulkWriterOperation {
   private deferred = new Deferred<WriteResult>();
   private failedAttempts = 0;
 
+  /**
+   * @param ref The document reference being written to.
+   * @param type The type of operation that created this write.
+   * @param op A closure that encapsulates the API call which adds this write to 
+   * a BulkCommitBatch.
+   * @param sendFn A callback to invoke when the operation should be sent.
+   * @param errorFn The user provided global error callback.
+   * @param successFn The user provided global success callback.
+   */
   constructor(
     public ref: firestore.DocumentReference<unknown>,
     private type: 'create' | 'set' | 'update' | 'delete',

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -84,7 +84,7 @@ class BulkWriterOperation {
   /**
    * @param ref The document reference being written to.
    * @param type The type of operation that created this write.
-   * @param op A closure that encapsulates the API call which adds this write to 
+   * @param op A closure that encapsulates the API call which adds this write to
    * a BulkCommitBatch.
    * @param sendFn A callback to invoke when the operation should be sent.
    * @param errorFn The user provided global error callback.

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -118,11 +118,11 @@ class BulkWriterOperation {
       logger(
         'BulkWriter.errorFn',
         null,
-        'Running error callback on error code:',
+        'Ran error callback on error code:',
         error.code,
         ', shouldRetry:',
         shouldRetry,
-        ' for document: ',
+        ' for document:',
         this.ref.path
       );
 

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -45,7 +45,7 @@ import {
   validateMinNumberOfArguments,
   validateOptional,
 } from './validate';
-import {GoogleError, Status} from 'google-gax';
+import {Status} from 'google-gax';
 import api = google.firestore.v1;
 
 /**

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -96,19 +96,6 @@ export class WriteResult implements firestore.WriteResult {
 }
 
 /**
- * A BatchWriteResult wraps the write time and status returned by Firestore
- * when making BatchWriteRequests.
- *
- * @private
- */
-export class BatchWriteResult {
-  constructor(
-    readonly writeTime: Timestamp | null,
-    readonly status: GoogleError
-  ) {}
-}
-
-/**
  * A lazily-evaluated write that allows us to detect the Project ID before
  * serializing the request.
  * @private

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2613,7 +2613,8 @@ describe('BulkWriter class', () => {
     const op2 = writer.set(ref, {foo: 'bar2'});
     await writer.close();
     const result = await ref.get();
-    expect(result.data()).to.deep.equal({foo: 'bar2'});
+    // The order of writes is not guaranteed.
+    expect(result.get('foo')).to.not.be.undefined;
     const writeTime1 = (await op1).writeTime;
     const writeTime2 = (await op2).writeTime;
     expect(writeTime1).to.not.be.null;

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -679,6 +679,43 @@ describe('BulkWriter', () => {
     expect(writeResult).to.equal(1);
   });
 
+  it('retries maintain correct write resolution ordering', async () => {
+    const bulkWriter = await instantiateInstance([
+      {
+        request: createRequest([setOp('doc', 'bar')]),
+        response: failedResponse(Status.INTERNAL),
+      },
+      {
+        request: createRequest([setOp('doc', 'bar')]),
+        response: successResponse(1),
+      },
+      {
+        request: createRequest([setOp('doc2', 'bar')]),
+        response: successResponse(2),
+      },
+    ]);
+    const ops: string[] = [];
+    bulkWriter.onWriteError(() => {
+      return true;
+    });
+    bulkWriter.set(firestore.doc('collectionId/doc'), {foo: 'bar'}).then(() => {
+      ops.push('before_flush');
+    });
+    await bulkWriter.flush().then(() => {
+      ops.push('flush');
+    });
+    bulkWriter
+      .set(firestore.doc('collectionId/doc2'), {foo: 'bar'})
+      .then(() => {
+        ops.push('after_flush');
+      });
+
+    expect(ops).to.deep.equal(['before_flush', 'flush']);
+    return bulkWriter.close().then(() => {
+      expect(ops).to.deep.equal(['before_flush', 'flush', 'after_flush']);
+    });
+  });
+
   it('returns the error if no retry is specified', async () => {
     const bulkWriter = await instantiateInstance([
       {

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -239,50 +239,50 @@ describe('BulkWriter', () => {
       let bulkWriter = firestore.bulkWriter({
         throttling: {initialOpsPerSecond: 500, maxOpsPerSecond: 550},
       });
-      expect(bulkWriter._getRateLimiter().availableTokens).to.equal(500);
-      expect(bulkWriter._getRateLimiter().maximumCapacity).to.equal(550);
+      expect(bulkWriter._rateLimiter.availableTokens).to.equal(500);
+      expect(bulkWriter._rateLimiter.maximumCapacity).to.equal(550);
 
       bulkWriter = firestore.bulkWriter({
         throttling: {maxOpsPerSecond: 1000},
       });
-      expect(bulkWriter._getRateLimiter().availableTokens).to.equal(500);
-      expect(bulkWriter._getRateLimiter().maximumCapacity).to.equal(1000);
+      expect(bulkWriter._rateLimiter.availableTokens).to.equal(500);
+      expect(bulkWriter._rateLimiter.maximumCapacity).to.equal(1000);
 
       bulkWriter = firestore.bulkWriter({
         throttling: {initialOpsPerSecond: 100},
       });
-      expect(bulkWriter._getRateLimiter().availableTokens).to.equal(100);
-      expect(bulkWriter._getRateLimiter().maximumCapacity).to.equal(
+      expect(bulkWriter._rateLimiter.availableTokens).to.equal(100);
+      expect(bulkWriter._rateLimiter.maximumCapacity).to.equal(
         Number.POSITIVE_INFINITY
       );
 
       bulkWriter = firestore.bulkWriter({
         throttling: {maxOpsPerSecond: 100},
       });
-      expect(bulkWriter._getRateLimiter().availableTokens).to.equal(100);
-      expect(bulkWriter._getRateLimiter().maximumCapacity).to.equal(100);
+      expect(bulkWriter._rateLimiter.availableTokens).to.equal(100);
+      expect(bulkWriter._rateLimiter.maximumCapacity).to.equal(100);
 
       bulkWriter = firestore.bulkWriter();
-      expect(bulkWriter._getRateLimiter().availableTokens).to.equal(
+      expect(bulkWriter._rateLimiter.availableTokens).to.equal(
         DEFAULT_STARTING_MAXIMUM_OPS_PER_SECOND
       );
-      expect(bulkWriter._getRateLimiter().maximumCapacity).to.equal(
+      expect(bulkWriter._rateLimiter.maximumCapacity).to.equal(
         Number.POSITIVE_INFINITY
       );
 
       bulkWriter = firestore.bulkWriter({throttling: true});
-      expect(bulkWriter._getRateLimiter().availableTokens).to.equal(
+      expect(bulkWriter._rateLimiter.availableTokens).to.equal(
         DEFAULT_STARTING_MAXIMUM_OPS_PER_SECOND
       );
-      expect(bulkWriter._getRateLimiter().maximumCapacity).to.equal(
+      expect(bulkWriter._rateLimiter.maximumCapacity).to.equal(
         Number.POSITIVE_INFINITY
       );
 
       bulkWriter = firestore.bulkWriter({throttling: false});
-      expect(bulkWriter._getRateLimiter().availableTokens).to.equal(
+      expect(bulkWriter._rateLimiter.availableTokens).to.equal(
         Number.POSITIVE_INFINITY
       );
-      expect(bulkWriter._getRateLimiter().maximumCapacity).to.equal(
+      expect(bulkWriter._rateLimiter.maximumCapacity).to.equal(
         Number.POSITIVE_INFINITY
       );
     });
@@ -767,7 +767,7 @@ describe('BulkWriter', () => {
       },
     ]);
 
-    bulkWriter._setMaxBatchSize(2);
+    bulkWriter._maxBatchSize = 2;
     for (let i = 0; i < 6; i++) {
       bulkWriter
         .set(firestore.doc('collectionId/doc' + i), {foo: 'bar'})
@@ -799,7 +799,7 @@ describe('BulkWriter', () => {
       },
     ]);
 
-    bulkWriter._setMaxBatchSize(3);
+    bulkWriter._maxBatchSize = 3;
     const promise1 = bulkWriter
       .set(firestore.doc('collectionId/doc1'), {foo: 'bar'})
       .then(incrementOpCount);

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -616,7 +616,10 @@ declare namespace FirebaseFirestore {
      * successfully completes.
      */
     onWriteResult(
-      callback: (documentRef: DocumentReference, result: WriteResult) => void
+      callback: (
+        documentRef: DocumentReference<any>,
+        result: WriteResult
+      ) => void
     ): void;
 
     /**


### PR DESCRIPTION
This is my attempt to simplify some of the callback logic in BulkWriter, and will hopefully allow us add Backoff handling for retries pretty easily.

The overall changes are:

- There are no more batch queues. Instead, there is only ever a single batch. If this batch reaches capacity, it is send. 
- To allow 'flush' to block, I am instead keeping a list of pending operations.
- An operation can go from "sent" to "ready_to_send" if the retry mechanism kicks in. 

One behavior change is that it is now possible that a retry will get scheduled after other operations in a flush. Let's say we have the calls:

- Op1
- Op2
- Flush
- Op3

And Op1 fails. The write order could now be: Op1, Op2, Op3, Op1. This breaks a single unit test, but I think it is sane behavior as it allows us to make progress while we wait for more reponses.