### PR TITLE
chore: add option to fetch all descendants

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1220,7 +1220,7 @@ export class Firestore implements firestore.Firestore {
     const collectionId =
       ref instanceof CollectionReference ? ref.id : ref.parent.id;
 
-    let query: Query<firestore.DocumentData> = new Query(
+    let query: Query = new Query(
       this,
       QueryOptions.forKindlessAllDescendants(parentPath, collectionId)
     );

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -178,6 +178,18 @@ abstract class Path<T> {
   }
 
   /**
+   * Pops the last segment from this `Path` and returns a newly constructed
+   * `Path`.
+   *
+   * @private
+   * @returns The newly created Path.
+   */
+  popLast(): T {
+    this.segments.pop();
+    return this.construct(this.segments);
+  }
+
+  /**
    * Returns true if this `Path` is equal to the provided value.
    *
    * @private

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1013,7 +1013,7 @@ export class QueryOptions<T> {
    * Returns query options for a collection group query.
    * @private
    */
-  static forCollectionGroupQuery<T>(
+  static forCollectionGroupQuery<T = firestore.DocumentData>(
     collectionId: string,
     converter = defaultConverter<T>()
   ): QueryOptions<T> {
@@ -1031,7 +1031,7 @@ export class QueryOptions<T> {
    * Returns query options for a single-collection query.
    * @private
    */
-  static forCollectionQuery<T>(
+  static forCollectionQuery<T = firestore.DocumentData>(
     collectionRef: ResourcePath,
     converter = defaultConverter<T>()
   ): QueryOptions<T> {
@@ -1051,7 +1051,7 @@ export class QueryOptions<T> {
    *
    * @private
    */
-  static forKindlessAllDescendants<T>(
+  static forKindlessAllDescendants<T = firestore.DocumentData>(
     parent: ResourcePath,
     id: string
   ): QueryOptions<T> {


### PR DESCRIPTION
I'm trying to separate out the PRs into smaller chunks where I can. This PR contains only the logic to fetch all descendants using a StructuredQuery. I only included a single system test as a sanity check. Once I add recursive delete functionality, the test coverage should include the code to fetch all descendants.