### PR TITLE
chore: update license.js to 2021

### DIFF
--- a/scripts/license.js
+++ b/scripts/license.js
@@ -17,7 +17,7 @@
 const fs = require('fs');
 
 const LICENSE_HEADER = `/*!
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Doing this separately in case we don't end up merging the PRs for adding types.