### PR TITLE
fix: Use `Array.isArray` instead of an `instanceof` check

### DIFF
--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -169,7 +169,7 @@ export class Serializer {
       }
     }
 
-    if (val instanceof Array) {
+    if (Array.isArray(val)) {
       const array: api.IValue = {
         arrayValue: {},
       };


### PR DESCRIPTION
Our code already relies on `isArray` whereas the `instanceof` check may fail when the array was created in a different module (as detailed in the linked issue).

Fixes #1409
