### PR TITLE
fix: use BigInt when calculating nanos in Timestamp.fromMillis()

### DIFF
--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -107,10 +107,7 @@ export class Timestamp implements firestore.Timestamp {
    */
   static fromMillis(milliseconds: number): Timestamp {
     const seconds = Math.floor(milliseconds / 1000);
-    // Use BigInt to avoid floating point precision loss.
-    const bigIntNanos =
-      BigInt(milliseconds * MS_TO_NANOS) - BigInt(seconds * 1000 * MS_TO_NANOS);
-    const nanos = Math.floor(Number(bigIntNanos));
+    const nanos = Math.floor((milliseconds - seconds * 1000) * MS_TO_NANOS);
     return new Timestamp(seconds, nanos);
   }
 

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -108,7 +108,8 @@ export class Timestamp implements firestore.Timestamp {
   static fromMillis(milliseconds: number): Timestamp {
     const seconds = Math.floor(milliseconds / 1000);
     // Use BigInt to avoid floating point precision loss.
-    const bigIntNanos = BigInt(milliseconds * MS_TO_NANOS) - BigInt(seconds * 1000 * MS_TO_NANOS);
+    const bigIntNanos =
+      BigInt(milliseconds * MS_TO_NANOS) - BigInt(seconds * 1000 * MS_TO_NANOS);
     const nanos = Math.floor(Number(bigIntNanos));
     return new Timestamp(seconds, nanos);
   }

--- a/dev/src/timestamp.ts
+++ b/dev/src/timestamp.ts
@@ -107,9 +107,9 @@ export class Timestamp implements firestore.Timestamp {
    */
   static fromMillis(milliseconds: number): Timestamp {
     const seconds = Math.floor(milliseconds / 1000);
-    const nanos = Math.floor(
-      milliseconds * MS_TO_NANOS - seconds * 1000 * MS_TO_NANOS
-    );
+    // Use BigInt to avoid floating point precision loss.
+    const bigIntNanos = BigInt(milliseconds * MS_TO_NANOS) - BigInt(seconds * 1000 * MS_TO_NANOS);
+    const nanos = Math.floor(Number(bigIntNanos));
     return new Timestamp(seconds, nanos);
   }
 


### PR DESCRIPTION
After porting the original change to the web SDK, I noticed that the nanos calculation is subject to floating point precision loss. I used Math.floor() on the Web SDK, but using BigInt is more accurate, so I prefer to use it where we can.