### PR TITLE
chore: run synthtool and fix synth.py

### DIFF
--- a/dev/protos/firestore_v1beta1_proto_api.d.ts
+++ b/dev/protos/firestore_v1beta1_proto_api.d.ts
@@ -2897,20 +2897,6 @@ export namespace google {
                 public listDocuments(request: google.firestore.v1beta1.IListDocumentsRequest): Promise<google.firestore.v1beta1.ListDocumentsResponse>;
 
                 /**
-                 * Calls CreateDocument.
-                 * @param request CreateDocumentRequest message or plain object
-                 * @param callback Node-style callback called with the error, if any, and Document
-                 */
-                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest, callback: google.firestore.v1beta1.Firestore.CreateDocumentCallback): void;
-
-                /**
-                 * Calls CreateDocument.
-                 * @param request CreateDocumentRequest message or plain object
-                 * @returns Promise
-                 */
-                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest): Promise<google.firestore.v1beta1.Document>;
-
-                /**
                  * Calls UpdateDocument.
                  * @param request UpdateDocumentRequest message or plain object
                  * @param callback Node-style callback called with the error, if any, and Document
@@ -3009,6 +2995,20 @@ export namespace google {
                 public runQuery(request: google.firestore.v1beta1.IRunQueryRequest): Promise<google.firestore.v1beta1.RunQueryResponse>;
 
                 /**
+                 * Calls PartitionQuery.
+                 * @param request PartitionQueryRequest message or plain object
+                 * @param callback Node-style callback called with the error, if any, and PartitionQueryResponse
+                 */
+                public partitionQuery(request: google.firestore.v1beta1.IPartitionQueryRequest, callback: google.firestore.v1beta1.Firestore.PartitionQueryCallback): void;
+
+                /**
+                 * Calls PartitionQuery.
+                 * @param request PartitionQueryRequest message or plain object
+                 * @returns Promise
+                 */
+                public partitionQuery(request: google.firestore.v1beta1.IPartitionQueryRequest): Promise<google.firestore.v1beta1.PartitionQueryResponse>;
+
+                /**
                  * Calls Write.
                  * @param request WriteRequest message or plain object
                  * @param callback Node-style callback called with the error, if any, and WriteResponse
@@ -3049,6 +3049,34 @@ export namespace google {
                  * @returns Promise
                  */
                 public listCollectionIds(request: google.firestore.v1beta1.IListCollectionIdsRequest): Promise<google.firestore.v1beta1.ListCollectionIdsResponse>;
+
+                /**
+                 * Calls BatchWrite.
+                 * @param request BatchWriteRequest message or plain object
+                 * @param callback Node-style callback called with the error, if any, and BatchWriteResponse
+                 */
+                public batchWrite(request: google.firestore.v1beta1.IBatchWriteRequest, callback: google.firestore.v1beta1.Firestore.BatchWriteCallback): void;
+
+                /**
+                 * Calls BatchWrite.
+                 * @param request BatchWriteRequest message or plain object
+                 * @returns Promise
+                 */
+                public batchWrite(request: google.firestore.v1beta1.IBatchWriteRequest): Promise<google.firestore.v1beta1.BatchWriteResponse>;
+
+                /**
+                 * Calls CreateDocument.
+                 * @param request CreateDocumentRequest message or plain object
+                 * @param callback Node-style callback called with the error, if any, and Document
+                 */
+                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest, callback: google.firestore.v1beta1.Firestore.CreateDocumentCallback): void;
+
+                /**
+                 * Calls CreateDocument.
+                 * @param request CreateDocumentRequest message or plain object
+                 * @returns Promise
+                 */
+                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest): Promise<google.firestore.v1beta1.Document>;
             }
 
             namespace Firestore {
@@ -3066,13 +3094,6 @@ export namespace google {
                  * @param [response] ListDocumentsResponse
                  */
                 type ListDocumentsCallback = (error: (Error|null), response?: google.firestore.v1beta1.ListDocumentsResponse) => void;
-
-                /**
-                 * Callback as used by {@link google.firestore.v1beta1.Firestore#createDocument}.
-                 * @param error Error, if any
-                 * @param [response] Document
-                 */
-                type CreateDocumentCallback = (error: (Error|null), response?: google.firestore.v1beta1.Document) => void;
 
                 /**
                  * Callback as used by {@link google.firestore.v1beta1.Firestore#updateDocument}.
@@ -3124,6 +3145,13 @@ export namespace google {
                 type RunQueryCallback = (error: (Error|null), response?: google.firestore.v1beta1.RunQueryResponse) => void;
 
                 /**
+                 * Callback as used by {@link google.firestore.v1beta1.Firestore#partitionQuery}.
+                 * @param error Error, if any
+                 * @param [response] PartitionQueryResponse
+                 */
+                type PartitionQueryCallback = (error: (Error|null), response?: google.firestore.v1beta1.PartitionQueryResponse) => void;
+
+                /**
                  * Callback as used by {@link google.firestore.v1beta1.Firestore#write}.
                  * @param error Error, if any
                  * @param [response] WriteResponse
@@ -3143,6 +3171,20 @@ export namespace google {
                  * @param [response] ListCollectionIdsResponse
                  */
                 type ListCollectionIdsCallback = (error: (Error|null), response?: google.firestore.v1beta1.ListCollectionIdsResponse) => void;
+
+                /**
+                 * Callback as used by {@link google.firestore.v1beta1.Firestore#batchWrite}.
+                 * @param error Error, if any
+                 * @param [response] BatchWriteResponse
+                 */
+                type BatchWriteCallback = (error: (Error|null), response?: google.firestore.v1beta1.BatchWriteResponse) => void;
+
+                /**
+                 * Callback as used by {@link google.firestore.v1beta1.Firestore#createDocument}.
+                 * @param error Error, if any
+                 * @param [response] Document
+                 */
+                type CreateDocumentCallback = (error: (Error|null), response?: google.firestore.v1beta1.Document) => void;
             }
 
             /** Properties of a GetDocumentRequest. */
@@ -4018,6 +4060,121 @@ export namespace google {
                 public toJSON(): { [k: string]: any };
             }
 
+            /** Properties of a PartitionQueryRequest. */
+            interface IPartitionQueryRequest {
+
+                /** PartitionQueryRequest parent */
+                parent?: (string|null);
+
+                /** PartitionQueryRequest structuredQuery */
+                structuredQuery?: (google.firestore.v1beta1.IStructuredQuery|null);
+
+                /** PartitionQueryRequest partitionCount */
+                partitionCount?: (number|string|null);
+
+                /** PartitionQueryRequest pageToken */
+                pageToken?: (string|null);
+
+                /** PartitionQueryRequest pageSize */
+                pageSize?: (number|null);
+            }
+
+            /** Represents a PartitionQueryRequest. */
+            class PartitionQueryRequest implements IPartitionQueryRequest {
+
+                /**
+                 * Constructs a new PartitionQueryRequest.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IPartitionQueryRequest);
+
+                /** PartitionQueryRequest parent. */
+                public parent: string;
+
+                /** PartitionQueryRequest structuredQuery. */
+                public structuredQuery?: (google.firestore.v1beta1.IStructuredQuery|null);
+
+                /** PartitionQueryRequest partitionCount. */
+                public partitionCount: (number|string);
+
+                /** PartitionQueryRequest pageToken. */
+                public pageToken: string;
+
+                /** PartitionQueryRequest pageSize. */
+                public pageSize: number;
+
+                /** PartitionQueryRequest queryType. */
+                public queryType?: "structuredQuery";
+
+                /**
+                 * Creates a PartitionQueryRequest message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns PartitionQueryRequest
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.PartitionQueryRequest;
+
+                /**
+                 * Creates a plain object from a PartitionQueryRequest message. Also converts values to other types if specified.
+                 * @param message PartitionQueryRequest
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.PartitionQueryRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this PartitionQueryRequest to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            /** Properties of a PartitionQueryResponse. */
+            interface IPartitionQueryResponse {
+
+                /** PartitionQueryResponse partitions */
+                partitions?: (google.firestore.v1beta1.ICursor[]|null);
+
+                /** PartitionQueryResponse nextPageToken */
+                nextPageToken?: (string|null);
+            }
+
+            /** Represents a PartitionQueryResponse. */
+            class PartitionQueryResponse implements IPartitionQueryResponse {
+
+                /**
+                 * Constructs a new PartitionQueryResponse.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IPartitionQueryResponse);
+
+                /** PartitionQueryResponse partitions. */
+                public partitions: google.firestore.v1beta1.ICursor[];
+
+                /** PartitionQueryResponse nextPageToken. */
+                public nextPageToken: string;
+
+                /**
+                 * Creates a PartitionQueryResponse message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns PartitionQueryResponse
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.PartitionQueryResponse;
+
+                /**
+                 * Creates a plain object from a PartitionQueryResponse message. Also converts values to other types if specified.
+                 * @param message PartitionQueryResponse
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.PartitionQueryResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this PartitionQueryResponse to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
             /** Properties of a WriteRequest. */
             interface IWriteRequest {
 
@@ -4615,6 +4772,106 @@ export namespace google {
                 public toJSON(): { [k: string]: any };
             }
 
+            /** Properties of a BatchWriteRequest. */
+            interface IBatchWriteRequest {
+
+                /** BatchWriteRequest database */
+                database?: (string|null);
+
+                /** BatchWriteRequest writes */
+                writes?: (google.firestore.v1beta1.IWrite[]|null);
+
+                /** BatchWriteRequest labels */
+                labels?: ({ [k: string]: string }|null);
+            }
+
+            /** Represents a BatchWriteRequest. */
+            class BatchWriteRequest implements IBatchWriteRequest {
+
+                /**
+                 * Constructs a new BatchWriteRequest.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IBatchWriteRequest);
+
+                /** BatchWriteRequest database. */
+                public database: string;
+
+                /** BatchWriteRequest writes. */
+                public writes: google.firestore.v1beta1.IWrite[];
+
+                /** BatchWriteRequest labels. */
+                public labels: { [k: string]: string };
+
+                /**
+                 * Creates a BatchWriteRequest message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns BatchWriteRequest
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.BatchWriteRequest;
+
+                /**
+                 * Creates a plain object from a BatchWriteRequest message. Also converts values to other types if specified.
+                 * @param message BatchWriteRequest
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.BatchWriteRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this BatchWriteRequest to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            /** Properties of a BatchWriteResponse. */
+            interface IBatchWriteResponse {
+
+                /** BatchWriteResponse writeResults */
+                writeResults?: (google.firestore.v1beta1.IWriteResult[]|null);
+
+                /** BatchWriteResponse status */
+                status?: (google.rpc.IStatus[]|null);
+            }
+
+            /** Represents a BatchWriteResponse. */
+            class BatchWriteResponse implements IBatchWriteResponse {
+
+                /**
+                 * Constructs a new BatchWriteResponse.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IBatchWriteResponse);
+
+                /** BatchWriteResponse writeResults. */
+                public writeResults: google.firestore.v1beta1.IWriteResult[];
+
+                /** BatchWriteResponse status. */
+                public status: google.rpc.IStatus[];
+
+                /**
+                 * Creates a BatchWriteResponse message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns BatchWriteResponse
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.BatchWriteResponse;
+
+                /**
+                 * Creates a plain object from a BatchWriteResponse message. Also converts values to other types if specified.
+                 * @param message BatchWriteResponse
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.BatchWriteResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this BatchWriteResponse to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
             /** Properties of a StructuredQuery. */
             interface IStructuredQuery {
 
@@ -4914,7 +5171,7 @@ export namespace google {
 
                     /** Operator enum. */
                     type Operator =
-                        "OPERATOR_UNSPECIFIED"| "LESS_THAN"| "LESS_THAN_OR_EQUAL"| "GREATER_THAN"| "GREATER_THAN_OR_EQUAL"| "EQUAL"| "ARRAY_CONTAINS"| "IN"| "ARRAY_CONTAINS_ANY";
+                        "OPERATOR_UNSPECIFIED"| "LESS_THAN"| "LESS_THAN_OR_EQUAL"| "GREATER_THAN"| "GREATER_THAN_OR_EQUAL"| "EQUAL"| "NOT_EQUAL"| "ARRAY_CONTAINS"| "IN"| "ARRAY_CONTAINS_ANY"| "NOT_IN";
                 }
 
                 /** Properties of an UnaryFilter. */
@@ -4971,7 +5228,48 @@ export namespace google {
 
                     /** Operator enum. */
                     type Operator =
-                        "OPERATOR_UNSPECIFIED"| "IS_NAN"| "IS_NULL";
+                        "OPERATOR_UNSPECIFIED"| "IS_NAN"| "IS_NULL"| "IS_NOT_NAN"| "IS_NOT_NULL";
+                }
+
+                /** Properties of a FieldReference. */
+                interface IFieldReference {
+
+                    /** FieldReference fieldPath */
+                    fieldPath?: (string|null);
+                }
+
+                /** Represents a FieldReference. */
+                class FieldReference implements IFieldReference {
+
+                    /**
+                     * Constructs a new FieldReference.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.firestore.v1beta1.StructuredQuery.IFieldReference);
+
+                    /** FieldReference fieldPath. */
+                    public fieldPath: string;
+
+                    /**
+                     * Creates a FieldReference message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns FieldReference
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.StructuredQuery.FieldReference;
+
+                    /**
+                     * Creates a plain object from a FieldReference message. Also converts values to other types if specified.
+                     * @param message FieldReference
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.firestore.v1beta1.StructuredQuery.FieldReference, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this FieldReference to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
                 }
 
                 /** Properties of an Order. */
@@ -5016,47 +5314,6 @@ export namespace google {
 
                     /**
                      * Converts this Order to JSON.
-                     * @returns JSON object
-                     */
-                    public toJSON(): { [k: string]: any };
-                }
-
-                /** Properties of a FieldReference. */
-                interface IFieldReference {
-
-                    /** FieldReference fieldPath */
-                    fieldPath?: (string|null);
-                }
-
-                /** Represents a FieldReference. */
-                class FieldReference implements IFieldReference {
-
-                    /**
-                     * Constructs a new FieldReference.
-                     * @param [properties] Properties to set
-                     */
-                    constructor(properties?: google.firestore.v1beta1.StructuredQuery.IFieldReference);
-
-                    /** FieldReference fieldPath. */
-                    public fieldPath: string;
-
-                    /**
-                     * Creates a FieldReference message from a plain object. Also converts values to their respective internal types.
-                     * @param object Plain object
-                     * @returns FieldReference
-                     */
-                    public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.StructuredQuery.FieldReference;
-
-                    /**
-                     * Creates a plain object from a FieldReference message. Also converts values to other types if specified.
-                     * @param message FieldReference
-                     * @param [options] Conversion options
-                     * @returns Plain object
-                     */
-                    public static toObject(message: google.firestore.v1beta1.StructuredQuery.FieldReference, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-                    /**
-                     * Converts this FieldReference to JSON.
                      * @returns JSON object
                      */
                     public toJSON(): { [k: string]: any };
@@ -5170,6 +5427,9 @@ export namespace google {
                 /** Write updateMask */
                 updateMask?: (google.firestore.v1beta1.IDocumentMask|null);
 
+                /** Write updateTransforms */
+                updateTransforms?: (google.firestore.v1beta1.DocumentTransform.IFieldTransform[]|null);
+
                 /** Write currentDocument */
                 currentDocument?: (google.firestore.v1beta1.IPrecondition|null);
             }
@@ -5194,6 +5454,9 @@ export namespace google {
 
                 /** Write updateMask. */
                 public updateMask?: (google.firestore.v1beta1.IDocumentMask|null);
+
+                /** Write updateTransforms. */
+                public updateTransforms: google.firestore.v1beta1.DocumentTransform.IFieldTransform[];
 
                 /** Write currentDocument. */
                 public currentDocument?: (google.firestore.v1beta1.IPrecondition|null);

--- a/dev/protos/firestore_v1beta1_proto_api.js
+++ b/dev/protos/firestore_v1beta1_proto_api.js
@@ -7147,39 +7147,6 @@
                      */
     
                     /**
-                     * Callback as used by {@link google.firestore.v1beta1.Firestore#createDocument}.
-                     * @memberof google.firestore.v1beta1.Firestore
-                     * @typedef CreateDocumentCallback
-                     * @type {function}
-                     * @param {Error|null} error Error, if any
-                     * @param {google.firestore.v1beta1.Document} [response] Document
-                     */
-    
-                    /**
-                     * Calls CreateDocument.
-                     * @function createDocument
-                     * @memberof google.firestore.v1beta1.Firestore
-                     * @instance
-                     * @param {google.firestore.v1beta1.ICreateDocumentRequest} request CreateDocumentRequest message or plain object
-                     * @param {google.firestore.v1beta1.Firestore.CreateDocumentCallback} callback Node-style callback called with the error, if any, and Document
-                     * @returns {undefined}
-                     * @variation 1
-                     */
-                    Object.defineProperty(Firestore.prototype.createDocument = function createDocument(request, callback) {
-                        return this.rpcCall(createDocument, $root.google.firestore.v1beta1.CreateDocumentRequest, $root.google.firestore.v1beta1.Document, request, callback);
-                    }, "name", { value: "CreateDocument" });
-    
-                    /**
-                     * Calls CreateDocument.
-                     * @function createDocument
-                     * @memberof google.firestore.v1beta1.Firestore
-                     * @instance
-                     * @param {google.firestore.v1beta1.ICreateDocumentRequest} request CreateDocumentRequest message or plain object
-                     * @returns {Promise<google.firestore.v1beta1.Document>} Promise
-                     * @variation 2
-                     */
-    
-                    /**
                      * Callback as used by {@link google.firestore.v1beta1.Firestore#updateDocument}.
                      * @memberof google.firestore.v1beta1.Firestore
                      * @typedef UpdateDocumentCallback
@@ -7411,6 +7378,39 @@
                      */
     
                     /**
+                     * Callback as used by {@link google.firestore.v1beta1.Firestore#partitionQuery}.
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @typedef PartitionQueryCallback
+                     * @type {function}
+                     * @param {Error|null} error Error, if any
+                     * @param {google.firestore.v1beta1.PartitionQueryResponse} [response] PartitionQueryResponse
+                     */
+    
+                    /**
+                     * Calls PartitionQuery.
+                     * @function partitionQuery
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @instance
+                     * @param {google.firestore.v1beta1.IPartitionQueryRequest} request PartitionQueryRequest message or plain object
+                     * @param {google.firestore.v1beta1.Firestore.PartitionQueryCallback} callback Node-style callback called with the error, if any, and PartitionQueryResponse
+                     * @returns {undefined}
+                     * @variation 1
+                     */
+                    Object.defineProperty(Firestore.prototype.partitionQuery = function partitionQuery(request, callback) {
+                        return this.rpcCall(partitionQuery, $root.google.firestore.v1beta1.PartitionQueryRequest, $root.google.firestore.v1beta1.PartitionQueryResponse, request, callback);
+                    }, "name", { value: "PartitionQuery" });
+    
+                    /**
+                     * Calls PartitionQuery.
+                     * @function partitionQuery
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @instance
+                     * @param {google.firestore.v1beta1.IPartitionQueryRequest} request PartitionQueryRequest message or plain object
+                     * @returns {Promise<google.firestore.v1beta1.PartitionQueryResponse>} Promise
+                     * @variation 2
+                     */
+    
+                    /**
                      * Callback as used by {@link google.firestore.v1beta1.Firestore#write}.
                      * @memberof google.firestore.v1beta1.Firestore
                      * @typedef WriteCallback
@@ -7506,6 +7506,72 @@
                      * @instance
                      * @param {google.firestore.v1beta1.IListCollectionIdsRequest} request ListCollectionIdsRequest message or plain object
                      * @returns {Promise<google.firestore.v1beta1.ListCollectionIdsResponse>} Promise
+                     * @variation 2
+                     */
+    
+                    /**
+                     * Callback as used by {@link google.firestore.v1beta1.Firestore#batchWrite}.
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @typedef BatchWriteCallback
+                     * @type {function}
+                     * @param {Error|null} error Error, if any
+                     * @param {google.firestore.v1beta1.BatchWriteResponse} [response] BatchWriteResponse
+                     */
+    
+                    /**
+                     * Calls BatchWrite.
+                     * @function batchWrite
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @instance
+                     * @param {google.firestore.v1beta1.IBatchWriteRequest} request BatchWriteRequest message or plain object
+                     * @param {google.firestore.v1beta1.Firestore.BatchWriteCallback} callback Node-style callback called with the error, if any, and BatchWriteResponse
+                     * @returns {undefined}
+                     * @variation 1
+                     */
+                    Object.defineProperty(Firestore.prototype.batchWrite = function batchWrite(request, callback) {
+                        return this.rpcCall(batchWrite, $root.google.firestore.v1beta1.BatchWriteRequest, $root.google.firestore.v1beta1.BatchWriteResponse, request, callback);
+                    }, "name", { value: "BatchWrite" });
+    
+                    /**
+                     * Calls BatchWrite.
+                     * @function batchWrite
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @instance
+                     * @param {google.firestore.v1beta1.IBatchWriteRequest} request BatchWriteRequest message or plain object
+                     * @returns {Promise<google.firestore.v1beta1.BatchWriteResponse>} Promise
+                     * @variation 2
+                     */
+    
+                    /**
+                     * Callback as used by {@link google.firestore.v1beta1.Firestore#createDocument}.
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @typedef CreateDocumentCallback
+                     * @type {function}
+                     * @param {Error|null} error Error, if any
+                     * @param {google.firestore.v1beta1.Document} [response] Document
+                     */
+    
+                    /**
+                     * Calls CreateDocument.
+                     * @function createDocument
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @instance
+                     * @param {google.firestore.v1beta1.ICreateDocumentRequest} request CreateDocumentRequest message or plain object
+                     * @param {google.firestore.v1beta1.Firestore.CreateDocumentCallback} callback Node-style callback called with the error, if any, and Document
+                     * @returns {undefined}
+                     * @variation 1
+                     */
+                    Object.defineProperty(Firestore.prototype.createDocument = function createDocument(request, callback) {
+                        return this.rpcCall(createDocument, $root.google.firestore.v1beta1.CreateDocumentRequest, $root.google.firestore.v1beta1.Document, request, callback);
+                    }, "name", { value: "CreateDocument" });
+    
+                    /**
+                     * Calls CreateDocument.
+                     * @function createDocument
+                     * @memberof google.firestore.v1beta1.Firestore
+                     * @instance
+                     * @param {google.firestore.v1beta1.ICreateDocumentRequest} request CreateDocumentRequest message or plain object
+                     * @returns {Promise<google.firestore.v1beta1.Document>} Promise
                      * @variation 2
                      */
     
@@ -9610,6 +9676,289 @@
                     return RunQueryResponse;
                 })();
     
+                v1beta1.PartitionQueryRequest = (function() {
+    
+                    /**
+                     * Properties of a PartitionQueryRequest.
+                     * @memberof google.firestore.v1beta1
+                     * @interface IPartitionQueryRequest
+                     * @property {string|null} [parent] PartitionQueryRequest parent
+                     * @property {google.firestore.v1beta1.IStructuredQuery|null} [structuredQuery] PartitionQueryRequest structuredQuery
+                     * @property {number|string|null} [partitionCount] PartitionQueryRequest partitionCount
+                     * @property {string|null} [pageToken] PartitionQueryRequest pageToken
+                     * @property {number|null} [pageSize] PartitionQueryRequest pageSize
+                     */
+    
+                    /**
+                     * Constructs a new PartitionQueryRequest.
+                     * @memberof google.firestore.v1beta1
+                     * @classdesc Represents a PartitionQueryRequest.
+                     * @implements IPartitionQueryRequest
+                     * @constructor
+                     * @param {google.firestore.v1beta1.IPartitionQueryRequest=} [properties] Properties to set
+                     */
+                    function PartitionQueryRequest(properties) {
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+    
+                    /**
+                     * PartitionQueryRequest parent.
+                     * @member {string} parent
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @instance
+                     */
+                    PartitionQueryRequest.prototype.parent = "";
+    
+                    /**
+                     * PartitionQueryRequest structuredQuery.
+                     * @member {google.firestore.v1beta1.IStructuredQuery|null|undefined} structuredQuery
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @instance
+                     */
+                    PartitionQueryRequest.prototype.structuredQuery = null;
+    
+                    /**
+                     * PartitionQueryRequest partitionCount.
+                     * @member {number|string} partitionCount
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @instance
+                     */
+                    PartitionQueryRequest.prototype.partitionCount = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+    
+                    /**
+                     * PartitionQueryRequest pageToken.
+                     * @member {string} pageToken
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @instance
+                     */
+                    PartitionQueryRequest.prototype.pageToken = "";
+    
+                    /**
+                     * PartitionQueryRequest pageSize.
+                     * @member {number} pageSize
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @instance
+                     */
+                    PartitionQueryRequest.prototype.pageSize = 0;
+    
+                    // OneOf field names bound to virtual getters and setters
+                    var $oneOfFields;
+    
+                    /**
+                     * PartitionQueryRequest queryType.
+                     * @member {"structuredQuery"|undefined} queryType
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @instance
+                     */
+                    Object.defineProperty(PartitionQueryRequest.prototype, "queryType", {
+                        get: $util.oneOfGetter($oneOfFields = ["structuredQuery"]),
+                        set: $util.oneOfSetter($oneOfFields)
+                    });
+    
+                    /**
+                     * Creates a PartitionQueryRequest message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.firestore.v1beta1.PartitionQueryRequest} PartitionQueryRequest
+                     */
+                    PartitionQueryRequest.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.firestore.v1beta1.PartitionQueryRequest)
+                            return object;
+                        var message = new $root.google.firestore.v1beta1.PartitionQueryRequest();
+                        if (object.parent != null)
+                            message.parent = String(object.parent);
+                        if (object.structuredQuery != null) {
+                            if (typeof object.structuredQuery !== "object")
+                                throw TypeError(".google.firestore.v1beta1.PartitionQueryRequest.structuredQuery: object expected");
+                            message.structuredQuery = $root.google.firestore.v1beta1.StructuredQuery.fromObject(object.structuredQuery);
+                        }
+                        if (object.partitionCount != null)
+                            if ($util.Long)
+                                (message.partitionCount = $util.Long.fromValue(object.partitionCount)).unsigned = false;
+                            else if (typeof object.partitionCount === "string")
+                                message.partitionCount = parseInt(object.partitionCount, 10);
+                            else if (typeof object.partitionCount === "number")
+                                message.partitionCount = object.partitionCount;
+                            else if (typeof object.partitionCount === "object")
+                                message.partitionCount = new $util.LongBits(object.partitionCount.low >>> 0, object.partitionCount.high >>> 0).toNumber();
+                        if (object.pageToken != null)
+                            message.pageToken = String(object.pageToken);
+                        if (object.pageSize != null)
+                            message.pageSize = object.pageSize | 0;
+                        return message;
+                    };
+    
+                    /**
+                     * Creates a plain object from a PartitionQueryRequest message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @static
+                     * @param {google.firestore.v1beta1.PartitionQueryRequest} message PartitionQueryRequest
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    PartitionQueryRequest.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.defaults) {
+                            object.parent = "";
+                            if ($util.Long) {
+                                var long = new $util.Long(0, 0, false);
+                                object.partitionCount = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                            } else
+                                object.partitionCount = options.longs === String ? "0" : 0;
+                            object.pageToken = "";
+                            object.pageSize = 0;
+                        }
+                        if (message.parent != null && message.hasOwnProperty("parent"))
+                            object.parent = message.parent;
+                        if (message.structuredQuery != null && message.hasOwnProperty("structuredQuery")) {
+                            object.structuredQuery = $root.google.firestore.v1beta1.StructuredQuery.toObject(message.structuredQuery, options);
+                            if (options.oneofs)
+                                object.queryType = "structuredQuery";
+                        }
+                        if (message.partitionCount != null && message.hasOwnProperty("partitionCount"))
+                            if (typeof message.partitionCount === "number")
+                                object.partitionCount = options.longs === String ? String(message.partitionCount) : message.partitionCount;
+                            else
+                                object.partitionCount = options.longs === String ? $util.Long.prototype.toString.call(message.partitionCount) : options.longs === Number ? new $util.LongBits(message.partitionCount.low >>> 0, message.partitionCount.high >>> 0).toNumber() : message.partitionCount;
+                        if (message.pageToken != null && message.hasOwnProperty("pageToken"))
+                            object.pageToken = message.pageToken;
+                        if (message.pageSize != null && message.hasOwnProperty("pageSize"))
+                            object.pageSize = message.pageSize;
+                        return object;
+                    };
+    
+                    /**
+                     * Converts this PartitionQueryRequest to JSON.
+                     * @function toJSON
+                     * @memberof google.firestore.v1beta1.PartitionQueryRequest
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    PartitionQueryRequest.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+    
+                    return PartitionQueryRequest;
+                })();
+    
+                v1beta1.PartitionQueryResponse = (function() {
+    
+                    /**
+                     * Properties of a PartitionQueryResponse.
+                     * @memberof google.firestore.v1beta1
+                     * @interface IPartitionQueryResponse
+                     * @property {Array.<google.firestore.v1beta1.ICursor>|null} [partitions] PartitionQueryResponse partitions
+                     * @property {string|null} [nextPageToken] PartitionQueryResponse nextPageToken
+                     */
+    
+                    /**
+                     * Constructs a new PartitionQueryResponse.
+                     * @memberof google.firestore.v1beta1
+                     * @classdesc Represents a PartitionQueryResponse.
+                     * @implements IPartitionQueryResponse
+                     * @constructor
+                     * @param {google.firestore.v1beta1.IPartitionQueryResponse=} [properties] Properties to set
+                     */
+                    function PartitionQueryResponse(properties) {
+                        this.partitions = [];
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+    
+                    /**
+                     * PartitionQueryResponse partitions.
+                     * @member {Array.<google.firestore.v1beta1.ICursor>} partitions
+                     * @memberof google.firestore.v1beta1.PartitionQueryResponse
+                     * @instance
+                     */
+                    PartitionQueryResponse.prototype.partitions = $util.emptyArray;
+    
+                    /**
+                     * PartitionQueryResponse nextPageToken.
+                     * @member {string} nextPageToken
+                     * @memberof google.firestore.v1beta1.PartitionQueryResponse
+                     * @instance
+                     */
+                    PartitionQueryResponse.prototype.nextPageToken = "";
+    
+                    /**
+                     * Creates a PartitionQueryResponse message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.firestore.v1beta1.PartitionQueryResponse
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.firestore.v1beta1.PartitionQueryResponse} PartitionQueryResponse
+                     */
+                    PartitionQueryResponse.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.firestore.v1beta1.PartitionQueryResponse)
+                            return object;
+                        var message = new $root.google.firestore.v1beta1.PartitionQueryResponse();
+                        if (object.partitions) {
+                            if (!Array.isArray(object.partitions))
+                                throw TypeError(".google.firestore.v1beta1.PartitionQueryResponse.partitions: array expected");
+                            message.partitions = [];
+                            for (var i = 0; i < object.partitions.length; ++i) {
+                                if (typeof object.partitions[i] !== "object")
+                                    throw TypeError(".google.firestore.v1beta1.PartitionQueryResponse.partitions: object expected");
+                                message.partitions[i] = $root.google.firestore.v1beta1.Cursor.fromObject(object.partitions[i]);
+                            }
+                        }
+                        if (object.nextPageToken != null)
+                            message.nextPageToken = String(object.nextPageToken);
+                        return message;
+                    };
+    
+                    /**
+                     * Creates a plain object from a PartitionQueryResponse message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.firestore.v1beta1.PartitionQueryResponse
+                     * @static
+                     * @param {google.firestore.v1beta1.PartitionQueryResponse} message PartitionQueryResponse
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    PartitionQueryResponse.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.arrays || options.defaults)
+                            object.partitions = [];
+                        if (options.defaults)
+                            object.nextPageToken = "";
+                        if (message.partitions && message.partitions.length) {
+                            object.partitions = [];
+                            for (var j = 0; j < message.partitions.length; ++j)
+                                object.partitions[j] = $root.google.firestore.v1beta1.Cursor.toObject(message.partitions[j], options);
+                        }
+                        if (message.nextPageToken != null && message.hasOwnProperty("nextPageToken"))
+                            object.nextPageToken = message.nextPageToken;
+                        return object;
+                    };
+    
+                    /**
+                     * Converts this PartitionQueryResponse to JSON.
+                     * @function toJSON
+                     * @memberof google.firestore.v1beta1.PartitionQueryResponse
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    PartitionQueryResponse.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+    
+                    return PartitionQueryResponse;
+                })();
+    
                 v1beta1.WriteRequest = (function() {
     
                     /**
@@ -11099,6 +11448,263 @@
                     return ListCollectionIdsResponse;
                 })();
     
+                v1beta1.BatchWriteRequest = (function() {
+    
+                    /**
+                     * Properties of a BatchWriteRequest.
+                     * @memberof google.firestore.v1beta1
+                     * @interface IBatchWriteRequest
+                     * @property {string|null} [database] BatchWriteRequest database
+                     * @property {Array.<google.firestore.v1beta1.IWrite>|null} [writes] BatchWriteRequest writes
+                     * @property {Object.<string,string>|null} [labels] BatchWriteRequest labels
+                     */
+    
+                    /**
+                     * Constructs a new BatchWriteRequest.
+                     * @memberof google.firestore.v1beta1
+                     * @classdesc Represents a BatchWriteRequest.
+                     * @implements IBatchWriteRequest
+                     * @constructor
+                     * @param {google.firestore.v1beta1.IBatchWriteRequest=} [properties] Properties to set
+                     */
+                    function BatchWriteRequest(properties) {
+                        this.writes = [];
+                        this.labels = {};
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+    
+                    /**
+                     * BatchWriteRequest database.
+                     * @member {string} database
+                     * @memberof google.firestore.v1beta1.BatchWriteRequest
+                     * @instance
+                     */
+                    BatchWriteRequest.prototype.database = "";
+    
+                    /**
+                     * BatchWriteRequest writes.
+                     * @member {Array.<google.firestore.v1beta1.IWrite>} writes
+                     * @memberof google.firestore.v1beta1.BatchWriteRequest
+                     * @instance
+                     */
+                    BatchWriteRequest.prototype.writes = $util.emptyArray;
+    
+                    /**
+                     * BatchWriteRequest labels.
+                     * @member {Object.<string,string>} labels
+                     * @memberof google.firestore.v1beta1.BatchWriteRequest
+                     * @instance
+                     */
+                    BatchWriteRequest.prototype.labels = $util.emptyObject;
+    
+                    /**
+                     * Creates a BatchWriteRequest message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.firestore.v1beta1.BatchWriteRequest
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.firestore.v1beta1.BatchWriteRequest} BatchWriteRequest
+                     */
+                    BatchWriteRequest.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.firestore.v1beta1.BatchWriteRequest)
+                            return object;
+                        var message = new $root.google.firestore.v1beta1.BatchWriteRequest();
+                        if (object.database != null)
+                            message.database = String(object.database);
+                        if (object.writes) {
+                            if (!Array.isArray(object.writes))
+                                throw TypeError(".google.firestore.v1beta1.BatchWriteRequest.writes: array expected");
+                            message.writes = [];
+                            for (var i = 0; i < object.writes.length; ++i) {
+                                if (typeof object.writes[i] !== "object")
+                                    throw TypeError(".google.firestore.v1beta1.BatchWriteRequest.writes: object expected");
+                                message.writes[i] = $root.google.firestore.v1beta1.Write.fromObject(object.writes[i]);
+                            }
+                        }
+                        if (object.labels) {
+                            if (typeof object.labels !== "object")
+                                throw TypeError(".google.firestore.v1beta1.BatchWriteRequest.labels: object expected");
+                            message.labels = {};
+                            for (var keys = Object.keys(object.labels), i = 0; i < keys.length; ++i)
+                                message.labels[keys[i]] = String(object.labels[keys[i]]);
+                        }
+                        return message;
+                    };
+    
+                    /**
+                     * Creates a plain object from a BatchWriteRequest message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.firestore.v1beta1.BatchWriteRequest
+                     * @static
+                     * @param {google.firestore.v1beta1.BatchWriteRequest} message BatchWriteRequest
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    BatchWriteRequest.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.arrays || options.defaults)
+                            object.writes = [];
+                        if (options.objects || options.defaults)
+                            object.labels = {};
+                        if (options.defaults)
+                            object.database = "";
+                        if (message.database != null && message.hasOwnProperty("database"))
+                            object.database = message.database;
+                        if (message.writes && message.writes.length) {
+                            object.writes = [];
+                            for (var j = 0; j < message.writes.length; ++j)
+                                object.writes[j] = $root.google.firestore.v1beta1.Write.toObject(message.writes[j], options);
+                        }
+                        var keys2;
+                        if (message.labels && (keys2 = Object.keys(message.labels)).length) {
+                            object.labels = {};
+                            for (var j = 0; j < keys2.length; ++j)
+                                object.labels[keys2[j]] = message.labels[keys2[j]];
+                        }
+                        return object;
+                    };
+    
+                    /**
+                     * Converts this BatchWriteRequest to JSON.
+                     * @function toJSON
+                     * @memberof google.firestore.v1beta1.BatchWriteRequest
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    BatchWriteRequest.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+    
+                    return BatchWriteRequest;
+                })();
+    
+                v1beta1.BatchWriteResponse = (function() {
+    
+                    /**
+                     * Properties of a BatchWriteResponse.
+                     * @memberof google.firestore.v1beta1
+                     * @interface IBatchWriteResponse
+                     * @property {Array.<google.firestore.v1beta1.IWriteResult>|null} [writeResults] BatchWriteResponse writeResults
+                     * @property {Array.<google.rpc.IStatus>|null} [status] BatchWriteResponse status
+                     */
+    
+                    /**
+                     * Constructs a new BatchWriteResponse.
+                     * @memberof google.firestore.v1beta1
+                     * @classdesc Represents a BatchWriteResponse.
+                     * @implements IBatchWriteResponse
+                     * @constructor
+                     * @param {google.firestore.v1beta1.IBatchWriteResponse=} [properties] Properties to set
+                     */
+                    function BatchWriteResponse(properties) {
+                        this.writeResults = [];
+                        this.status = [];
+                        if (properties)
+                            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                if (properties[keys[i]] != null)
+                                    this[keys[i]] = properties[keys[i]];
+                    }
+    
+                    /**
+                     * BatchWriteResponse writeResults.
+                     * @member {Array.<google.firestore.v1beta1.IWriteResult>} writeResults
+                     * @memberof google.firestore.v1beta1.BatchWriteResponse
+                     * @instance
+                     */
+                    BatchWriteResponse.prototype.writeResults = $util.emptyArray;
+    
+                    /**
+                     * BatchWriteResponse status.
+                     * @member {Array.<google.rpc.IStatus>} status
+                     * @memberof google.firestore.v1beta1.BatchWriteResponse
+                     * @instance
+                     */
+                    BatchWriteResponse.prototype.status = $util.emptyArray;
+    
+                    /**
+                     * Creates a BatchWriteResponse message from a plain object. Also converts values to their respective internal types.
+                     * @function fromObject
+                     * @memberof google.firestore.v1beta1.BatchWriteResponse
+                     * @static
+                     * @param {Object.<string,*>} object Plain object
+                     * @returns {google.firestore.v1beta1.BatchWriteResponse} BatchWriteResponse
+                     */
+                    BatchWriteResponse.fromObject = function fromObject(object) {
+                        if (object instanceof $root.google.firestore.v1beta1.BatchWriteResponse)
+                            return object;
+                        var message = new $root.google.firestore.v1beta1.BatchWriteResponse();
+                        if (object.writeResults) {
+                            if (!Array.isArray(object.writeResults))
+                                throw TypeError(".google.firestore.v1beta1.BatchWriteResponse.writeResults: array expected");
+                            message.writeResults = [];
+                            for (var i = 0; i < object.writeResults.length; ++i) {
+                                if (typeof object.writeResults[i] !== "object")
+                                    throw TypeError(".google.firestore.v1beta1.BatchWriteResponse.writeResults: object expected");
+                                message.writeResults[i] = $root.google.firestore.v1beta1.WriteResult.fromObject(object.writeResults[i]);
+                            }
+                        }
+                        if (object.status) {
+                            if (!Array.isArray(object.status))
+                                throw TypeError(".google.firestore.v1beta1.BatchWriteResponse.status: array expected");
+                            message.status = [];
+                            for (var i = 0; i < object.status.length; ++i) {
+                                if (typeof object.status[i] !== "object")
+                                    throw TypeError(".google.firestore.v1beta1.BatchWriteResponse.status: object expected");
+                                message.status[i] = $root.google.rpc.Status.fromObject(object.status[i]);
+                            }
+                        }
+                        return message;
+                    };
+    
+                    /**
+                     * Creates a plain object from a BatchWriteResponse message. Also converts values to other types if specified.
+                     * @function toObject
+                     * @memberof google.firestore.v1beta1.BatchWriteResponse
+                     * @static
+                     * @param {google.firestore.v1beta1.BatchWriteResponse} message BatchWriteResponse
+                     * @param {$protobuf.IConversionOptions} [options] Conversion options
+                     * @returns {Object.<string,*>} Plain object
+                     */
+                    BatchWriteResponse.toObject = function toObject(message, options) {
+                        if (!options)
+                            options = {};
+                        var object = {};
+                        if (options.arrays || options.defaults) {
+                            object.writeResults = [];
+                            object.status = [];
+                        }
+                        if (message.writeResults && message.writeResults.length) {
+                            object.writeResults = [];
+                            for (var j = 0; j < message.writeResults.length; ++j)
+                                object.writeResults[j] = $root.google.firestore.v1beta1.WriteResult.toObject(message.writeResults[j], options);
+                        }
+                        if (message.status && message.status.length) {
+                            object.status = [];
+                            for (var j = 0; j < message.status.length; ++j)
+                                object.status[j] = $root.google.rpc.Status.toObject(message.status[j], options);
+                        }
+                        return object;
+                    };
+    
+                    /**
+                     * Converts this BatchWriteResponse to JSON.
+                     * @function toJSON
+                     * @memberof google.firestore.v1beta1.BatchWriteResponse
+                     * @instance
+                     * @returns {Object.<string,*>} JSON object
+                     */
+                    BatchWriteResponse.prototype.toJSON = function toJSON() {
+                        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                    };
+    
+                    return BatchWriteResponse;
+                })();
+    
                 v1beta1.StructuredQuery = (function() {
     
                     /**
@@ -11780,6 +12386,10 @@
                             case 5:
                                 message.op = 5;
                                 break;
+                            case "NOT_EQUAL":
+                            case 6:
+                                message.op = 6;
+                                break;
                             case "ARRAY_CONTAINS":
                             case 7:
                                 message.op = 7;
@@ -11791,6 +12401,10 @@
                             case "ARRAY_CONTAINS_ANY":
                             case 9:
                                 message.op = 9;
+                                break;
+                            case "NOT_IN":
+                            case 10:
+                                message.op = 10;
                                 break;
                             }
                             if (object.value != null) {
@@ -11849,9 +12463,11 @@
                          * @property {string} GREATER_THAN=GREATER_THAN GREATER_THAN value
                          * @property {string} GREATER_THAN_OR_EQUAL=GREATER_THAN_OR_EQUAL GREATER_THAN_OR_EQUAL value
                          * @property {string} EQUAL=EQUAL EQUAL value
+                         * @property {string} NOT_EQUAL=NOT_EQUAL NOT_EQUAL value
                          * @property {string} ARRAY_CONTAINS=ARRAY_CONTAINS ARRAY_CONTAINS value
                          * @property {string} IN=IN IN value
                          * @property {string} ARRAY_CONTAINS_ANY=ARRAY_CONTAINS_ANY ARRAY_CONTAINS_ANY value
+                         * @property {string} NOT_IN=NOT_IN NOT_IN value
                          */
                         FieldFilter.Operator = (function() {
                             var valuesById = {}, values = Object.create(valuesById);
@@ -11861,9 +12477,11 @@
                             values[valuesById[3] = "GREATER_THAN"] = "GREATER_THAN";
                             values[valuesById[4] = "GREATER_THAN_OR_EQUAL"] = "GREATER_THAN_OR_EQUAL";
                             values[valuesById[5] = "EQUAL"] = "EQUAL";
+                            values[valuesById[6] = "NOT_EQUAL"] = "NOT_EQUAL";
                             values[valuesById[7] = "ARRAY_CONTAINS"] = "ARRAY_CONTAINS";
                             values[valuesById[8] = "IN"] = "IN";
                             values[valuesById[9] = "ARRAY_CONTAINS_ANY"] = "ARRAY_CONTAINS_ANY";
+                            values[valuesById[10] = "NOT_IN"] = "NOT_IN";
                             return values;
                         })();
     
@@ -11950,6 +12568,14 @@
                             case 3:
                                 message.op = 3;
                                 break;
+                            case "IS_NOT_NAN":
+                            case 4:
+                                message.op = 4;
+                                break;
+                            case "IS_NOT_NULL":
+                            case 5:
+                                message.op = 5;
+                                break;
                             }
                             if (object.field != null) {
                                 if (typeof object.field !== "object")
@@ -12002,16 +12628,103 @@
                          * @property {string} OPERATOR_UNSPECIFIED=OPERATOR_UNSPECIFIED OPERATOR_UNSPECIFIED value
                          * @property {string} IS_NAN=IS_NAN IS_NAN value
                          * @property {string} IS_NULL=IS_NULL IS_NULL value
+                         * @property {string} IS_NOT_NAN=IS_NOT_NAN IS_NOT_NAN value
+                         * @property {string} IS_NOT_NULL=IS_NOT_NULL IS_NOT_NULL value
                          */
                         UnaryFilter.Operator = (function() {
                             var valuesById = {}, values = Object.create(valuesById);
                             values[valuesById[0] = "OPERATOR_UNSPECIFIED"] = "OPERATOR_UNSPECIFIED";
                             values[valuesById[2] = "IS_NAN"] = "IS_NAN";
                             values[valuesById[3] = "IS_NULL"] = "IS_NULL";
+                            values[valuesById[4] = "IS_NOT_NAN"] = "IS_NOT_NAN";
+                            values[valuesById[5] = "IS_NOT_NULL"] = "IS_NOT_NULL";
                             return values;
                         })();
     
                         return UnaryFilter;
+                    })();
+    
+                    StructuredQuery.FieldReference = (function() {
+    
+                        /**
+                         * Properties of a FieldReference.
+                         * @memberof google.firestore.v1beta1.StructuredQuery
+                         * @interface IFieldReference
+                         * @property {string|null} [fieldPath] FieldReference fieldPath
+                         */
+    
+                        /**
+                         * Constructs a new FieldReference.
+                         * @memberof google.firestore.v1beta1.StructuredQuery
+                         * @classdesc Represents a FieldReference.
+                         * @implements IFieldReference
+                         * @constructor
+                         * @param {google.firestore.v1beta1.StructuredQuery.IFieldReference=} [properties] Properties to set
+                         */
+                        function FieldReference(properties) {
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * FieldReference fieldPath.
+                         * @member {string} fieldPath
+                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
+                         * @instance
+                         */
+                        FieldReference.prototype.fieldPath = "";
+    
+                        /**
+                         * Creates a FieldReference message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.firestore.v1beta1.StructuredQuery.FieldReference} FieldReference
+                         */
+                        FieldReference.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.firestore.v1beta1.StructuredQuery.FieldReference)
+                                return object;
+                            var message = new $root.google.firestore.v1beta1.StructuredQuery.FieldReference();
+                            if (object.fieldPath != null)
+                                message.fieldPath = String(object.fieldPath);
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a FieldReference message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
+                         * @static
+                         * @param {google.firestore.v1beta1.StructuredQuery.FieldReference} message FieldReference
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        FieldReference.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.defaults)
+                                object.fieldPath = "";
+                            if (message.fieldPath != null && message.hasOwnProperty("fieldPath"))
+                                object.fieldPath = message.fieldPath;
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this FieldReference to JSON.
+                         * @function toJSON
+                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        FieldReference.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        return FieldReference;
                     })();
     
                     StructuredQuery.Order = (function() {
@@ -12125,89 +12838,6 @@
                         };
     
                         return Order;
-                    })();
-    
-                    StructuredQuery.FieldReference = (function() {
-    
-                        /**
-                         * Properties of a FieldReference.
-                         * @memberof google.firestore.v1beta1.StructuredQuery
-                         * @interface IFieldReference
-                         * @property {string|null} [fieldPath] FieldReference fieldPath
-                         */
-    
-                        /**
-                         * Constructs a new FieldReference.
-                         * @memberof google.firestore.v1beta1.StructuredQuery
-                         * @classdesc Represents a FieldReference.
-                         * @implements IFieldReference
-                         * @constructor
-                         * @param {google.firestore.v1beta1.StructuredQuery.IFieldReference=} [properties] Properties to set
-                         */
-                        function FieldReference(properties) {
-                            if (properties)
-                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                                    if (properties[keys[i]] != null)
-                                        this[keys[i]] = properties[keys[i]];
-                        }
-    
-                        /**
-                         * FieldReference fieldPath.
-                         * @member {string} fieldPath
-                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
-                         * @instance
-                         */
-                        FieldReference.prototype.fieldPath = "";
-    
-                        /**
-                         * Creates a FieldReference message from a plain object. Also converts values to their respective internal types.
-                         * @function fromObject
-                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
-                         * @static
-                         * @param {Object.<string,*>} object Plain object
-                         * @returns {google.firestore.v1beta1.StructuredQuery.FieldReference} FieldReference
-                         */
-                        FieldReference.fromObject = function fromObject(object) {
-                            if (object instanceof $root.google.firestore.v1beta1.StructuredQuery.FieldReference)
-                                return object;
-                            var message = new $root.google.firestore.v1beta1.StructuredQuery.FieldReference();
-                            if (object.fieldPath != null)
-                                message.fieldPath = String(object.fieldPath);
-                            return message;
-                        };
-    
-                        /**
-                         * Creates a plain object from a FieldReference message. Also converts values to other types if specified.
-                         * @function toObject
-                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
-                         * @static
-                         * @param {google.firestore.v1beta1.StructuredQuery.FieldReference} message FieldReference
-                         * @param {$protobuf.IConversionOptions} [options] Conversion options
-                         * @returns {Object.<string,*>} Plain object
-                         */
-                        FieldReference.toObject = function toObject(message, options) {
-                            if (!options)
-                                options = {};
-                            var object = {};
-                            if (options.defaults)
-                                object.fieldPath = "";
-                            if (message.fieldPath != null && message.hasOwnProperty("fieldPath"))
-                                object.fieldPath = message.fieldPath;
-                            return object;
-                        };
-    
-                        /**
-                         * Converts this FieldReference to JSON.
-                         * @function toJSON
-                         * @memberof google.firestore.v1beta1.StructuredQuery.FieldReference
-                         * @instance
-                         * @returns {Object.<string,*>} JSON object
-                         */
-                        FieldReference.prototype.toJSON = function toJSON() {
-                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-                        };
-    
-                        return FieldReference;
                     })();
     
                     StructuredQuery.Projection = (function() {
@@ -12444,6 +13074,7 @@
                      * @property {string|null} ["delete"] Write delete
                      * @property {google.firestore.v1beta1.IDocumentTransform|null} [transform] Write transform
                      * @property {google.firestore.v1beta1.IDocumentMask|null} [updateMask] Write updateMask
+                     * @property {Array.<google.firestore.v1beta1.DocumentTransform.IFieldTransform>|null} [updateTransforms] Write updateTransforms
                      * @property {google.firestore.v1beta1.IPrecondition|null} [currentDocument] Write currentDocument
                      */
     
@@ -12456,6 +13087,7 @@
                      * @param {google.firestore.v1beta1.IWrite=} [properties] Properties to set
                      */
                     function Write(properties) {
+                        this.updateTransforms = [];
                         if (properties)
                             for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                                 if (properties[keys[i]] != null)
@@ -12493,6 +13125,14 @@
                      * @instance
                      */
                     Write.prototype.updateMask = null;
+    
+                    /**
+                     * Write updateTransforms.
+                     * @member {Array.<google.firestore.v1beta1.DocumentTransform.IFieldTransform>} updateTransforms
+                     * @memberof google.firestore.v1beta1.Write
+                     * @instance
+                     */
+                    Write.prototype.updateTransforms = $util.emptyArray;
     
                     /**
                      * Write currentDocument.
@@ -12545,6 +13185,16 @@
                                 throw TypeError(".google.firestore.v1beta1.Write.updateMask: object expected");
                             message.updateMask = $root.google.firestore.v1beta1.DocumentMask.fromObject(object.updateMask);
                         }
+                        if (object.updateTransforms) {
+                            if (!Array.isArray(object.updateTransforms))
+                                throw TypeError(".google.firestore.v1beta1.Write.updateTransforms: array expected");
+                            message.updateTransforms = [];
+                            for (var i = 0; i < object.updateTransforms.length; ++i) {
+                                if (typeof object.updateTransforms[i] !== "object")
+                                    throw TypeError(".google.firestore.v1beta1.Write.updateTransforms: object expected");
+                                message.updateTransforms[i] = $root.google.firestore.v1beta1.DocumentTransform.FieldTransform.fromObject(object.updateTransforms[i]);
+                            }
+                        }
                         if (object.currentDocument != null) {
                             if (typeof object.currentDocument !== "object")
                                 throw TypeError(".google.firestore.v1beta1.Write.currentDocument: object expected");
@@ -12566,6 +13216,8 @@
                         if (!options)
                             options = {};
                         var object = {};
+                        if (options.arrays || options.defaults)
+                            object.updateTransforms = [];
                         if (options.defaults) {
                             object.updateMask = null;
                             object.currentDocument = null;
@@ -12588,6 +13240,11 @@
                             object.transform = $root.google.firestore.v1beta1.DocumentTransform.toObject(message.transform, options);
                             if (options.oneofs)
                                 object.operation = "transform";
+                        }
+                        if (message.updateTransforms && message.updateTransforms.length) {
+                            object.updateTransforms = [];
+                            for (var j = 0; j < message.updateTransforms.length; ++j)
+                                object.updateTransforms[j] = $root.google.firestore.v1beta1.DocumentTransform.FieldTransform.toObject(message.updateTransforms[j], options);
                         }
                         return object;
                     };

--- a/dev/protos/google/firestore/v1/common.proto
+++ b/dev/protos/google/firestore/v1/common.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/protos/google/firestore/v1/document.proto
+++ b/dev/protos/google/firestore/v1/document.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/protos/google/firestore/v1/firestore.proto
+++ b/dev/protos/google/firestore/v1/firestore.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/protos/google/firestore/v1/query.proto
+++ b/dev/protos/google/firestore/v1/query.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dev/protos/google/firestore/v1/write.proto
+++ b/dev/protos/google/firestore/v1/write.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,7 +80,8 @@ message DocumentTransform {
       SERVER_VALUE_UNSPECIFIED = 0;
 
       // The time at which the server processed the request, with millisecond
-      // precision.
+      // precision. If used on multiple fields (same or different documents) in
+      // a transaction, all the fields will get the same server timestamp.
       REQUEST_TIME = 1;
     }
 

--- a/dev/protos/google/firestore/v1beta1/common.proto
+++ b/dev/protos/google/firestore/v1beta1/common.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 

--- a/dev/protos/google/firestore/v1beta1/document.proto
+++ b/dev/protos/google/firestore/v1beta1/document.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 

--- a/dev/protos/google/firestore/v1beta1/firestore.proto
+++ b/dev/protos/google/firestore/v1beta1/firestore.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -41,20 +40,12 @@ option ruby_package = "Google::Cloud::Firestore::V1beta1";
 
 // The Cloud Firestore service.
 //
-// This service exposes several types of comparable timestamps:
-//
-// *    `create_time` - The time at which a document was created. Changes only
-//      when a document is deleted, then re-created. Increases in a strict
-//       monotonic fashion.
-// *    `update_time` - The time at which a document was last updated. Changes
-//      every time a document is modified. Does not change when a write results
-//      in no modifications. Increases in a strict monotonic fashion.
-// *    `read_time` - The time at which a particular state was observed. Used
-//      to denote a consistent snapshot of the database or the time at which a
-//      Document was observed to not exist.
-// *    `commit_time` - The time at which the writes in a transaction were
-//      committed. Any read with an equal or greater `read_time` is guaranteed
-//      to see the effects of the transaction.
+// Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL
+// document database that simplifies storing, syncing, and querying data for
+// your mobile, web, and IoT apps at global scale. Its client libraries provide
+// live synchronization and offline support, while its security features and
+// integrations with Firebase and Google Cloud Platform (GCP) accelerate
+// building truly serverless apps.
 service Firestore {
   option (google.api.default_host) = "firestore.googleapis.com";
   option (google.api.oauth_scopes) =
@@ -72,14 +63,6 @@ service Firestore {
   rpc ListDocuments(ListDocumentsRequest) returns (ListDocumentsResponse) {
     option (google.api.http) = {
       get: "/v1beta1/{parent=projects/*/databases/*/documents/*/**}/{collection_id}"
-    };
-  }
-
-  // Creates a new document.
-  rpc CreateDocument(CreateDocumentRequest) returns (Document) {
-    option (google.api.http) = {
-      post: "/v1beta1/{parent=projects/*/databases/*/documents/**}/{collection_id}"
-      body: "document"
     };
   }
 
@@ -150,6 +133,20 @@ service Firestore {
     };
   }
 
+  // Partitions a query by returning partition cursors that can be used to run
+  // the query in parallel. The returned partition cursors are split points that
+  // can be used by RunQuery as starting/end points for the query results.
+  rpc PartitionQuery(PartitionQueryRequest) returns (PartitionQueryResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/{parent=projects/*/databases/*/documents}:partitionQuery"
+      body: "*"
+      additional_bindings {
+        post: "/v1beta1/{parent=projects/*/databases/*/documents/*/**}:partitionQuery"
+        body: "*"
+      }
+    };
+  }
+
   // Streams batches of document updates and deletes, in order.
   rpc Write(stream WriteRequest) returns (stream WriteResponse) {
     option (google.api.http) = {
@@ -178,6 +175,30 @@ service Firestore {
     };
     option (google.api.method_signature) = "parent";
   }
+
+  // Applies a batch of write operations.
+  //
+  // The BatchWrite method does not apply the write operations atomically
+  // and can apply them out of order. Method does not allow more than one write
+  // per document. Each write succeeds or fails independently. See the
+  // [BatchWriteResponse][google.firestore.v1beta1.BatchWriteResponse] for the success status of each write.
+  //
+  // If you require an atomically applied set of writes, use
+  // [Commit][google.firestore.v1beta1.Firestore.Commit] instead.
+  rpc BatchWrite(BatchWriteRequest) returns (BatchWriteResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/{database=projects/*/databases/*}/documents:batchWrite"
+      body: "*"
+    };
+  }
+
+  // Creates a new document.
+  rpc CreateDocument(CreateDocumentRequest) returns (Document) {
+    option (google.api.http) = {
+      post: "/v1beta1/{parent=projects/*/databases/*/documents/**}/{collection_id}"
+      body: "document"
+    };
+  }
 }
 
 // The request for [Firestore.GetDocument][google.firestore.v1beta1.Firestore.GetDocument].
@@ -199,7 +220,7 @@ message GetDocumentRequest {
     bytes transaction = 3;
 
     // Reads the version of the document at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 5;
   }
 }
@@ -240,7 +261,7 @@ message ListDocumentsRequest {
     bytes transaction = 8;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 10;
   }
 
@@ -356,7 +377,7 @@ message BatchGetDocumentsRequest {
     TransactionOptions new_transaction = 5;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 7;
   }
 }
@@ -426,7 +447,8 @@ message CommitResponse {
   // request.
   repeated WriteResult write_results = 1;
 
-  // The time at which the commit occurred.
+  // The time at which the commit occurred. Any read with an equal or greater
+  // `read_time` is guaranteed to see the effects of the commit.
   google.protobuf.Timestamp commit_time = 2;
 }
 
@@ -469,7 +491,7 @@ message RunQueryRequest {
     TransactionOptions new_transaction = 6;
 
     // Reads documents as they were at the given time.
-    // This may not be older than 60 seconds.
+    // This may not be older than 270 seconds.
     google.protobuf.Timestamp read_time = 7;
   }
 }
@@ -498,6 +520,85 @@ message RunQueryResponse {
   // The number of results that have been skipped due to an offset between
   // the last response and the current response.
   int32 skipped_results = 4;
+}
+
+// The request for [Firestore.PartitionQuery][google.firestore.v1beta1.Firestore.PartitionQuery].
+message PartitionQueryRequest {
+  // Required. The parent resource name. In the format:
+  // `projects/{project_id}/databases/{database_id}/documents`.
+  // Document resource names are not supported; only database resource names
+  // can be specified.
+  string parent = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The query to partition.
+  oneof query_type {
+    // A structured query.
+    // Query must specify collection with all descendants and be ordered by name
+    // ascending. Other filters, order bys, limits, offsets, and start/end
+    // cursors are not supported.
+    StructuredQuery structured_query = 2;
+  }
+
+  // The desired maximum number of partition points.
+  // The partitions may be returned across multiple pages of results.
+  // The number must be positive. The actual number of partitions
+  // returned may be fewer.
+  //
+  // For example, this may be set to one fewer than the number of parallel
+  // queries to be run, or in running a data pipeline job, one fewer than the
+  // number of workers or compute instances available.
+  int64 partition_count = 3;
+
+  // The `next_page_token` value returned from a previous call to
+  // PartitionQuery that may be used to get an additional set of results.
+  // There are no ordering guarantees between sets of results. Thus, using
+  // multiple sets of results will require merging the different result sets.
+  //
+  // For example, two subsequent calls using a page_token may return:
+  //
+  //  * cursor B, cursor M, cursor Q
+  //  * cursor A, cursor U, cursor W
+  //
+  // To obtain a complete result set ordered with respect to the results of the
+  // query supplied to PartitionQuery, the results sets should be merged:
+  // cursor A, cursor B, cursor M, cursor Q, cursor U, cursor W
+  string page_token = 4;
+
+  // The maximum number of partitions to return in this call, subject to
+  // `partition_count`.
+  //
+  // For example, if `partition_count` = 10 and `page_size` = 8, the first call
+  // to PartitionQuery will return up to 8 partitions and a `next_page_token`
+  // if more results exist. A second call to PartitionQuery will return up to
+  // 2 partitions, to complete the total of 10 specified in `partition_count`.
+  int32 page_size = 5;
+}
+
+// The response for [Firestore.PartitionQuery][google.firestore.v1beta1.Firestore.PartitionQuery].
+message PartitionQueryResponse {
+  // Partition results.
+  // Each partition is a split point that can be used by RunQuery as a starting
+  // or end point for the query results. The RunQuery requests must be made with
+  // the same query supplied to this PartitionQuery request. The partition
+  // cursors will be ordered according to same ordering as the results of the
+  // query supplied to PartitionQuery.
+  //
+  // For example, if a PartitionQuery request returns partition cursors A and B,
+  // running the following three queries will return the entire result set of
+  // the original query:
+  //
+  //  * query, end_at A
+  //  * query, start_at A, end_at B
+  //  * query, start_at B
+  //
+  // An empty result may indicate that the query has too few results to be
+  // partitioned.
+  repeated Cursor partitions = 1;
+
+  // A page token that may be used to request an additional set of results, up
+  // to the number specified by `partition_count` in the PartitionQuery request.
+  // If blank, there are no more results.
+  string next_page_token = 2;
 }
 
 // The request for [Firestore.Write][google.firestore.v1beta1.Firestore.Write].
@@ -567,7 +668,8 @@ message WriteResponse {
   // request.
   repeated WriteResult write_results = 3;
 
-  // The time at which the commit occurred.
+  // The time at which the commit occurred. Any read with an equal or greater
+  // `read_time` is guaranteed to see the effects of the write.
   google.protobuf.Timestamp commit_time = 4;
 }
 
@@ -763,4 +865,36 @@ message ListCollectionIdsResponse {
 
   // A page token that may be used to continue the list.
   string next_page_token = 2;
+}
+
+// The request for [Firestore.BatchWrite][google.firestore.v1beta1.Firestore.BatchWrite].
+message BatchWriteRequest {
+  // Required. The database name. In the format:
+  // `projects/{project_id}/databases/{database_id}`.
+  string database = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The writes to apply.
+  //
+  // Method does not apply writes atomically and does not guarantee ordering.
+  // Each write succeeds or fails independently. You cannot write to the same
+  // document more than once per request.
+  repeated Write writes = 2;
+
+  // Labels associated with this batch write.
+  map<string, string> labels = 3;
+}
+
+// The response from [Firestore.BatchWrite][google.firestore.v1beta1.Firestore.BatchWrite].
+message BatchWriteResponse {
+  // The result of applying the writes.
+  //
+  // This i-th write result corresponds to the i-th write in the
+  // request.
+  repeated WriteResult write_results = 1;
+
+  // The status of applying the writes.
+  //
+  // This i-th write status corresponds to the i-th write in the
+  // request.
+  repeated google.rpc.Status status = 2;
 }

--- a/dev/protos/google/firestore/v1beta1/query.proto
+++ b/dev/protos/google/firestore/v1beta1/query.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -85,32 +84,74 @@ message StructuredQuery {
       // Unspecified. This value must not be used.
       OPERATOR_UNSPECIFIED = 0;
 
-      // Less than. Requires that the field come first in `order_by`.
+      // The given `field` is less than the given `value`.
+      //
+      // Requires:
+      //
+      // * That `field` come first in `order_by`.
       LESS_THAN = 1;
 
-      // Less than or equal. Requires that the field come first in `order_by`.
+      // The given `field` is less than or equal to the given `value`.
+      //
+      // Requires:
+      //
+      // * That `field` come first in `order_by`.
       LESS_THAN_OR_EQUAL = 2;
 
-      // Greater than. Requires that the field come first in `order_by`.
+      // The given `field` is greater than the given `value`.
+      //
+      // Requires:
+      //
+      // * That `field` come first in `order_by`.
       GREATER_THAN = 3;
 
-      // Greater than or equal. Requires that the field come first in
-      // `order_by`.
+      // The given `field` is greater than or equal to the given `value`.
+      //
+      // Requires:
+      //
+      // * That `field` come first in `order_by`.
       GREATER_THAN_OR_EQUAL = 4;
 
-      // Equal.
+      // The given `field` is equal to the given `value`.
       EQUAL = 5;
 
-      // Contains. Requires that the field is an array.
+      // The given `field` is not equal to the given `value`.
+      //
+      // Requires:
+      //
+      // * No other `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
+      // * That `field` comes first in the `order_by`.
+      NOT_EQUAL = 6;
+
+      // The given `field` is an array that contains the given `value`.
       ARRAY_CONTAINS = 7;
 
-      // In. Requires that `value` is a non-empty ArrayValue with at most 10
-      // values.
+      // The given `field` is equal to at least one value in the given array.
+      //
+      // Requires:
+      //
+      // * That `value` is a non-empty `ArrayValue` with at most 10 values.
+      // * No other `IN` or `ARRAY_CONTAINS_ANY` or `NOT_IN`.
       IN = 8;
 
-      // Contains any. Requires that the field is an array and
-      // `value` is a non-empty ArrayValue with at most 10 values.
+      // The given `field` is an array that contains any of the values in the
+      // given array.
+      //
+      // Requires:
+      //
+      // * That `value` is a non-empty `ArrayValue` with at most 10 values.
+      // * No other `IN` or `ARRAY_CONTAINS_ANY` or `NOT_IN`.
       ARRAY_CONTAINS_ANY = 9;
+
+      // The value of the `field` is not in the given array.
+      //
+      // Requires:
+      //
+      // * That `value` is a non-empty `ArrayValue` with at most 10 values.
+      // * No other `IN`, `ARRAY_CONTAINS_ANY`, `NOT_IN`, `NOT_EQUAL`,
+      //   `IS_NOT_NULL`, or `IS_NOT_NAN`.
+      // * That `field` comes first in the `order_by`.
+      NOT_IN = 10;
     }
 
     // The field to filter by.
@@ -130,11 +171,27 @@ message StructuredQuery {
       // Unspecified. This value must not be used.
       OPERATOR_UNSPECIFIED = 0;
 
-      // Test if a field is equal to NaN.
+      // The given `field` is equal to `NaN`.
       IS_NAN = 2;
 
-      // Test if an expression evaluates to Null.
+      // The given `field` is equal to `NULL`.
       IS_NULL = 3;
+
+      // The given `field` is not equal to `NaN`.
+      //
+      // Requires:
+      //
+      // * No other `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
+      // * That `field` comes first in the `order_by`.
+      IS_NOT_NAN = 4;
+
+      // The given `field` is not equal to `NULL`.
+      //
+      // Requires:
+      //
+      // * A single `NOT_EQUAL`, `NOT_IN`, `IS_NOT_NULL`, or `IS_NOT_NAN`.
+      // * That `field` comes first in the `order_by`.
+      IS_NOT_NULL = 5;
     }
 
     // The unary operator to apply.
@@ -147,6 +204,11 @@ message StructuredQuery {
     }
   }
 
+  // A reference to a field, such as `max(messages.time) as max_time`.
+  message FieldReference {
+    string field_path = 2;
+  }
+
   // An order on a field.
   message Order {
     // The field to order by.
@@ -154,11 +216,6 @@ message StructuredQuery {
 
     // The direction to order by. Defaults to `ASCENDING`.
     Direction direction = 2;
-  }
-
-  // A reference to a field, such as `max(messages.time) as max_time`.
-  message FieldReference {
-    string field_path = 2;
   }
 
   // The projection of document's fields to return.

--- a/dev/protos/google/firestore/v1beta1/write.proto
+++ b/dev/protos/google/firestore/v1beta1/write.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -43,9 +42,6 @@ message Write {
     string delete = 2;
 
     // Applies a transformation to a document.
-    // At most one `transform` per document is allowed in a given request.
-    // An `update` cannot follow a `transform` on the same document in a given
-    // request.
     DocumentTransform transform = 6;
   }
 
@@ -60,6 +56,13 @@ message Write {
   // deleted from the document on the server.
   // The field paths in this mask must not contain a reserved field name.
   DocumentMask update_mask = 3;
+
+  // The transforms to perform after update.
+  //
+  // This field can be set only when the operation is `update`. If present, this
+  // write is equivalent to performing `update` and `transform` to the same
+  // document atomically and in order.
+  repeated DocumentTransform.FieldTransform update_transforms = 7;
 
   // An optional precondition on the document.
   //
@@ -77,7 +80,8 @@ message DocumentTransform {
       SERVER_VALUE_UNSPECIFIED = 0;
 
       // The time at which the server processed the request, with millisecond
-      // precision.
+      // precision. If used on multiple fields (same or different documents) in
+      // a transaction, all the fields will get the same server timestamp.
       REQUEST_TIME = 1;
     }
 

--- a/dev/protos/protos.json
+++ b/dev/protos/protos.json
@@ -2535,22 +2535,6 @@
                         }
                       ]
                     },
-                    "CreateDocument": {
-                      "requestType": "CreateDocumentRequest",
-                      "responseType": "Document",
-                      "options": {
-                        "(google.api.http).post": "/v1beta1/{parent=projects/*/databases/*/documents/**}/{collection_id}",
-                        "(google.api.http).body": "document"
-                      },
-                      "parsedOptions": [
-                        {
-                          "(google.api.http)": {
-                            "post": "/v1beta1/{parent=projects/*/databases/*/documents/**}/{collection_id}",
-                            "body": "document"
-                          }
-                        }
-                      ]
-                    },
                     "UpdateDocument": {
                       "requestType": "UpdateDocumentRequest",
                       "responseType": "Document",
@@ -2689,6 +2673,28 @@
                         }
                       ]
                     },
+                    "PartitionQuery": {
+                      "requestType": "PartitionQueryRequest",
+                      "responseType": "PartitionQueryResponse",
+                      "options": {
+                        "(google.api.http).post": "/v1beta1/{parent=projects/*/databases/*/documents}:partitionQuery",
+                        "(google.api.http).body": "*",
+                        "(google.api.http).additional_bindings.post": "/v1beta1/{parent=projects/*/databases/*/documents/*/**}:partitionQuery",
+                        "(google.api.http).additional_bindings.body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1beta1/{parent=projects/*/databases/*/documents}:partitionQuery",
+                            "body": "*",
+                            "additional_bindings": {
+                              "post": "/v1beta1/{parent=projects/*/databases/*/documents/*/**}:partitionQuery",
+                              "body": "*"
+                            }
+                          }
+                        }
+                      ]
+                    },
                     "Write": {
                       "requestType": "WriteRequest",
                       "requestStream": true,
@@ -2748,6 +2754,38 @@
                         },
                         {
                           "(google.api.method_signature)": "parent"
+                        }
+                      ]
+                    },
+                    "BatchWrite": {
+                      "requestType": "BatchWriteRequest",
+                      "responseType": "BatchWriteResponse",
+                      "options": {
+                        "(google.api.http).post": "/v1beta1/{database=projects/*/databases/*}/documents:batchWrite",
+                        "(google.api.http).body": "*"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1beta1/{database=projects/*/databases/*}/documents:batchWrite",
+                            "body": "*"
+                          }
+                        }
+                      ]
+                    },
+                    "CreateDocument": {
+                      "requestType": "CreateDocumentRequest",
+                      "responseType": "Document",
+                      "options": {
+                        "(google.api.http).post": "/v1beta1/{parent=projects/*/databases/*/documents/**}/{collection_id}",
+                        "(google.api.http).body": "document"
+                      },
+                      "parsedOptions": [
+                        {
+                          "(google.api.http)": {
+                            "post": "/v1beta1/{parent=projects/*/databases/*/documents/**}/{collection_id}",
+                            "body": "document"
+                          }
                         }
                       ]
                     }
@@ -3126,6 +3164,53 @@
                     }
                   }
                 },
+                "PartitionQueryRequest": {
+                  "oneofs": {
+                    "queryType": {
+                      "oneof": [
+                        "structuredQuery"
+                      ]
+                    }
+                  },
+                  "fields": {
+                    "parent": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "structuredQuery": {
+                      "type": "StructuredQuery",
+                      "id": 2
+                    },
+                    "partitionCount": {
+                      "type": "int64",
+                      "id": 3
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "pageSize": {
+                      "type": "int32",
+                      "id": 5
+                    }
+                  }
+                },
+                "PartitionQueryResponse": {
+                  "fields": {
+                    "partitions": {
+                      "rule": "repeated",
+                      "type": "Cursor",
+                      "id": 1
+                    },
+                    "nextPageToken": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                },
                 "WriteRequest": {
                   "fields": {
                     "database": {
@@ -3383,6 +3468,41 @@
                     }
                   }
                 },
+                "BatchWriteRequest": {
+                  "fields": {
+                    "database": {
+                      "type": "string",
+                      "id": 1,
+                      "options": {
+                        "(google.api.field_behavior)": "REQUIRED"
+                      }
+                    },
+                    "writes": {
+                      "rule": "repeated",
+                      "type": "Write",
+                      "id": 2
+                    },
+                    "labels": {
+                      "keyType": "string",
+                      "type": "string",
+                      "id": 3
+                    }
+                  }
+                },
+                "BatchWriteResponse": {
+                  "fields": {
+                    "writeResults": {
+                      "rule": "repeated",
+                      "type": "WriteResult",
+                      "id": 1
+                    },
+                    "status": {
+                      "rule": "repeated",
+                      "type": "google.rpc.Status",
+                      "id": 2
+                    }
+                  }
+                },
                 "StructuredQuery": {
                   "fields": {
                     "select": {
@@ -3503,9 +3623,11 @@
                             "GREATER_THAN": 3,
                             "GREATER_THAN_OR_EQUAL": 4,
                             "EQUAL": 5,
+                            "NOT_EQUAL": 6,
                             "ARRAY_CONTAINS": 7,
                             "IN": 8,
-                            "ARRAY_CONTAINS_ANY": 9
+                            "ARRAY_CONTAINS_ANY": 9,
+                            "NOT_IN": 10
                           }
                         }
                       }
@@ -3533,8 +3655,18 @@
                           "values": {
                             "OPERATOR_UNSPECIFIED": 0,
                             "IS_NAN": 2,
-                            "IS_NULL": 3
+                            "IS_NULL": 3,
+                            "IS_NOT_NAN": 4,
+                            "IS_NOT_NULL": 5
                           }
+                        }
+                      }
+                    },
+                    "FieldReference": {
+                      "fields": {
+                        "fieldPath": {
+                          "type": "string",
+                          "id": 2
                         }
                       }
                     },
@@ -3546,14 +3678,6 @@
                         },
                         "direction": {
                           "type": "Direction",
-                          "id": 2
-                        }
-                      }
-                    },
-                    "FieldReference": {
-                      "fields": {
-                        "fieldPath": {
-                          "type": "string",
                           "id": 2
                         }
                       }
@@ -3615,6 +3739,11 @@
                     "updateMask": {
                       "type": "DocumentMask",
                       "id": 3
+                    },
+                    "updateTransforms": {
+                      "rule": "repeated",
+                      "type": "DocumentTransform.FieldTransform",
+                      "id": 7
                     },
                     "currentDocument": {
                       "type": "Precondition",

--- a/dev/src/v1/firestore_client_config.json
+++ b/dev/src/v1/firestore_client_config.json
@@ -7,15 +7,18 @@
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
         ],
-        "deadline_exceeded_internal_unavailable": [
+        "deadline_exceeded_resource_exhausted_internal_unavailable": [
           "DEADLINE_EXCEEDED",
+          "RESOURCE_EXHAUSTED",
           "INTERNAL",
           "UNAVAILABLE"
         ],
-        "unavailable": [
+        "resource_exhausted_unavailable": [
+          "RESOURCE_EXHAUSTED",
           "UNAVAILABLE"
         ],
-        "aborted_unavailable": [
+        "resource_exhausted_aborted_unavailable": [
+          "RESOURCE_EXHAUSTED",
           "ABORTED",
           "UNAVAILABLE"
         ]
@@ -34,52 +37,52 @@
       "methods": {
         "GetDocument": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "ListDocuments": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "UpdateDocument": {
           "timeout_millis": 60000,
-          "retry_codes_name": "unavailable",
+          "retry_codes_name": "resource_exhausted_unavailable",
           "retry_params_name": "default"
         },
         "DeleteDocument": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "BatchGetDocuments": {
           "timeout_millis": 300000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "BeginTransaction": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "Commit": {
           "timeout_millis": 60000,
-          "retry_codes_name": "unavailable",
+          "retry_codes_name": "resource_exhausted_unavailable",
           "retry_params_name": "default"
         },
         "Rollback": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "RunQuery": {
           "timeout_millis": 300000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "PartitionQuery": {
           "timeout_millis": 300000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "Write": {
@@ -89,22 +92,22 @@
         },
         "Listen": {
           "timeout_millis": 86400000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "ListCollectionIds": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_internal_unavailable",
+          "retry_codes_name": "deadline_exceeded_resource_exhausted_internal_unavailable",
           "retry_params_name": "default"
         },
         "BatchWrite": {
           "timeout_millis": 60000,
-          "retry_codes_name": "aborted_unavailable",
+          "retry_codes_name": "resource_exhausted_aborted_unavailable",
           "retry_params_name": "default"
         },
         "CreateDocument": {
           "timeout_millis": 60000,
-          "retry_codes_name": "unavailable",
+          "retry_codes_name": "resource_exhausted_unavailable",
           "retry_params_name": "default"
         }
       }

--- a/dev/src/v1beta1/firestore_client.ts
+++ b/dev/src/v1beta1/firestore_client.ts
@@ -45,20 +45,12 @@ const version = require('../../../package.json').version;
 /**
  *  The Cloud Firestore service.
  *
- *  This service exposes several types of comparable timestamps:
- *
- *  *    `create_time` - The time at which a document was created. Changes only
- *       when a document is deleted, then re-created. Increases in a strict
- *        monotonic fashion.
- *  *    `update_time` - The time at which a document was last updated. Changes
- *       every time a document is modified. Does not change when a write results
- *       in no modifications. Increases in a strict monotonic fashion.
- *  *    `read_time` - The time at which a particular state was observed. Used
- *       to denote a consistent snapshot of the database or the time at which a
- *       Document was observed to not exist.
- *  *    `commit_time` - The time at which the writes in a transaction were
- *       committed. Any read with an equal or greater `read_time` is guaranteed
- *       to see the effects of the transaction.
+ *  Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL
+ *  document database that simplifies storing, syncing, and querying data for
+ *  your mobile, web, and IoT apps at global scale. Its client libraries provide
+ *  live synchronization and offline support, while its security features and
+ *  integrations with Firebase and Google Cloud Platform (GCP) accelerate
+ *  building truly serverless apps.
  * @class
  * @deprecated Use v1/firestore_client instead.
  * @memberof v1beta1
@@ -188,6 +180,11 @@ export class FirestoreClient {
         'nextPageToken',
         'documents'
       ),
+      partitionQuery: new this._gaxModule.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'partitions'
+      ),
       listCollectionIds: new this._gaxModule.PageDescriptor(
         'pageToken',
         'nextPageToken',
@@ -260,7 +257,6 @@ export class FirestoreClient {
     const firestoreStubMethods = [
       'getDocument',
       'listDocuments',
-      'createDocument',
       'updateDocument',
       'deleteDocument',
       'batchGetDocuments',
@@ -268,9 +264,12 @@ export class FirestoreClient {
       'commit',
       'rollback',
       'runQuery',
+      'partitionQuery',
       'write',
       'listen',
       'listCollectionIds',
+      'batchWrite',
+      'createDocument',
     ];
     for (const methodName of firestoreStubMethods) {
       const callPromise = this.firestoreStub.then(
@@ -402,7 +401,7 @@ export class FirestoreClient {
    *   Reads the document in a transaction.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads the version of the document at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -454,107 +453,6 @@ export class FirestoreClient {
     });
     this.initialize();
     return this.innerApiCalls.getDocument(request, options, callback);
-  }
-  createDocument(
-    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  createDocument(
-    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  createDocument(
-    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
-    callback: Callback<
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  /**
-   * Creates a new document.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.parent
-   *   Required. The parent resource. For example:
-   *   `projects/{project_id}/databases/{database_id}/documents` or
-   *   `projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}`
-   * @param {string} request.collectionId
-   *   Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`.
-   * @param {string} request.documentId
-   *   The client-assigned document ID to use for this document.
-   *
-   *   Optional. If not specified, an ID will be assigned by the service.
-   * @param {google.firestore.v1beta1.Document} request.document
-   *   Required. The document to create. `name` must not be set.
-   * @param {google.firestore.v1beta1.DocumentMask} request.mask
-   *   The fields to return. If not set, returns all fields.
-   *
-   *   If the document has a field that is not present in this mask, that field
-   *   will not be returned in the response.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Document]{@link google.firestore.v1beta1.Document}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * const [response] = await client.createDocument(request);
-   */
-  createDocument(
-    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
-    optionsOrCallback?:
-      | CallOptions
-      | Callback<
-          protos.google.firestore.v1beta1.IDocument,
-          | protos.google.firestore.v1beta1.ICreateDocumentRequest
-          | null
-          | undefined,
-          {} | null | undefined
-        >,
-    callback?: Callback<
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): Promise<
-    [
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | undefined,
-      {} | undefined
-    ]
-  > | void {
-    request = request || {};
-    let options: CallOptions;
-    if (typeof optionsOrCallback === 'function' && callback === undefined) {
-      callback = optionsOrCallback;
-      options = {};
-    } else {
-      options = optionsOrCallback as CallOptions;
-    }
-    options = options || {};
-    options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers[
-      'x-goog-request-params'
-    ] = gax.routingHeader.fromParams({
-      parent: request.parent || '',
-    });
-    this.initialize();
-    return this.innerApiCalls.createDocument(request, options, callback);
   }
   updateDocument(
     request: protos.google.firestore.v1beta1.IUpdateDocumentRequest,
@@ -1023,6 +921,208 @@ export class FirestoreClient {
     this.initialize();
     return this.innerApiCalls.rollback(request, options, callback);
   }
+  batchWrite(
+    request: protos.google.firestore.v1beta1.IBatchWriteRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  batchWrite(
+    request: protos.google.firestore.v1beta1.IBatchWriteRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  batchWrite(
+    request: protos.google.firestore.v1beta1.IBatchWriteRequest,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  /**
+   * Applies a batch of write operations.
+   *
+   * The BatchWrite method does not apply the write operations atomically
+   * and can apply them out of order. Method does not allow more than one write
+   * per document. Each write succeeds or fails independently. See the
+   * {@link google.firestore.v1beta1.BatchWriteResponse|BatchWriteResponse} for the success status of each write.
+   *
+   * If you require an atomically applied set of writes, use
+   * {@link google.firestore.v1beta1.Firestore.Commit|Commit} instead.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.database
+   *   Required. The database name. In the format:
+   *   `projects/{project_id}/databases/{database_id}`.
+   * @param {number[]} request.writes
+   *   The writes to apply.
+   *
+   *   Method does not apply writes atomically and does not guarantee ordering.
+   *   Each write succeeds or fails independently. You cannot write to the same
+   *   document more than once per request.
+   * @param {number[]} request.labels
+   *   Labels associated with this batch write.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [BatchWriteResponse]{@link google.firestore.v1beta1.BatchWriteResponse}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.batchWrite(request);
+   */
+  batchWrite(
+    request: protos.google.firestore.v1beta1.IBatchWriteRequest,
+    optionsOrCallback?:
+      | CallOptions
+      | Callback<
+          protos.google.firestore.v1beta1.IBatchWriteResponse,
+          protos.google.firestore.v1beta1.IBatchWriteRequest | null | undefined,
+          {} | null | undefined
+        >,
+    callback?: Callback<
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | undefined,
+      {} | undefined
+    ]
+  > | void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    } else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      database: request.database || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.batchWrite(request, options, callback);
+  }
+  createDocument(
+    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  createDocument(
+    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createDocument(
+    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  /**
+   * Creates a new document.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   *   Required. The parent resource. For example:
+   *   `projects/{project_id}/databases/{database_id}/documents` or
+   *   `projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}`
+   * @param {string} request.collectionId
+   *   Required. The collection ID, relative to `parent`, to list. For example: `chatrooms`.
+   * @param {string} request.documentId
+   *   The client-assigned document ID to use for this document.
+   *
+   *   Optional. If not specified, an ID will be assigned by the service.
+   * @param {google.firestore.v1beta1.Document} request.document
+   *   Required. The document to create. `name` must not be set.
+   * @param {google.firestore.v1beta1.DocumentMask} request.mask
+   *   The fields to return. If not set, returns all fields.
+   *
+   *   If the document has a field that is not present in this mask, that field
+   *   will not be returned in the response.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Document]{@link google.firestore.v1beta1.Document}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * const [response] = await client.createDocument(request);
+   */
+  createDocument(
+    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
+    optionsOrCallback?:
+      | CallOptions
+      | Callback<
+          protos.google.firestore.v1beta1.IDocument,
+          | protos.google.firestore.v1beta1.ICreateDocumentRequest
+          | null
+          | undefined,
+          {} | null | undefined
+        >,
+    callback?: Callback<
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | undefined,
+      {} | undefined
+    ]
+  > | void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    } else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      parent: request.parent || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.createDocument(request, options, callback);
+  }
 
   /**
    * Gets multiple documents.
@@ -1054,7 +1154,7 @@ export class FirestoreClient {
    *   stream.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -1107,7 +1207,7 @@ export class FirestoreClient {
    *   stream.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -1242,7 +1342,7 @@ export class FirestoreClient {
    *   Reads documents in a transaction.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {boolean} request.showMissing
    *   If the list should show missing documents. A missing document is a
    *   document that does not exist but has sub-documents. These documents will
@@ -1336,7 +1436,7 @@ export class FirestoreClient {
    *   Reads documents in a transaction.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {boolean} request.showMissing
    *   If the list should show missing documents. A missing document is a
    *   document that does not exist but has sub-documents. These documents will
@@ -1410,7 +1510,7 @@ export class FirestoreClient {
    *   Reads documents in a transaction.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {boolean} request.showMissing
    *   If the list should show missing documents. A missing document is a
    *   document that does not exist but has sub-documents. These documents will
@@ -1456,6 +1556,307 @@ export class FirestoreClient {
       (request as unknown) as RequestType,
       callSettings
     ) as AsyncIterable<protos.google.firestore.v1beta1.IDocument>;
+  }
+  partitionQuery(
+    request: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.ICursor[],
+      protos.google.firestore.v1beta1.IPartitionQueryRequest | null,
+      protos.google.firestore.v1beta1.IPartitionQueryResponse
+    ]
+  >;
+  partitionQuery(
+    request: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options: CallOptions,
+    callback: PaginationCallback<
+      protos.google.firestore.v1beta1.IPartitionQueryRequest,
+      | protos.google.firestore.v1beta1.IPartitionQueryResponse
+      | null
+      | undefined,
+      protos.google.firestore.v1beta1.ICursor
+    >
+  ): void;
+  partitionQuery(
+    request: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    callback: PaginationCallback<
+      protos.google.firestore.v1beta1.IPartitionQueryRequest,
+      | protos.google.firestore.v1beta1.IPartitionQueryResponse
+      | null
+      | undefined,
+      protos.google.firestore.v1beta1.ICursor
+    >
+  ): void;
+  /**
+   * Partitions a query by returning partition cursors that can be used to run
+   * the query in parallel. The returned partition cursors are split points that
+   * can be used by RunQuery as starting/end points for the query results.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   *   Required. The parent resource name. In the format:
+   *   `projects/{project_id}/databases/{database_id}/documents`.
+   *   Document resource names are not supported; only database resource names
+   *   can be specified.
+   * @param {google.firestore.v1beta1.StructuredQuery} request.structuredQuery
+   *   A structured query.
+   *   Query must specify collection with all descendants and be ordered by name
+   *   ascending. Other filters, order bys, limits, offsets, and start/end
+   *   cursors are not supported.
+   * @param {number} request.partitionCount
+   *   The desired maximum number of partition points.
+   *   The partitions may be returned across multiple pages of results.
+   *   The number must be positive. The actual number of partitions
+   *   returned may be fewer.
+   *
+   *   For example, this may be set to one fewer than the number of parallel
+   *   queries to be run, or in running a data pipeline job, one fewer than the
+   *   number of workers or compute instances available.
+   * @param {string} request.pageToken
+   *   The `next_page_token` value returned from a previous call to
+   *   PartitionQuery that may be used to get an additional set of results.
+   *   There are no ordering guarantees between sets of results. Thus, using
+   *   multiple sets of results will require merging the different result sets.
+   *
+   *   For example, two subsequent calls using a page_token may return:
+   *
+   *    * cursor B, cursor M, cursor Q
+   *    * cursor A, cursor U, cursor W
+   *
+   *   To obtain a complete result set ordered with respect to the results of the
+   *   query supplied to PartitionQuery, the results sets should be merged:
+   *   cursor A, cursor B, cursor M, cursor Q, cursor U, cursor W
+   * @param {number} request.pageSize
+   *   The maximum number of partitions to return in this call, subject to
+   *   `partition_count`.
+   *
+   *   For example, if `partition_count` = 10 and `page_size` = 8, the first call
+   *   to PartitionQuery will return up to 8 partitions and a `next_page_token`
+   *   if more results exist. A second call to PartitionQuery will return up to
+   *   2 partitions, to complete the total of 10 specified in `partition_count`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of [Cursor]{@link google.firestore.v1beta1.Cursor}.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed and will merge results from all the pages into this array.
+   *   Note that it can affect your quota.
+   *   We recommend using `partitionQueryAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   */
+  partitionQuery(
+    request: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    optionsOrCallback?:
+      | CallOptions
+      | PaginationCallback<
+          protos.google.firestore.v1beta1.IPartitionQueryRequest,
+          | protos.google.firestore.v1beta1.IPartitionQueryResponse
+          | null
+          | undefined,
+          protos.google.firestore.v1beta1.ICursor
+        >,
+    callback?: PaginationCallback<
+      protos.google.firestore.v1beta1.IPartitionQueryRequest,
+      | protos.google.firestore.v1beta1.IPartitionQueryResponse
+      | null
+      | undefined,
+      protos.google.firestore.v1beta1.ICursor
+    >
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.ICursor[],
+      protos.google.firestore.v1beta1.IPartitionQueryRequest | null,
+      protos.google.firestore.v1beta1.IPartitionQueryResponse
+    ]
+  > | void {
+    request = request || {};
+    let options: CallOptions;
+    if (typeof optionsOrCallback === 'function' && callback === undefined) {
+      callback = optionsOrCallback;
+      options = {};
+    } else {
+      options = optionsOrCallback as CallOptions;
+    }
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      parent: request.parent || '',
+    });
+    this.initialize();
+    return this.innerApiCalls.partitionQuery(request, options, callback);
+  }
+
+  /**
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   *   Required. The parent resource name. In the format:
+   *   `projects/{project_id}/databases/{database_id}/documents`.
+   *   Document resource names are not supported; only database resource names
+   *   can be specified.
+   * @param {google.firestore.v1beta1.StructuredQuery} request.structuredQuery
+   *   A structured query.
+   *   Query must specify collection with all descendants and be ordered by name
+   *   ascending. Other filters, order bys, limits, offsets, and start/end
+   *   cursors are not supported.
+   * @param {number} request.partitionCount
+   *   The desired maximum number of partition points.
+   *   The partitions may be returned across multiple pages of results.
+   *   The number must be positive. The actual number of partitions
+   *   returned may be fewer.
+   *
+   *   For example, this may be set to one fewer than the number of parallel
+   *   queries to be run, or in running a data pipeline job, one fewer than the
+   *   number of workers or compute instances available.
+   * @param {string} request.pageToken
+   *   The `next_page_token` value returned from a previous call to
+   *   PartitionQuery that may be used to get an additional set of results.
+   *   There are no ordering guarantees between sets of results. Thus, using
+   *   multiple sets of results will require merging the different result sets.
+   *
+   *   For example, two subsequent calls using a page_token may return:
+   *
+   *    * cursor B, cursor M, cursor Q
+   *    * cursor A, cursor U, cursor W
+   *
+   *   To obtain a complete result set ordered with respect to the results of the
+   *   query supplied to PartitionQuery, the results sets should be merged:
+   *   cursor A, cursor B, cursor M, cursor Q, cursor U, cursor W
+   * @param {number} request.pageSize
+   *   The maximum number of partitions to return in this call, subject to
+   *   `partition_count`.
+   *
+   *   For example, if `partition_count` = 10 and `page_size` = 8, the first call
+   *   to PartitionQuery will return up to 8 partitions and a `next_page_token`
+   *   if more results exist. A second call to PartitionQuery will return up to
+   *   2 partitions, to complete the total of 10 specified in `partition_count`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Stream}
+   *   An object stream which emits an object representing [Cursor]{@link google.firestore.v1beta1.Cursor} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `partitionQueryAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   */
+  partitionQueryStream(
+    request?: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options?: CallOptions
+  ): Transform {
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      parent: request.parent || '',
+    });
+    const callSettings = new gax.CallSettings(options);
+    this.initialize();
+    return this.descriptors.page.partitionQuery.createStream(
+      this.innerApiCalls.partitionQuery as gax.GaxCall,
+      request,
+      callSettings
+    );
+  }
+
+  /**
+   * Equivalent to `partitionQuery`, but returns an iterable object.
+   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   *   Required. The parent resource name. In the format:
+   *   `projects/{project_id}/databases/{database_id}/documents`.
+   *   Document resource names are not supported; only database resource names
+   *   can be specified.
+   * @param {google.firestore.v1beta1.StructuredQuery} request.structuredQuery
+   *   A structured query.
+   *   Query must specify collection with all descendants and be ordered by name
+   *   ascending. Other filters, order bys, limits, offsets, and start/end
+   *   cursors are not supported.
+   * @param {number} request.partitionCount
+   *   The desired maximum number of partition points.
+   *   The partitions may be returned across multiple pages of results.
+   *   The number must be positive. The actual number of partitions
+   *   returned may be fewer.
+   *
+   *   For example, this may be set to one fewer than the number of parallel
+   *   queries to be run, or in running a data pipeline job, one fewer than the
+   *   number of workers or compute instances available.
+   * @param {string} request.pageToken
+   *   The `next_page_token` value returned from a previous call to
+   *   PartitionQuery that may be used to get an additional set of results.
+   *   There are no ordering guarantees between sets of results. Thus, using
+   *   multiple sets of results will require merging the different result sets.
+   *
+   *   For example, two subsequent calls using a page_token may return:
+   *
+   *    * cursor B, cursor M, cursor Q
+   *    * cursor A, cursor U, cursor W
+   *
+   *   To obtain a complete result set ordered with respect to the results of the
+   *   query supplied to PartitionQuery, the results sets should be merged:
+   *   cursor A, cursor B, cursor M, cursor Q, cursor U, cursor W
+   * @param {number} request.pageSize
+   *   The maximum number of partitions to return in this call, subject to
+   *   `partition_count`.
+   *
+   *   For example, if `partition_count` = 10 and `page_size` = 8, the first call
+   *   to PartitionQuery will return up to 8 partitions and a `next_page_token`
+   *   if more results exist. A second call to PartitionQuery will return up to
+   *   2 partitions, to complete the total of 10 specified in `partition_count`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Object}
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [Cursor]{@link google.firestore.v1beta1.Cursor}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.partitionQueryAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
+   */
+  partitionQueryAsync(
+    request?: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options?: CallOptions
+  ): AsyncIterable<protos.google.firestore.v1beta1.ICursor> {
+    request = request || {};
+    options = options || {};
+    options.otherArgs = options.otherArgs || {};
+    options.otherArgs.headers = options.otherArgs.headers || {};
+    options.otherArgs.headers[
+      'x-goog-request-params'
+    ] = gax.routingHeader.fromParams({
+      parent: request.parent || '',
+    });
+    options = options || {};
+    const callSettings = new gax.CallSettings(options);
+    this.initialize();
+    return this.descriptors.page.partitionQuery.asyncIterate(
+      this.innerApiCalls['partitionQuery'] as GaxCall,
+      (request as unknown) as RequestType,
+      callSettings
+    ) as AsyncIterable<protos.google.firestore.v1beta1.ICursor>;
   }
   listCollectionIds(
     request: protos.google.firestore.v1beta1.IListCollectionIdsRequest,

--- a/dev/src/v1beta1/firestore_client_config.json
+++ b/dev/src/v1beta1/firestore_client_config.json
@@ -6,11 +6,6 @@
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
-        "deadline_exceeded_resource_exhausted_unavailable": [
-          "DEADLINE_EXCEEDED",
-          "RESOURCE_EXHAUSTED",
-          "UNAVAILABLE"
         ]
       },
       "retry_params": {
@@ -27,17 +22,12 @@
       "methods": {
         "GetDocument": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListDocuments": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
-          "retry_params_name": "default"
-        },
-        "CreateDocument": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "non_idempotent",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "UpdateDocument": {
@@ -47,17 +37,17 @@
         },
         "DeleteDocument": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "BatchGetDocuments": {
           "timeout_millis": 300000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "BeginTransaction": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "Commit": {
@@ -67,12 +57,16 @@
         },
         "Rollback": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "RunQuery": {
           "timeout_millis": 300000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "PartitionQuery": {
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "Write": {
@@ -82,12 +76,21 @@
         },
         "Listen": {
           "timeout_millis": 86400000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListCollectionIds": {
           "timeout_millis": 60000,
-          "retry_codes_name": "deadline_exceeded_resource_exhausted_unavailable",
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "BatchWrite": {
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateDocument": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
       }

--- a/dev/src/v1beta1/gapic_metadata.json
+++ b/dev/src/v1beta1/gapic_metadata.json
@@ -15,11 +15,6 @@
                 "getDocument"
               ]
             },
-            "CreateDocument": {
-              "methods": [
-                "createDocument"
-              ]
-            },
             "UpdateDocument": {
               "methods": [
                 "updateDocument"
@@ -43,6 +38,16 @@
             "Rollback": {
               "methods": [
                 "rollback"
+              ]
+            },
+            "BatchWrite": {
+              "methods": [
+                "batchWrite"
+              ]
+            },
+            "CreateDocument": {
+              "methods": [
+                "createDocument"
               ]
             },
             "BatchGetDocuments": {
@@ -72,6 +77,13 @@
                 "listDocumentsAsync"
               ]
             },
+            "PartitionQuery": {
+              "methods": [
+                "partitionQuery",
+                "partitionQueryStream",
+                "partitionQueryAsync"
+              ]
+            },
             "ListCollectionIds": {
               "methods": [
                 "listCollectionIds",
@@ -87,11 +99,6 @@
             "GetDocument": {
               "methods": [
                 "getDocument"
-              ]
-            },
-            "CreateDocument": {
-              "methods": [
-                "createDocument"
               ]
             },
             "UpdateDocument": {
@@ -119,11 +126,28 @@
                 "rollback"
               ]
             },
+            "BatchWrite": {
+              "methods": [
+                "batchWrite"
+              ]
+            },
+            "CreateDocument": {
+              "methods": [
+                "createDocument"
+              ]
+            },
             "ListDocuments": {
               "methods": [
                 "listDocuments",
                 "listDocumentsStream",
                 "listDocumentsAsync"
+              ]
+            },
+            "PartitionQuery": {
+              "methods": [
+                "partitionQuery",
+                "partitionQueryStream",
+                "partitionQueryAsync"
               ]
             },
             "ListCollectionIds": {

--- a/dev/test/gapic_firestore_v1beta1.ts
+++ b/dev/test/gapic_firestore_v1beta1.ts
@@ -341,118 +341,6 @@ describe('v1beta1.FirestoreClient', () => {
     });
   });
 
-  describe('createDocument', () => {
-    it('invokes createDocument without error', async () => {
-      const client = new firestoreModule.FirestoreClient({
-        credentials: {client_email: 'bogus', private_key: 'bogus'},
-        projectId: 'bogus',
-      });
-      client.initialize();
-      const request = generateSampleMessage(
-        new protos.google.firestore.v1beta1.CreateDocumentRequest()
-      );
-      request.parent = '';
-      const expectedHeaderRequestParams = 'parent=';
-      const expectedOptions = {
-        otherArgs: {
-          headers: {
-            'x-goog-request-params': expectedHeaderRequestParams,
-          },
-        },
-      };
-      const expectedResponse = generateSampleMessage(
-        new protos.google.firestore.v1beta1.Document()
-      );
-      client.innerApiCalls.createDocument = stubSimpleCall(expectedResponse);
-      const [response] = await client.createDocument(request);
-      assert.deepStrictEqual(response, expectedResponse);
-      assert(
-        (client.innerApiCalls.createDocument as SinonStub)
-          .getCall(0)
-          .calledWith(request, expectedOptions, undefined)
-      );
-    });
-
-    it('invokes createDocument without error using callback', async () => {
-      const client = new firestoreModule.FirestoreClient({
-        credentials: {client_email: 'bogus', private_key: 'bogus'},
-        projectId: 'bogus',
-      });
-      client.initialize();
-      const request = generateSampleMessage(
-        new protos.google.firestore.v1beta1.CreateDocumentRequest()
-      );
-      request.parent = '';
-      const expectedHeaderRequestParams = 'parent=';
-      const expectedOptions = {
-        otherArgs: {
-          headers: {
-            'x-goog-request-params': expectedHeaderRequestParams,
-          },
-        },
-      };
-      const expectedResponse = generateSampleMessage(
-        new protos.google.firestore.v1beta1.Document()
-      );
-      client.innerApiCalls.createDocument = stubSimpleCallWithCallback(
-        expectedResponse
-      );
-      const promise = new Promise((resolve, reject) => {
-        client.createDocument(
-          request,
-          (
-            err?: Error | null,
-            result?: protos.google.firestore.v1beta1.IDocument | null
-          ) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(result);
-            }
-          }
-        );
-      });
-      const response = await promise;
-      assert.deepStrictEqual(response, expectedResponse);
-      assert(
-        (client.innerApiCalls.createDocument as SinonStub)
-          .getCall(0)
-          .calledWith(request, expectedOptions /*, callback defined above */)
-      );
-    });
-
-    it('invokes createDocument with error', async () => {
-      const client = new firestoreModule.FirestoreClient({
-        credentials: {client_email: 'bogus', private_key: 'bogus'},
-        projectId: 'bogus',
-      });
-      client.initialize();
-      const request = generateSampleMessage(
-        new protos.google.firestore.v1beta1.CreateDocumentRequest()
-      );
-      request.parent = '';
-      const expectedHeaderRequestParams = 'parent=';
-      const expectedOptions = {
-        otherArgs: {
-          headers: {
-            'x-goog-request-params': expectedHeaderRequestParams,
-          },
-        },
-      };
-      const expectedError = new Error('expected');
-      client.innerApiCalls.createDocument = stubSimpleCall(
-        undefined,
-        expectedError
-      );
-      await assert.rejects(client.createDocument(request), expectedError);
-      assert(
-        (client.innerApiCalls.createDocument as SinonStub)
-          .getCall(0)
-          .calledWith(request, expectedOptions, undefined)
-      );
-    });
-  });
-
   describe('updateDocument', () => {
     it('invokes updateDocument without error', async () => {
       const client = new firestoreModule.FirestoreClient({
@@ -1004,6 +892,230 @@ describe('v1beta1.FirestoreClient', () => {
       await assert.rejects(client.rollback(request), expectedError);
       assert(
         (client.innerApiCalls.rollback as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions, undefined)
+      );
+    });
+  });
+
+  describe('batchWrite', () => {
+    it('invokes batchWrite without error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.BatchWriteRequest()
+      );
+      request.database = '';
+      const expectedHeaderRequestParams = 'database=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedResponse = generateSampleMessage(
+        new protos.google.firestore.v1beta1.BatchWriteResponse()
+      );
+      client.innerApiCalls.batchWrite = stubSimpleCall(expectedResponse);
+      const [response] = await client.batchWrite(request);
+      assert.deepStrictEqual(response, expectedResponse);
+      assert(
+        (client.innerApiCalls.batchWrite as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions, undefined)
+      );
+    });
+
+    it('invokes batchWrite without error using callback', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.BatchWriteRequest()
+      );
+      request.database = '';
+      const expectedHeaderRequestParams = 'database=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedResponse = generateSampleMessage(
+        new protos.google.firestore.v1beta1.BatchWriteResponse()
+      );
+      client.innerApiCalls.batchWrite = stubSimpleCallWithCallback(
+        expectedResponse
+      );
+      const promise = new Promise((resolve, reject) => {
+        client.batchWrite(
+          request,
+          (
+            err?: Error | null,
+            result?: protos.google.firestore.v1beta1.IBatchWriteResponse | null
+          ) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(result);
+            }
+          }
+        );
+      });
+      const response = await promise;
+      assert.deepStrictEqual(response, expectedResponse);
+      assert(
+        (client.innerApiCalls.batchWrite as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions /*, callback defined above */)
+      );
+    });
+
+    it('invokes batchWrite with error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.BatchWriteRequest()
+      );
+      request.database = '';
+      const expectedHeaderRequestParams = 'database=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedError = new Error('expected');
+      client.innerApiCalls.batchWrite = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.batchWrite(request), expectedError);
+      assert(
+        (client.innerApiCalls.batchWrite as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions, undefined)
+      );
+    });
+  });
+
+  describe('createDocument', () => {
+    it('invokes createDocument without error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.CreateDocumentRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedResponse = generateSampleMessage(
+        new protos.google.firestore.v1beta1.Document()
+      );
+      client.innerApiCalls.createDocument = stubSimpleCall(expectedResponse);
+      const [response] = await client.createDocument(request);
+      assert.deepStrictEqual(response, expectedResponse);
+      assert(
+        (client.innerApiCalls.createDocument as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions, undefined)
+      );
+    });
+
+    it('invokes createDocument without error using callback', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.CreateDocumentRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedResponse = generateSampleMessage(
+        new protos.google.firestore.v1beta1.Document()
+      );
+      client.innerApiCalls.createDocument = stubSimpleCallWithCallback(
+        expectedResponse
+      );
+      const promise = new Promise((resolve, reject) => {
+        client.createDocument(
+          request,
+          (
+            err?: Error | null,
+            result?: protos.google.firestore.v1beta1.IDocument | null
+          ) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(result);
+            }
+          }
+        );
+      });
+      const response = await promise;
+      assert.deepStrictEqual(response, expectedResponse);
+      assert(
+        (client.innerApiCalls.createDocument as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions /*, callback defined above */)
+      );
+    });
+
+    it('invokes createDocument with error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.CreateDocumentRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedError = new Error('expected');
+      client.innerApiCalls.createDocument = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.createDocument(request), expectedError);
+      assert(
+        (client.innerApiCalls.createDocument as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
@@ -1650,6 +1762,296 @@ describe('v1beta1.FirestoreClient', () => {
       );
       assert.strictEqual(
         (client.descriptors.page.listDocuments
+          .asyncIterate as SinonStub).getCall(0).args[2].otherArgs.headers[
+          'x-goog-request-params'
+        ],
+        expectedHeaderRequestParams
+      );
+    });
+  });
+
+  describe('partitionQuery', () => {
+    it('invokes partitionQuery without error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.PartitionQueryRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedResponse = [
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+      ];
+      client.innerApiCalls.partitionQuery = stubSimpleCall(expectedResponse);
+      const [response] = await client.partitionQuery(request);
+      assert.deepStrictEqual(response, expectedResponse);
+      assert(
+        (client.innerApiCalls.partitionQuery as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions, undefined)
+      );
+    });
+
+    it('invokes partitionQuery without error using callback', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.PartitionQueryRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedResponse = [
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+      ];
+      client.innerApiCalls.partitionQuery = stubSimpleCallWithCallback(
+        expectedResponse
+      );
+      const promise = new Promise((resolve, reject) => {
+        client.partitionQuery(
+          request,
+          (
+            err?: Error | null,
+            result?: protos.google.firestore.v1beta1.ICursor[] | null
+          ) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(result);
+            }
+          }
+        );
+      });
+      const response = await promise;
+      assert.deepStrictEqual(response, expectedResponse);
+      assert(
+        (client.innerApiCalls.partitionQuery as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions /*, callback defined above */)
+      );
+    });
+
+    it('invokes partitionQuery with error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.PartitionQueryRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedOptions = {
+        otherArgs: {
+          headers: {
+            'x-goog-request-params': expectedHeaderRequestParams,
+          },
+        },
+      };
+      const expectedError = new Error('expected');
+      client.innerApiCalls.partitionQuery = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(client.partitionQuery(request), expectedError);
+      assert(
+        (client.innerApiCalls.partitionQuery as SinonStub)
+          .getCall(0)
+          .calledWith(request, expectedOptions, undefined)
+      );
+    });
+
+    it('invokes partitionQueryStream without error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.PartitionQueryRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedResponse = [
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+      ];
+      client.descriptors.page.partitionQuery.createStream = stubPageStreamingCall(
+        expectedResponse
+      );
+      const stream = client.partitionQueryStream(request);
+      const promise = new Promise((resolve, reject) => {
+        const responses: protos.google.firestore.v1beta1.Cursor[] = [];
+        stream.on(
+          'data',
+          (response: protos.google.firestore.v1beta1.Cursor) => {
+            responses.push(response);
+          }
+        );
+        stream.on('end', () => {
+          resolve(responses);
+        });
+        stream.on('error', (err: Error) => {
+          reject(err);
+        });
+      });
+      const responses = await promise;
+      assert.deepStrictEqual(responses, expectedResponse);
+      assert(
+        (client.descriptors.page.partitionQuery.createStream as SinonStub)
+          .getCall(0)
+          .calledWith(client.innerApiCalls.partitionQuery, request)
+      );
+      assert.strictEqual(
+        (client.descriptors.page.partitionQuery
+          .createStream as SinonStub).getCall(0).args[2].otherArgs.headers[
+          'x-goog-request-params'
+        ],
+        expectedHeaderRequestParams
+      );
+    });
+
+    it('invokes partitionQueryStream with error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.PartitionQueryRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedError = new Error('expected');
+      client.descriptors.page.partitionQuery.createStream = stubPageStreamingCall(
+        undefined,
+        expectedError
+      );
+      const stream = client.partitionQueryStream(request);
+      const promise = new Promise((resolve, reject) => {
+        const responses: protos.google.firestore.v1beta1.Cursor[] = [];
+        stream.on(
+          'data',
+          (response: protos.google.firestore.v1beta1.Cursor) => {
+            responses.push(response);
+          }
+        );
+        stream.on('end', () => {
+          resolve(responses);
+        });
+        stream.on('error', (err: Error) => {
+          reject(err);
+        });
+      });
+      await assert.rejects(promise, expectedError);
+      assert(
+        (client.descriptors.page.partitionQuery.createStream as SinonStub)
+          .getCall(0)
+          .calledWith(client.innerApiCalls.partitionQuery, request)
+      );
+      assert.strictEqual(
+        (client.descriptors.page.partitionQuery
+          .createStream as SinonStub).getCall(0).args[2].otherArgs.headers[
+          'x-goog-request-params'
+        ],
+        expectedHeaderRequestParams
+      );
+    });
+
+    it('uses async iteration with partitionQuery without error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.PartitionQueryRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedResponse = [
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+        generateSampleMessage(new protos.google.firestore.v1beta1.Cursor()),
+      ];
+      client.descriptors.page.partitionQuery.asyncIterate = stubAsyncIterationCall(
+        expectedResponse
+      );
+      const responses: protos.google.firestore.v1beta1.ICursor[] = [];
+      const iterable = client.partitionQueryAsync(request);
+      for await (const resource of iterable) {
+        responses.push(resource!);
+      }
+      assert.deepStrictEqual(responses, expectedResponse);
+      assert.deepStrictEqual(
+        (client.descriptors.page.partitionQuery
+          .asyncIterate as SinonStub).getCall(0).args[1],
+        request
+      );
+      assert.strictEqual(
+        (client.descriptors.page.partitionQuery
+          .asyncIterate as SinonStub).getCall(0).args[2].otherArgs.headers[
+          'x-goog-request-params'
+        ],
+        expectedHeaderRequestParams
+      );
+    });
+
+    it('uses async iteration with partitionQuery with error', async () => {
+      const client = new firestoreModule.FirestoreClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      client.initialize();
+      const request = generateSampleMessage(
+        new protos.google.firestore.v1beta1.PartitionQueryRequest()
+      );
+      request.parent = '';
+      const expectedHeaderRequestParams = 'parent=';
+      const expectedError = new Error('expected');
+      client.descriptors.page.partitionQuery.asyncIterate = stubAsyncIterationCall(
+        undefined,
+        expectedError
+      );
+      const iterable = client.partitionQueryAsync(request);
+      await assert.rejects(async () => {
+        const responses: protos.google.firestore.v1beta1.ICursor[] = [];
+        for await (const resource of iterable) {
+          responses.push(resource!);
+        }
+      });
+      assert.deepStrictEqual(
+        (client.descriptors.page.partitionQuery
+          .asyncIterate as SinonStub).getCall(0).args[1],
+        request
+      );
+      assert.strictEqual(
+        (client.descriptors.page.partitionQuery
           .asyncIterate as SinonStub).getCall(0).args[2].otherArgs.headers[
           'x-goog-request-params'
         ],

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -1105,7 +1105,7 @@ describe('getAll() method', () => {
       [Status.NOT_FOUND]: 1,
       [Status.ALREADY_EXISTS]: 1,
       [Status.PERMISSION_DENIED]: 1,
-      [Status.RESOURCE_EXHAUSTED]: 1,
+      [Status.RESOURCE_EXHAUSTED]: 5,
       [Status.FAILED_PRECONDITION]: 1,
       [Status.ABORTED]: 1,
       [Status.OUT_OF_RANGE]: 1,

--- a/synth.py
+++ b/synth.py
@@ -158,7 +158,6 @@ s.copy(templates, excludes=[".eslintrc.json", ".kokoro/**/*", ".github/CODEOWNER
 # Remove auto-generated packaging tests
 os.system('rm -rf dev/system-test/fixtures dev/system-test/install.ts')
 
-node.install()
 os.chdir("dev")
 node.compile_protos()
 os.chdir("protos")
@@ -166,6 +165,7 @@ os.unlink('protos.js')
 os.unlink('protos.d.ts')
 subprocess.run('./update.sh', shell=True)
 os.chdir("../../")
+node.install()
 
 # Copy types into types/
 os.system("cp build/src/v1/firestore*.d.ts types/v1")

--- a/types/protos/firestore_v1beta1_proto_api.d.ts
+++ b/types/protos/firestore_v1beta1_proto_api.d.ts
@@ -2897,20 +2897,6 @@ export namespace google {
                 public listDocuments(request: google.firestore.v1beta1.IListDocumentsRequest): Promise<google.firestore.v1beta1.ListDocumentsResponse>;
 
                 /**
-                 * Calls CreateDocument.
-                 * @param request CreateDocumentRequest message or plain object
-                 * @param callback Node-style callback called with the error, if any, and Document
-                 */
-                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest, callback: google.firestore.v1beta1.Firestore.CreateDocumentCallback): void;
-
-                /**
-                 * Calls CreateDocument.
-                 * @param request CreateDocumentRequest message or plain object
-                 * @returns Promise
-                 */
-                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest): Promise<google.firestore.v1beta1.Document>;
-
-                /**
                  * Calls UpdateDocument.
                  * @param request UpdateDocumentRequest message or plain object
                  * @param callback Node-style callback called with the error, if any, and Document
@@ -3009,6 +2995,20 @@ export namespace google {
                 public runQuery(request: google.firestore.v1beta1.IRunQueryRequest): Promise<google.firestore.v1beta1.RunQueryResponse>;
 
                 /**
+                 * Calls PartitionQuery.
+                 * @param request PartitionQueryRequest message or plain object
+                 * @param callback Node-style callback called with the error, if any, and PartitionQueryResponse
+                 */
+                public partitionQuery(request: google.firestore.v1beta1.IPartitionQueryRequest, callback: google.firestore.v1beta1.Firestore.PartitionQueryCallback): void;
+
+                /**
+                 * Calls PartitionQuery.
+                 * @param request PartitionQueryRequest message or plain object
+                 * @returns Promise
+                 */
+                public partitionQuery(request: google.firestore.v1beta1.IPartitionQueryRequest): Promise<google.firestore.v1beta1.PartitionQueryResponse>;
+
+                /**
                  * Calls Write.
                  * @param request WriteRequest message or plain object
                  * @param callback Node-style callback called with the error, if any, and WriteResponse
@@ -3049,6 +3049,34 @@ export namespace google {
                  * @returns Promise
                  */
                 public listCollectionIds(request: google.firestore.v1beta1.IListCollectionIdsRequest): Promise<google.firestore.v1beta1.ListCollectionIdsResponse>;
+
+                /**
+                 * Calls BatchWrite.
+                 * @param request BatchWriteRequest message or plain object
+                 * @param callback Node-style callback called with the error, if any, and BatchWriteResponse
+                 */
+                public batchWrite(request: google.firestore.v1beta1.IBatchWriteRequest, callback: google.firestore.v1beta1.Firestore.BatchWriteCallback): void;
+
+                /**
+                 * Calls BatchWrite.
+                 * @param request BatchWriteRequest message or plain object
+                 * @returns Promise
+                 */
+                public batchWrite(request: google.firestore.v1beta1.IBatchWriteRequest): Promise<google.firestore.v1beta1.BatchWriteResponse>;
+
+                /**
+                 * Calls CreateDocument.
+                 * @param request CreateDocumentRequest message or plain object
+                 * @param callback Node-style callback called with the error, if any, and Document
+                 */
+                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest, callback: google.firestore.v1beta1.Firestore.CreateDocumentCallback): void;
+
+                /**
+                 * Calls CreateDocument.
+                 * @param request CreateDocumentRequest message or plain object
+                 * @returns Promise
+                 */
+                public createDocument(request: google.firestore.v1beta1.ICreateDocumentRequest): Promise<google.firestore.v1beta1.Document>;
             }
 
             namespace Firestore {
@@ -3066,13 +3094,6 @@ export namespace google {
                  * @param [response] ListDocumentsResponse
                  */
                 type ListDocumentsCallback = (error: (Error|null), response?: google.firestore.v1beta1.ListDocumentsResponse) => void;
-
-                /**
-                 * Callback as used by {@link google.firestore.v1beta1.Firestore#createDocument}.
-                 * @param error Error, if any
-                 * @param [response] Document
-                 */
-                type CreateDocumentCallback = (error: (Error|null), response?: google.firestore.v1beta1.Document) => void;
 
                 /**
                  * Callback as used by {@link google.firestore.v1beta1.Firestore#updateDocument}.
@@ -3124,6 +3145,13 @@ export namespace google {
                 type RunQueryCallback = (error: (Error|null), response?: google.firestore.v1beta1.RunQueryResponse) => void;
 
                 /**
+                 * Callback as used by {@link google.firestore.v1beta1.Firestore#partitionQuery}.
+                 * @param error Error, if any
+                 * @param [response] PartitionQueryResponse
+                 */
+                type PartitionQueryCallback = (error: (Error|null), response?: google.firestore.v1beta1.PartitionQueryResponse) => void;
+
+                /**
                  * Callback as used by {@link google.firestore.v1beta1.Firestore#write}.
                  * @param error Error, if any
                  * @param [response] WriteResponse
@@ -3143,6 +3171,20 @@ export namespace google {
                  * @param [response] ListCollectionIdsResponse
                  */
                 type ListCollectionIdsCallback = (error: (Error|null), response?: google.firestore.v1beta1.ListCollectionIdsResponse) => void;
+
+                /**
+                 * Callback as used by {@link google.firestore.v1beta1.Firestore#batchWrite}.
+                 * @param error Error, if any
+                 * @param [response] BatchWriteResponse
+                 */
+                type BatchWriteCallback = (error: (Error|null), response?: google.firestore.v1beta1.BatchWriteResponse) => void;
+
+                /**
+                 * Callback as used by {@link google.firestore.v1beta1.Firestore#createDocument}.
+                 * @param error Error, if any
+                 * @param [response] Document
+                 */
+                type CreateDocumentCallback = (error: (Error|null), response?: google.firestore.v1beta1.Document) => void;
             }
 
             /** Properties of a GetDocumentRequest. */
@@ -4018,6 +4060,121 @@ export namespace google {
                 public toJSON(): { [k: string]: any };
             }
 
+            /** Properties of a PartitionQueryRequest. */
+            interface IPartitionQueryRequest {
+
+                /** PartitionQueryRequest parent */
+                parent?: (string|null);
+
+                /** PartitionQueryRequest structuredQuery */
+                structuredQuery?: (google.firestore.v1beta1.IStructuredQuery|null);
+
+                /** PartitionQueryRequest partitionCount */
+                partitionCount?: (number|string|null);
+
+                /** PartitionQueryRequest pageToken */
+                pageToken?: (string|null);
+
+                /** PartitionQueryRequest pageSize */
+                pageSize?: (number|null);
+            }
+
+            /** Represents a PartitionQueryRequest. */
+            class PartitionQueryRequest implements IPartitionQueryRequest {
+
+                /**
+                 * Constructs a new PartitionQueryRequest.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IPartitionQueryRequest);
+
+                /** PartitionQueryRequest parent. */
+                public parent: string;
+
+                /** PartitionQueryRequest structuredQuery. */
+                public structuredQuery?: (google.firestore.v1beta1.IStructuredQuery|null);
+
+                /** PartitionQueryRequest partitionCount. */
+                public partitionCount: (number|string);
+
+                /** PartitionQueryRequest pageToken. */
+                public pageToken: string;
+
+                /** PartitionQueryRequest pageSize. */
+                public pageSize: number;
+
+                /** PartitionQueryRequest queryType. */
+                public queryType?: "structuredQuery";
+
+                /**
+                 * Creates a PartitionQueryRequest message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns PartitionQueryRequest
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.PartitionQueryRequest;
+
+                /**
+                 * Creates a plain object from a PartitionQueryRequest message. Also converts values to other types if specified.
+                 * @param message PartitionQueryRequest
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.PartitionQueryRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this PartitionQueryRequest to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            /** Properties of a PartitionQueryResponse. */
+            interface IPartitionQueryResponse {
+
+                /** PartitionQueryResponse partitions */
+                partitions?: (google.firestore.v1beta1.ICursor[]|null);
+
+                /** PartitionQueryResponse nextPageToken */
+                nextPageToken?: (string|null);
+            }
+
+            /** Represents a PartitionQueryResponse. */
+            class PartitionQueryResponse implements IPartitionQueryResponse {
+
+                /**
+                 * Constructs a new PartitionQueryResponse.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IPartitionQueryResponse);
+
+                /** PartitionQueryResponse partitions. */
+                public partitions: google.firestore.v1beta1.ICursor[];
+
+                /** PartitionQueryResponse nextPageToken. */
+                public nextPageToken: string;
+
+                /**
+                 * Creates a PartitionQueryResponse message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns PartitionQueryResponse
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.PartitionQueryResponse;
+
+                /**
+                 * Creates a plain object from a PartitionQueryResponse message. Also converts values to other types if specified.
+                 * @param message PartitionQueryResponse
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.PartitionQueryResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this PartitionQueryResponse to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
             /** Properties of a WriteRequest. */
             interface IWriteRequest {
 
@@ -4615,6 +4772,106 @@ export namespace google {
                 public toJSON(): { [k: string]: any };
             }
 
+            /** Properties of a BatchWriteRequest. */
+            interface IBatchWriteRequest {
+
+                /** BatchWriteRequest database */
+                database?: (string|null);
+
+                /** BatchWriteRequest writes */
+                writes?: (google.firestore.v1beta1.IWrite[]|null);
+
+                /** BatchWriteRequest labels */
+                labels?: ({ [k: string]: string }|null);
+            }
+
+            /** Represents a BatchWriteRequest. */
+            class BatchWriteRequest implements IBatchWriteRequest {
+
+                /**
+                 * Constructs a new BatchWriteRequest.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IBatchWriteRequest);
+
+                /** BatchWriteRequest database. */
+                public database: string;
+
+                /** BatchWriteRequest writes. */
+                public writes: google.firestore.v1beta1.IWrite[];
+
+                /** BatchWriteRequest labels. */
+                public labels: { [k: string]: string };
+
+                /**
+                 * Creates a BatchWriteRequest message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns BatchWriteRequest
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.BatchWriteRequest;
+
+                /**
+                 * Creates a plain object from a BatchWriteRequest message. Also converts values to other types if specified.
+                 * @param message BatchWriteRequest
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.BatchWriteRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this BatchWriteRequest to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            /** Properties of a BatchWriteResponse. */
+            interface IBatchWriteResponse {
+
+                /** BatchWriteResponse writeResults */
+                writeResults?: (google.firestore.v1beta1.IWriteResult[]|null);
+
+                /** BatchWriteResponse status */
+                status?: (google.rpc.IStatus[]|null);
+            }
+
+            /** Represents a BatchWriteResponse. */
+            class BatchWriteResponse implements IBatchWriteResponse {
+
+                /**
+                 * Constructs a new BatchWriteResponse.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.firestore.v1beta1.IBatchWriteResponse);
+
+                /** BatchWriteResponse writeResults. */
+                public writeResults: google.firestore.v1beta1.IWriteResult[];
+
+                /** BatchWriteResponse status. */
+                public status: google.rpc.IStatus[];
+
+                /**
+                 * Creates a BatchWriteResponse message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns BatchWriteResponse
+                 */
+                public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.BatchWriteResponse;
+
+                /**
+                 * Creates a plain object from a BatchWriteResponse message. Also converts values to other types if specified.
+                 * @param message BatchWriteResponse
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.firestore.v1beta1.BatchWriteResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this BatchWriteResponse to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
             /** Properties of a StructuredQuery. */
             interface IStructuredQuery {
 
@@ -4914,7 +5171,7 @@ export namespace google {
 
                     /** Operator enum. */
                     type Operator =
-                        "OPERATOR_UNSPECIFIED"| "LESS_THAN"| "LESS_THAN_OR_EQUAL"| "GREATER_THAN"| "GREATER_THAN_OR_EQUAL"| "EQUAL"| "ARRAY_CONTAINS"| "IN"| "ARRAY_CONTAINS_ANY";
+                        "OPERATOR_UNSPECIFIED"| "LESS_THAN"| "LESS_THAN_OR_EQUAL"| "GREATER_THAN"| "GREATER_THAN_OR_EQUAL"| "EQUAL"| "NOT_EQUAL"| "ARRAY_CONTAINS"| "IN"| "ARRAY_CONTAINS_ANY"| "NOT_IN";
                 }
 
                 /** Properties of an UnaryFilter. */
@@ -4971,7 +5228,48 @@ export namespace google {
 
                     /** Operator enum. */
                     type Operator =
-                        "OPERATOR_UNSPECIFIED"| "IS_NAN"| "IS_NULL";
+                        "OPERATOR_UNSPECIFIED"| "IS_NAN"| "IS_NULL"| "IS_NOT_NAN"| "IS_NOT_NULL";
+                }
+
+                /** Properties of a FieldReference. */
+                interface IFieldReference {
+
+                    /** FieldReference fieldPath */
+                    fieldPath?: (string|null);
+                }
+
+                /** Represents a FieldReference. */
+                class FieldReference implements IFieldReference {
+
+                    /**
+                     * Constructs a new FieldReference.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.firestore.v1beta1.StructuredQuery.IFieldReference);
+
+                    /** FieldReference fieldPath. */
+                    public fieldPath: string;
+
+                    /**
+                     * Creates a FieldReference message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns FieldReference
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.StructuredQuery.FieldReference;
+
+                    /**
+                     * Creates a plain object from a FieldReference message. Also converts values to other types if specified.
+                     * @param message FieldReference
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.firestore.v1beta1.StructuredQuery.FieldReference, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this FieldReference to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
                 }
 
                 /** Properties of an Order. */
@@ -5016,47 +5314,6 @@ export namespace google {
 
                     /**
                      * Converts this Order to JSON.
-                     * @returns JSON object
-                     */
-                    public toJSON(): { [k: string]: any };
-                }
-
-                /** Properties of a FieldReference. */
-                interface IFieldReference {
-
-                    /** FieldReference fieldPath */
-                    fieldPath?: (string|null);
-                }
-
-                /** Represents a FieldReference. */
-                class FieldReference implements IFieldReference {
-
-                    /**
-                     * Constructs a new FieldReference.
-                     * @param [properties] Properties to set
-                     */
-                    constructor(properties?: google.firestore.v1beta1.StructuredQuery.IFieldReference);
-
-                    /** FieldReference fieldPath. */
-                    public fieldPath: string;
-
-                    /**
-                     * Creates a FieldReference message from a plain object. Also converts values to their respective internal types.
-                     * @param object Plain object
-                     * @returns FieldReference
-                     */
-                    public static fromObject(object: { [k: string]: any }): google.firestore.v1beta1.StructuredQuery.FieldReference;
-
-                    /**
-                     * Creates a plain object from a FieldReference message. Also converts values to other types if specified.
-                     * @param message FieldReference
-                     * @param [options] Conversion options
-                     * @returns Plain object
-                     */
-                    public static toObject(message: google.firestore.v1beta1.StructuredQuery.FieldReference, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-                    /**
-                     * Converts this FieldReference to JSON.
                      * @returns JSON object
                      */
                     public toJSON(): { [k: string]: any };
@@ -5170,6 +5427,9 @@ export namespace google {
                 /** Write updateMask */
                 updateMask?: (google.firestore.v1beta1.IDocumentMask|null);
 
+                /** Write updateTransforms */
+                updateTransforms?: (google.firestore.v1beta1.DocumentTransform.IFieldTransform[]|null);
+
                 /** Write currentDocument */
                 currentDocument?: (google.firestore.v1beta1.IPrecondition|null);
             }
@@ -5194,6 +5454,9 @@ export namespace google {
 
                 /** Write updateMask. */
                 public updateMask?: (google.firestore.v1beta1.IDocumentMask|null);
+
+                /** Write updateTransforms. */
+                public updateTransforms: google.firestore.v1beta1.DocumentTransform.IFieldTransform[];
 
                 /** Write currentDocument. */
                 public currentDocument?: (google.firestore.v1beta1.IPrecondition|null);

--- a/types/v1/firestore_admin_client.d.ts
+++ b/types/v1/firestore_admin_client.d.ts
@@ -1,3 +1,19 @@
+/*!
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /// <reference types="node" />
 import * as gax from 'google-gax';
 import {

--- a/types/v1/firestore_admin_client.d.ts
+++ b/types/v1/firestore_admin_client.d.ts
@@ -1,19 +1,3 @@
-/*!
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /// <reference types="node" />
 import * as gax from 'google-gax';
 import {

--- a/types/v1/firestore_client.d.ts
+++ b/types/v1/firestore_client.d.ts
@@ -1,3 +1,19 @@
+/*!
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /// <reference types="node" />
 import * as gax from 'google-gax';
 import {

--- a/types/v1/firestore_client.d.ts
+++ b/types/v1/firestore_client.d.ts
@@ -1,19 +1,3 @@
-/*!
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /// <reference types="node" />
 import * as gax from 'google-gax';
 import {

--- a/types/v1beta1/firestore_client.d.ts
+++ b/types/v1beta1/firestore_client.d.ts
@@ -1,3 +1,19 @@
+/*!
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /// <reference types="node" />
 import * as gax from 'google-gax';
 import {

--- a/types/v1beta1/firestore_client.d.ts
+++ b/types/v1beta1/firestore_client.d.ts
@@ -1,19 +1,3 @@
-/*!
- * Copyright 2021 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /// <reference types="node" />
 import * as gax from 'google-gax';
 import {
@@ -28,20 +12,12 @@ import * as protos from '../protos/firestore_v1beta1_proto_api';
 /**
  *  The Cloud Firestore service.
  *
- *  This service exposes several types of comparable timestamps:
- *
- *  *    `create_time` - The time at which a document was created. Changes only
- *       when a document is deleted, then re-created. Increases in a strict
- *        monotonic fashion.
- *  *    `update_time` - The time at which a document was last updated. Changes
- *       every time a document is modified. Does not change when a write results
- *       in no modifications. Increases in a strict monotonic fashion.
- *  *    `read_time` - The time at which a particular state was observed. Used
- *       to denote a consistent snapshot of the database or the time at which a
- *       Document was observed to not exist.
- *  *    `commit_time` - The time at which the writes in a transaction were
- *       committed. Any read with an equal or greater `read_time` is guaranteed
- *       to see the effects of the transaction.
+ *  Cloud Firestore is a fast, fully managed, serverless, cloud-native NoSQL
+ *  document database that simplifies storing, syncing, and querying data for
+ *  your mobile, web, and IoT apps at global scale. Its client libraries provide
+ *  live synchronization and offline support, while its security features and
+ *  integrations with Firebase and Google Cloud Platform (GCP) accelerate
+ *  building truly serverless apps.
  * @class
  * @deprecated Use v1/firestore_client instead.
  * @memberof v1beta1
@@ -158,33 +134,6 @@ export declare class FirestoreClient {
     callback: Callback<
       protos.google.firestore.v1beta1.IDocument,
       protos.google.firestore.v1beta1.IGetDocumentRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  createDocument(
-    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  createDocument(
-    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  createDocument(
-    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
-    callback: Callback<
-      protos.google.firestore.v1beta1.IDocument,
-      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
       {} | null | undefined
     >
   ): void;
@@ -327,6 +276,60 @@ export declare class FirestoreClient {
       {} | null | undefined
     >
   ): void;
+  batchWrite(
+    request: protos.google.firestore.v1beta1.IBatchWriteRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  batchWrite(
+    request: protos.google.firestore.v1beta1.IBatchWriteRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  batchWrite(
+    request: protos.google.firestore.v1beta1.IBatchWriteRequest,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IBatchWriteResponse,
+      protos.google.firestore.v1beta1.IBatchWriteRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createDocument(
+    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  createDocument(
+    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createDocument(
+    request: protos.google.firestore.v1beta1.ICreateDocumentRequest,
+    callback: Callback<
+      protos.google.firestore.v1beta1.IDocument,
+      protos.google.firestore.v1beta1.ICreateDocumentRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   /**
    * Gets multiple documents.
    *
@@ -357,7 +360,7 @@ export declare class FirestoreClient {
    *   stream.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -397,7 +400,7 @@ export declare class FirestoreClient {
    *   stream.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -510,7 +513,7 @@ export declare class FirestoreClient {
    *   Reads documents in a transaction.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {boolean} request.showMissing
    *   If the list should show missing documents. A missing document is a
    *   document that does not exist but has sub-documents. These documents will
@@ -566,7 +569,7 @@ export declare class FirestoreClient {
    *   Reads documents in a transaction.
    * @param {google.protobuf.Timestamp} request.readTime
    *   Reads documents as they were at the given time.
-   *   This may not be older than 60 seconds.
+   *   This may not be older than 270 seconds.
    * @param {boolean} request.showMissing
    *   If the list should show missing documents. A missing document is a
    *   document that does not exist but has sub-documents. These documents will
@@ -595,6 +598,165 @@ export declare class FirestoreClient {
     request?: protos.google.firestore.v1beta1.IListDocumentsRequest,
     options?: CallOptions
   ): AsyncIterable<protos.google.firestore.v1beta1.IDocument>;
+  partitionQuery(
+    request: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.firestore.v1beta1.ICursor[],
+      protos.google.firestore.v1beta1.IPartitionQueryRequest | null,
+      protos.google.firestore.v1beta1.IPartitionQueryResponse
+    ]
+  >;
+  partitionQuery(
+    request: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options: CallOptions,
+    callback: PaginationCallback<
+      protos.google.firestore.v1beta1.IPartitionQueryRequest,
+      | protos.google.firestore.v1beta1.IPartitionQueryResponse
+      | null
+      | undefined,
+      protos.google.firestore.v1beta1.ICursor
+    >
+  ): void;
+  partitionQuery(
+    request: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    callback: PaginationCallback<
+      protos.google.firestore.v1beta1.IPartitionQueryRequest,
+      | protos.google.firestore.v1beta1.IPartitionQueryResponse
+      | null
+      | undefined,
+      protos.google.firestore.v1beta1.ICursor
+    >
+  ): void;
+  /**
+   * Equivalent to `method.name.toCamelCase()`, but returns a NodeJS Stream object.
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   *   Required. The parent resource name. In the format:
+   *   `projects/{project_id}/databases/{database_id}/documents`.
+   *   Document resource names are not supported; only database resource names
+   *   can be specified.
+   * @param {google.firestore.v1beta1.StructuredQuery} request.structuredQuery
+   *   A structured query.
+   *   Query must specify collection with all descendants and be ordered by name
+   *   ascending. Other filters, order bys, limits, offsets, and start/end
+   *   cursors are not supported.
+   * @param {number} request.partitionCount
+   *   The desired maximum number of partition points.
+   *   The partitions may be returned across multiple pages of results.
+   *   The number must be positive. The actual number of partitions
+   *   returned may be fewer.
+   *
+   *   For example, this may be set to one fewer than the number of parallel
+   *   queries to be run, or in running a data pipeline job, one fewer than the
+   *   number of workers or compute instances available.
+   * @param {string} request.pageToken
+   *   The `next_page_token` value returned from a previous call to
+   *   PartitionQuery that may be used to get an additional set of results.
+   *   There are no ordering guarantees between sets of results. Thus, using
+   *   multiple sets of results will require merging the different result sets.
+   *
+   *   For example, two subsequent calls using a page_token may return:
+   *
+   *    * cursor B, cursor M, cursor Q
+   *    * cursor A, cursor U, cursor W
+   *
+   *   To obtain a complete result set ordered with respect to the results of the
+   *   query supplied to PartitionQuery, the results sets should be merged:
+   *   cursor A, cursor B, cursor M, cursor Q, cursor U, cursor W
+   * @param {number} request.pageSize
+   *   The maximum number of partitions to return in this call, subject to
+   *   `partition_count`.
+   *
+   *   For example, if `partition_count` = 10 and `page_size` = 8, the first call
+   *   to PartitionQuery will return up to 8 partitions and a `next_page_token`
+   *   if more results exist. A second call to PartitionQuery will return up to
+   *   2 partitions, to complete the total of 10 specified in `partition_count`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Stream}
+   *   An object stream which emits an object representing [Cursor]{@link google.firestore.v1beta1.Cursor} on 'data' event.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed. Note that it can affect your quota.
+   *   We recommend using `partitionQueryAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   */
+  partitionQueryStream(
+    request?: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options?: CallOptions
+  ): Transform;
+  /**
+   * Equivalent to `partitionQuery`, but returns an iterable object.
+   *
+   * `for`-`await`-`of` syntax is used with the iterable to get response elements on-demand.
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   *   Required. The parent resource name. In the format:
+   *   `projects/{project_id}/databases/{database_id}/documents`.
+   *   Document resource names are not supported; only database resource names
+   *   can be specified.
+   * @param {google.firestore.v1beta1.StructuredQuery} request.structuredQuery
+   *   A structured query.
+   *   Query must specify collection with all descendants and be ordered by name
+   *   ascending. Other filters, order bys, limits, offsets, and start/end
+   *   cursors are not supported.
+   * @param {number} request.partitionCount
+   *   The desired maximum number of partition points.
+   *   The partitions may be returned across multiple pages of results.
+   *   The number must be positive. The actual number of partitions
+   *   returned may be fewer.
+   *
+   *   For example, this may be set to one fewer than the number of parallel
+   *   queries to be run, or in running a data pipeline job, one fewer than the
+   *   number of workers or compute instances available.
+   * @param {string} request.pageToken
+   *   The `next_page_token` value returned from a previous call to
+   *   PartitionQuery that may be used to get an additional set of results.
+   *   There are no ordering guarantees between sets of results. Thus, using
+   *   multiple sets of results will require merging the different result sets.
+   *
+   *   For example, two subsequent calls using a page_token may return:
+   *
+   *    * cursor B, cursor M, cursor Q
+   *    * cursor A, cursor U, cursor W
+   *
+   *   To obtain a complete result set ordered with respect to the results of the
+   *   query supplied to PartitionQuery, the results sets should be merged:
+   *   cursor A, cursor B, cursor M, cursor Q, cursor U, cursor W
+   * @param {number} request.pageSize
+   *   The maximum number of partitions to return in this call, subject to
+   *   `partition_count`.
+   *
+   *   For example, if `partition_count` = 10 and `page_size` = 8, the first call
+   *   to PartitionQuery will return up to 8 partitions and a `next_page_token`
+   *   if more results exist. A second call to PartitionQuery will return up to
+   *   2 partitions, to complete the total of 10 specified in `partition_count`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Object}
+   *   An iterable Object that allows [async iteration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+   *   When you iterate the returned iterable, each element will be an object representing
+   *   [Cursor]{@link google.firestore.v1beta1.Cursor}. The API will be called under the hood as needed, once per the page,
+   *   so you can stop the iteration when you don't need more results.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   * @example
+   * const iterable = client.partitionQueryAsync(request);
+   * for await (const response of iterable) {
+   *   // process response
+   * }
+   */
+  partitionQueryAsync(
+    request?: protos.google.firestore.v1beta1.IPartitionQueryRequest,
+    options?: CallOptions
+  ): AsyncIterable<protos.google.firestore.v1beta1.ICursor>;
   listCollectionIds(
     request: protos.google.firestore.v1beta1.IListCollectionIdsRequest,
     options?: CallOptions


### PR DESCRIPTION
The important changes are in synth.py. Previous synthtool runs were failing because `npm install` was called before the new proto heading files were generated by `update.sh`. Instead, `npm install` is now called after the proto generation is complete. 