### PR TITLE
feat: add buffering layer to BulkWriter

### DIFF
--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -861,9 +861,7 @@ export class BulkWriter {
 
     // Advance the `_lastOp` pointer. This ensures that `_lastOp` only resolves
     // when both the previous and the current write resolves.
-    this._lastOp = this._lastOp.then(() => {
-      return silencePromise(bulkWriterOp.promise);
-    });
+    this._lastOp = this._lastOp.then(() => silencePromise(bulkWriterOp.promise));
 
     // Schedule the operation if the BulkWriter has fewer than the maximum
     // number of allowed pending operations, or add the operation to the

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -861,7 +861,9 @@ export class BulkWriter {
 
     // Advance the `_lastOp` pointer. This ensures that `_lastOp` only resolves
     // when both the previous and the current write resolves.
-    this._lastOp = this._lastOp.then(() => silencePromise(bulkWriterOp.promise));
+    this._lastOp = this._lastOp.then(() =>
+      silencePromise(bulkWriterOp.promise)
+    );
 
     // Schedule the operation if the BulkWriter has fewer than the maximum
     // number of allowed pending operations, or add the operation to the

--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -88,6 +88,13 @@ const RATE_LIMITER_MULTIPLIER = 1.5;
  */
 const RATE_LIMITER_MULTIPLIER_MILLIS = 5 * 60 * 1000;
 
+/*!
+ * The default maximum number of pending operations that can be enqueued onto a
+ * BulkWriter instance. BulkWriter buffers additional writes after this many
+ * pending operations in order to avoiding going OOM.
+ */
+const DEFAULT_MAXIMUM_PENDING_OPERATIONS_COUNT = 10000;
+
 /**
  * Represents a single write for BulkWriter, encapsulating operation dispatch
  * and error handling.
@@ -329,6 +336,37 @@ export class BulkWriter {
    * @private
    */
   readonly _rateLimiter: RateLimiter;
+
+  /**
+   * The number of pending operations enqueued on this BulkWriter instance.
+   * @private
+   */
+  private _pendingOpsCount = 0;
+
+  /**
+   * An array containing buffered BulkWriter operations after the maximum number
+   * of pending operations has been enqueued.
+   * @private
+   */
+  private _bufferedOperations: Array<() => void> = [];
+
+  // Visible for testing.
+  _getBufferedOperationsCount(): number {
+    return this._bufferedOperations.length;
+  }
+
+  /**
+   * The maximum number of pending operations that can be enqueued onto this
+   * BulkWriter instance. Once the this number of writes have been enqueued,
+   * subsequent writes are buffered.
+   * @private
+   */
+  private _maxPendingOpCount = DEFAULT_MAXIMUM_PENDING_OPERATIONS_COUNT;
+
+  // Visible for testing.
+  _setMaxPendingOpCount(newMax: number): void {
+    this._maxPendingOpCount = newMax;
+  }
 
   /**
    * The user-provided callback to be run every time a BulkWriter operation
@@ -817,8 +855,54 @@ export class BulkWriter {
       this._errorFn.bind(this),
       this._successFn.bind(this)
     );
-    this._sendFn(enqueueOnBatchCallback, bulkWriterOp);
-    return bulkWriterOp.promise;
+
+    // Advance the `_lastOp` pointer. This ensures that `_lastOp` only resolves
+    // when both the previous and the current write resolves.
+    this._lastOp = this._lastOp.then(() => {
+      return silencePromise(bulkWriterOp.promise);
+    });
+
+    // Schedule the operation if the BulkWriter has fewer than the maximum
+    // number of allowed pending operations, or add the operation to the
+    // buffer.
+    if (this._pendingOpsCount < this._maxPendingOpCount) {
+      this._pendingOpsCount++;
+      this._sendFn(enqueueOnBatchCallback, bulkWriterOp);
+    } else {
+      this._bufferedOperations.push(() => {
+        this._pendingOpsCount++;
+        this._sendFn(enqueueOnBatchCallback, bulkWriterOp);
+      });
+    }
+
+    // Chain the BulkWriter operation promise with the buffer processing logic
+    // in order to ensure that it runs and that subsequent operations are
+    // enqueued before the next batch is scheduled in `_sendBatch()`.
+    return bulkWriterOp.promise
+      .then(res => {
+        this._processBufferedOps();
+        return res;
+      })
+      .catch(err => {
+        this._processBufferedOps();
+        throw err;
+      });
+  }
+
+  /**
+   * Manages the pending operation counter and schedules the next BulkWriter
+   * operation if we're under the maximum limit.
+   * @private
+   */
+  private _processBufferedOps(): void {
+    this._pendingOpsCount--;
+    if (
+      this._pendingOpsCount < this._maxPendingOpCount &&
+      this._bufferedOperations.length > 0
+    ) {
+      const nextOp = this._bufferedOperations.shift()!;
+      nextOp();
+    }
   }
 
   /**
@@ -837,12 +921,8 @@ export class BulkWriter {
       this._scheduleCurrentBatch();
     }
 
-    // Run the operation on the current batch and advance the `_lastOp` pointer.
-    // This ensures that `_lastOp` only resolves when both the previous and the
-    // current write resolves.
     enqueueOnBatchCallback(this._bulkCommitBatch);
     this._bulkCommitBatch.processLastOperation(op);
-    this._lastOp = this._lastOp.then(() => silencePromise(op.promise));
 
     if (this._bulkCommitBatch._opCount === this._maxBatchSize) {
       this._scheduleCurrentBatch();

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -519,8 +519,6 @@ describe('BulkWriter', () => {
         response: mergeResponses([successResponse(4), successResponse(5)]),
       },
     ]);
-    // eslint-disable-next-line no-console
-    console.log('BCHEN start buffer test');
     bulkWriter._setMaxPendingOpCount(3);
     bulkWriter
       .set(firestore.doc('collectionId/doc1'), {foo: 'bar'})
@@ -540,8 +538,6 @@ describe('BulkWriter', () => {
       .then(incrementOpCount);
     expect(bulkWriter._getBufferedOperationsCount()).to.equal(2);
     return bulkWriter.close().then(async () => {
-      // eslint-disable-next-line no-console
-      console.log('close complete');
       verifyOpCount(5);
     });
   });

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -500,6 +500,52 @@ describe('BulkWriter', () => {
     });
   });
 
+  it('buffers subsequent operations after reaching maximum pending op count', async () => {
+    const bulkWriter = await instantiateInstance([
+      {
+        request: createRequest([
+          setOp('doc1', 'bar'),
+          setOp('doc2', 'bar'),
+          setOp('doc3', 'bar'),
+        ]),
+        response: mergeResponses([
+          successResponse(1),
+          successResponse(2),
+          successResponse(3),
+        ]),
+      },
+      {
+        request: createRequest([setOp('doc4', 'bar'), setOp('doc5', 'bar')]),
+        response: mergeResponses([successResponse(4), successResponse(5)]),
+      },
+    ]);
+    // eslint-disable-next-line no-console
+    console.log('BCHEN start buffer test');
+    bulkWriter._setMaxPendingOpCount(3);
+    bulkWriter
+      .set(firestore.doc('collectionId/doc1'), {foo: 'bar'})
+      .then(incrementOpCount);
+    bulkWriter
+      .set(firestore.doc('collectionId/doc2'), {foo: 'bar'})
+      .then(incrementOpCount);
+    bulkWriter
+      .set(firestore.doc('collectionId/doc3'), {foo: 'bar'})
+      .then(incrementOpCount);
+    bulkWriter
+      .set(firestore.doc('collectionId/doc4'), {foo: 'bar'})
+      .then(incrementOpCount);
+    expect(bulkWriter._getBufferedOperationsCount()).to.equal(1);
+    bulkWriter
+      .set(firestore.doc('collectionId/doc5'), {foo: 'bar'})
+      .then(incrementOpCount);
+    expect(bulkWriter._getBufferedOperationsCount()).to.equal(2);
+    return bulkWriter.close().then(async () => {
+      // eslint-disable-next-line no-console
+      console.log('close complete');
+      verifyOpCount(5);
+    });
+  });
+
   it('runs the success handler', async () => {
     const bulkWriter = await instantiateInstance([
       {


### PR DESCRIPTION
This PR adds a buffer layer to BulkWriter to limit the number of outstanding RPCs that BulkWriter has. This helps prevent BulkWriter from OOMing when multiple RPCs start failing due to hotspotting or contention. 