### PR TITLE
fix: handle ignoreUndefinedProperties in set(merge: true)

### DIFF
--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -694,7 +694,11 @@ export class DocumentMask {
           }
         } else if (isPlainObject(value)) {
           extractFieldPaths(value, childPath);
-        } else {
+        } else if (value !== undefined) {
+          // If the value is undefined it can never participate in the document
+          // mask. With `ignoreUndefinedProperties` set to false,
+          // `validateDocumentData` will reject an undefined value before even
+          // computing the document mask.
           fieldPaths.push(childPath);
         }
       }

--- a/dev/test/ignore-undefined.ts
+++ b/dev/test/ignore-undefined.ts
@@ -64,6 +64,33 @@ describe('ignores undefined values', () => {
     );
   });
 
+  it('in set({ merge: true })', () => {
+    const overrides: ApiOverride = {
+      commit: request => {
+        requestEquals(
+          request,
+          set({
+            document: document('documentId', 'foo', 'foo'),
+            mask: updateMask('foo'),
+          })
+        );
+        return response(writeResult(1));
+      },
+    };
+
+    return createInstance(overrides, {ignoreUndefinedProperties: true}).then(
+      firestore => {
+        return firestore.doc('collectionId/documentId').set(
+          {
+            foo: 'foo',
+            bar: undefined,
+          },
+          {merge: true}
+        );
+      }
+    );
+  });
+
   it('in create()', () => {
     const overrides: ApiOverride = {
       commit: request => {


### PR DESCRIPTION
Previously any field in the document would be propagated into the DocumentMask regardless of whether or not it had an undefined value, which led to the client acting as if the user had passed `FieldValue.delete()`, which wasn't intended.

Fixes #1392
