### PR TITLE
fix: remove floating point rounding error in Timestamp.fromMillis()

### DIFF
--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -107,7 +107,7 @@ export class Timestamp implements firestore.Timestamp {
    */
   static fromMillis(milliseconds: number): Timestamp {
     const seconds = Math.floor(milliseconds / 1000);
-    const nanos = Math.round(
+    const nanos = Math.floor(
       milliseconds * MS_TO_NANOS - seconds * 1000 * MS_TO_NANOS
     );
     return new Timestamp(seconds, nanos);

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -107,7 +107,9 @@ export class Timestamp implements firestore.Timestamp {
    */
   static fromMillis(milliseconds: number): Timestamp {
     const seconds = Math.floor(milliseconds / 1000);
-    const nanos = (milliseconds - seconds * 1000) * MS_TO_NANOS;
+    const nanos = Math.round(
+      milliseconds * MS_TO_NANOS - seconds * 1000 * MS_TO_NANOS
+    );
     return new Timestamp(seconds, nanos);
   }
 

--- a/dev/test/timestamp.ts
+++ b/dev/test/timestamp.ts
@@ -132,6 +132,12 @@ describe('timestamps', () => {
     expect(actual.isEqual(expected)).to.be.true;
   });
 
+  it('handles decimal inputs in fromMillis()', () => {
+    const actual = Firestore.Timestamp.fromMillis(1000.1);
+    const expected = new Firestore.Timestamp(1, 100000);
+    expect(actual.isEqual(expected)).to.be.true;
+  });
+
   it('validates seconds', () => {
     expect(() => new Firestore.Timestamp(0.1, 0)).to.throw(
       'Value for argument "seconds" is not a valid integer.'


### PR DESCRIPTION
Fixes #1463.

By multiplying `MS_TO_NANOS` separately, we avoid the floating point precision rounding errors.