### PR TITLE
fix: avoid adding duplicate orderBys in startAfter()

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1515,28 +1515,21 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
     }
 
     const fieldOrders = this._queryOptions.fieldOrders.slice();
-    let hasDocumentId = false;
 
+    // If no explicit ordering is specified, use the first inequality to
+    // define an implicit order.
     if (fieldOrders.length === 0) {
-      // If no explicit ordering is specified, use the first inequality to
-      // define an implicit order.
       for (const fieldFilter of this._queryOptions.fieldFilters) {
-        if (FieldPath.documentId().isEqual(fieldFilter.field)) {
-          hasDocumentId = true;
-        }
         if (fieldFilter.isInequalityFilter()) {
           fieldOrders.push(new FieldOrder(fieldFilter.field));
           break;
         }
       }
-    } else {
-      for (const fieldOrder of fieldOrders) {
-        if (FieldPath.documentId().isEqual(fieldOrder.field)) {
-          hasDocumentId = true;
-        }
-      }
     }
 
+    const hasDocumentId = !!fieldOrders.find(fieldOrder =>
+      FieldPath.documentId().isEqual(fieldOrder.field)
+    );
     if (!hasDocumentId) {
       // Add implicit sorting by name, using the last specified direction.
       const lastDirection =

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1521,6 +1521,9 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
       // If no explicit ordering is specified, use the first inequality to
       // define an implicit order.
       for (const fieldFilter of this._queryOptions.fieldFilters) {
+        if (FieldPath.documentId().isEqual(fieldFilter.field)) {
+          hasDocumentId = true;
+        }
         if (fieldFilter.isInequalityFilter()) {
           fieldOrders.push(new FieldOrder(fieldFilter.field));
           break;

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -348,7 +348,7 @@ export function queryEquals(
 ): void {
   queryEqualsWithParentAndReadTime(
     actual,
-    '',
+    /* parent= */ '',
     /* readTime= */ undefined,
     ...protoComponents
   );


### PR DESCRIPTION
Fixing a bug in recursive delete where invalid queries would be created on stream errors due to adding two `orderBy('__name__', ASCENDING)` clauses when calling `startAfter()` ([location](https://github.com/googleapis/nodejs-firestore/blob/2cf01c2f3f1b2e439d0620a77afd292ec3707da4/dev/src/reference.ts#L2187)). The private method `createImplicitOrderBy` adds an implicit orderBy if there is is no documentId on the fieldOrder fields, but we didn't check the case where the documentId comes from the fieldPaths.

