### PR TITLE
fix: omit readTime in RunQueryRequest for recursive deletes

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1344,7 +1344,11 @@ export class Firestore implements firestore.Firestore {
 
     let query: Query = new Query(
       this,
-      QueryOptions.forKindlessAllDescendants(parentPath, collectionId)
+      QueryOptions.forKindlessAllDescendants(
+        parentPath,
+        collectionId,
+        /* requireConsistency= */ false
+      )
     );
 
     // Query for names only to fetch empty snapshots.

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1009,8 +1009,8 @@ export class QueryOptions<T> {
     readonly kindless = false,
     // Whether to require consistent documents when restarting the query. By
     // default, restarting the query uses the readTime offset of the original
-    // query.
-    readonly requireConsistency = false
+    // query to provide consistent results.
+    readonly requireConsistency = true
   ) {}
 
   /**
@@ -1057,7 +1057,8 @@ export class QueryOptions<T> {
    */
   static forKindlessAllDescendants<T = firestore.DocumentData>(
     parent: ResourcePath,
-    id: string
+    id: string,
+    requireConsistency = true
   ): QueryOptions<T> {
     let options = new QueryOptions<T>(
       parent,
@@ -1070,7 +1071,7 @@ export class QueryOptions<T> {
 
     options = options.with({
       kindless: true,
-      requireConsistency: true,
+      requireConsistency,
     });
     return options;
   }
@@ -2185,11 +2186,11 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
                 // `requestStream()` will backoff should the restart fail before
                 // delivering any results.
                 if (this._queryOptions.requireConsistency) {
-                  request = this.startAfter(lastReceivedDocument).toProto();
-                } else {
                   request = this.startAfter(lastReceivedDocument).toProto(
                     lastReceivedDocument.readTime
                   );
+                } else {
+                  request = this.startAfter(lastReceivedDocument).toProto();
                 }
               }
               streamActive.resolve(/* active= */ true);

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2177,9 +2177,18 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
                 // query cursor. Note that we do not use backoff here. The call to
                 // `requestStream()` will backoff should the restart fail before
                 // delivering any results.
-                request = this.startAfter(lastReceivedDocument).toProto(
-                  lastReceivedDocument.readTime
-                );
+                if (this._queryOptions.kindless) {
+                  // Kindless queries are currently used exclusively for recursive
+                  // deletes. We don't need the readTime in for documents that are
+                  // going to be deleted. The backend also requires the readTime
+                  // to not be older than 270 seconds, so omitting the readTime
+                  // is easier than trying to keep it updated.
+                  request = this.startAfter(lastReceivedDocument).toProto();
+                } else {
+                  request = this.startAfter(lastReceivedDocument).toProto(
+                    lastReceivedDocument.readTime
+                  );
+                }
               }
               streamActive.resolve(/* active= */ true);
             } else {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -300,10 +300,9 @@ export function readTime(
   return {seconds: String(seconds), nanos: nanos};
 }
 
-export function queryEqualsWithParentAndReadTime(
+export function queryEqualsWithParent(
   actual: api.IRunQueryRequest | undefined,
   parent: string,
-  readTime?: protobuf.ITimestamp,
   ...protoComponents: api.IStructuredQuery[]
 ): void {
   expect(actual).to.not.be.undefined;
@@ -331,10 +330,6 @@ export function queryEqualsWithParentAndReadTime(
     ];
   }
 
-  if (readTime) {
-    query.readTime = readTime;
-  }
-
   // 'extend' removes undefined fields in the request object. The backend
   // ignores these fields, but we need to manually strip them before we compare
   // the expected and the actual request.
@@ -346,12 +341,7 @@ export function queryEquals(
   actual: api.IRunQueryRequest | undefined,
   ...protoComponents: api.IStructuredQuery[]
 ): void {
-  queryEqualsWithParentAndReadTime(
-    actual,
-    /* parent= */ '',
-    /* readTime= */ undefined,
-    ...protoComponents
-  );
+  queryEqualsWithParent(actual, /* parent= */ '', ...protoComponents);
 }
 
 function bundledQueryEquals(

--- a/dev/test/recursive-delete.ts
+++ b/dev/test/recursive-delete.ts
@@ -34,8 +34,7 @@ import {
   fieldFilters,
   orderBy,
   queryEquals,
-  queryEqualsWithParentAndReadTime,
-  readTime,
+  queryEqualsWithParent,
   result,
   select,
   startAt as queryStartAt,
@@ -150,10 +149,9 @@ describe('recursiveDelete() method:', () => {
     it('for nested collections', async () => {
       const overrides: ApiOverride = {
         runQuery: req => {
-          queryEqualsWithParentAndReadTime(
+          queryEqualsWithParent(
             req,
             'root/doc',
-            /* readTime= */ undefined,
             select('__name__'),
             allDescendants(/* kindless= */ true),
             fieldFilters(
@@ -177,10 +175,9 @@ describe('recursiveDelete() method:', () => {
     it('documents', async () => {
       const overrides: ApiOverride = {
         runQuery: req => {
-          queryEqualsWithParentAndReadTime(
+          queryEqualsWithParent(
             req,
             'root/doc',
-            /* readTime= */ undefined,
             select('__name__'),
             allDescendants(/* kindless= */ true)
           );
@@ -201,10 +198,9 @@ describe('recursiveDelete() method:', () => {
           if (callCount === 1) {
             return stream(result('doc1'), new Error('failed in test'));
           } else {
-            queryEqualsWithParentAndReadTime(
+            queryEqualsWithParent(
               request,
               /* parent= */ '',
-              readTime(),
               select('__name__'),
               allDescendants(/* kindless= */ true),
               orderBy('__name__', 'ASCENDING'),


### PR DESCRIPTION
The RunQuery stream returns documents with the same readTime from when the query stream starts. Since the backend requires that the readTime be with 270 seconds, the query stream will error when it's restarted with an old readTime. Since we don't need the readTime when performing recursive deletes, we can omit the the field instead.