### PR TITLE
feat: use limit queries on recursiveDelete()

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1251,7 +1251,7 @@ export class Firestore implements firestore.Firestore {
   ): Promise<void> {
     const writer = bulkWriter ?? this.getBulkWriter();
     const deleter = new RecursiveDelete(this, writer, ref);
-    return deleter.delete();
+    return deleter.run();
   }
 
   /**

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -16,7 +16,7 @@
 
 import * as firestore from '@google-cloud/firestore';
 
-import {CallOptions, grpc, RetryOptions, Status} from 'google-gax';
+import {CallOptions, grpc, RetryOptions} from 'google-gax';
 import {Duplex, PassThrough, Transform} from 'stream';
 
 import {URL} from 'url';
@@ -40,7 +40,7 @@ import {
   validateResourcePath,
 } from './path';
 import {ClientPool} from './pool';
-import {CollectionReference, Query} from './reference';
+import {CollectionReference} from './reference';
 import {DocumentReference} from './reference';
 import {Serializer} from './serializer';
 import {Timestamp} from './timestamp';

--- a/dev/src/recursive-delete.ts
+++ b/dev/src/recursive-delete.ts
@@ -58,6 +58,12 @@ export const MAX_PENDING_OPS = 5000;
  */
 const MIN_PENDING_OPS = 1000;
 
+/**
+ * Class used to store state required for running a recursive delete operation.
+ * Each recursive delete call should use a new instance of the class, like the
+ * Transaction class.
+ * @private
+ */
 export class RecursiveDelete {
   /**
    * The number of deletes that failed with a permanent error.
@@ -73,7 +79,8 @@ export class RecursiveDelete {
   private lastError: GoogleError | BulkWriterError | undefined;
 
   /**
-   * Whether all descendants for this query have been fetched.
+   * Whether all descendants for this query have been fetched, or if the stream
+   * has errored.
    * @private
    */
   private allDescendantsFetched = false;

--- a/dev/src/recursive-delete.ts
+++ b/dev/src/recursive-delete.ts
@@ -43,14 +43,14 @@ import {QueryOptions} from './reference';
 export const REFERENCE_NAME_MIN_ID = '__id-9223372036854775808__';
 
 /*!
- * The query limit used for recursiveDelete() when fetching all descendants of
+ * The query limit used for recursive deletes when fetching all descendants of
  * the specified reference to delete. This is done to prevent the query stream
  * from streaming documents faster than Firestore can delete.
  */
 export const MAX_PENDING_OPS = 5000;
 
 /**
- * The number of pending BulkWriter operations at which recursiveDelete()
+ * The number of pending BulkWriter operations at which RecursiveDelete
  * starts the next limit query to fetch descendants. By starting the query
  * while there are pending operations, Firestore can improve BulkWriter
  * throughput. This helps prevent BulkWriter from idling while Firestore
@@ -60,8 +60,7 @@ const MIN_PENDING_OPS = 1000;
 
 /**
  * Class used to store state required for running a recursive delete operation.
- * Each recursive delete call should use a new instance of the class, like the
- * Transaction class.
+ * Each recursive delete call should use a new instance of the class.
  * @private
  */
 export class RecursiveDelete {
@@ -155,11 +154,12 @@ export class RecursiveDelete {
    * @private
    */
   private setupStream(startAfterLastSnapshot = false): void {
+    const limit = MAX_PENDING_OPS;
     const stream = this.getAllDescendants(
       this.ref instanceof CollectionReference
         ? (this.ref as CollectionReference<unknown>)
         : (this.ref as DocumentReference<unknown>),
-      MAX_PENDING_OPS,
+      limit,
       startAfterLastSnapshot
     );
     this.streamInProgress = true;
@@ -180,7 +180,7 @@ export class RecursiveDelete {
         this.streamInProgress = false;
         // If there are fewer than the number of documents specified in the
         // limit() field, we know that the query is complete.
-        if (streamedDocsCount < MAX_PENDING_OPS) {
+        if (streamedDocsCount < limit) {
           this.onQueryEnd();
         }
       });

--- a/dev/src/recursive-delete.ts
+++ b/dev/src/recursive-delete.ts
@@ -1,0 +1,310 @@
+/*!
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as firestore from '@google-cloud/firestore';
+
+import * as assert from 'assert';
+
+import Firestore, {
+  BulkWriter,
+  CollectionReference,
+  DocumentReference,
+  FieldPath,
+  Query,
+  QueryDocumentSnapshot,
+} from '.';
+import {Deferred, wrapError} from './util';
+import {GoogleError, Status} from 'google-gax';
+import {BulkWriterError} from './bulk-writer';
+import {QueryOptions} from './reference';
+
+/**
+ * Datastore allowed numeric IDs where Firestore only allows strings. Numeric
+ * IDs are exposed to Firestore as __idNUM__, so this is the lowest possible
+ * negative numeric value expressed in that format.
+ *
+ * This constant is used to specify startAt/endAt values when querying for all
+ * descendants in a single collection.
+ *
+ * @private
+ */
+export const REFERENCE_NAME_MIN_ID = '__id-9223372036854775808__';
+
+/*!
+ * The query limit used for recursiveDelete() when fetching all descendants of
+ * the specified reference to delete. This is done to prevent the query stream
+ * from streaming documents faster than Firestore can delete.
+ */
+export const MAX_PENDING_OPS = 5000;
+
+/**
+ * The number of pending BulkWriter operations at which recursiveDelete()
+ * starts the next limit query to fetch descendants. By starting the query
+ * while there are pending operations, Firestore can improve BulkWriter
+ * throughput. This helps prevent BulkWriter from idling while Firestore
+ * fetches the next query.
+ */
+const MIN_PENDING_OPS = 1000;
+
+export class RecursiveDelete {
+  /**
+   * The number of deletes that failed with a permanent error.
+   * @private
+   */
+  private errorCount = 0;
+
+  /**
+   * The most recently thrown error. Used to populate the developer-facing
+   * error message when the recursive delete operation completes.
+   * @private
+   */
+  private lastError: GoogleError | BulkWriterError | undefined;
+
+  /**
+   * Whether all descendants for this query have been fetched.
+   * @private
+   */
+  private allDescendantsFetched = false;
+
+  /**
+   * A deferred promise that resolves when the recursive delete operation
+   * is completed.
+   * @private
+   */
+  private readonly completionDeferred = new Deferred<void>();
+
+  /**
+   * Whether a query stream is currently in progress. Only one stream can be
+   * run at a time.
+   * @private
+   */
+  private streamInProgress = false;
+
+  /**
+   * The last document snapshot returned by the stream. Used to set the
+   * startAfter() field in the subsequent stream.
+   * @private
+   */
+  private lastDocumentSnap: QueryDocumentSnapshot | undefined;
+
+  /**
+   * The number of pending BulkWriter operations. Used to determine when the
+   * next query can be run.
+   * @private
+   */
+  private pendingOpsCount = 0;
+
+  private errorStack = '';
+
+  /**
+   *
+   * @param firestore The Firestore instance to use.
+   * @param writer The BulkWriter instance to use for delete operations.
+   * @param ref The document or collection reference to recursively delete.
+   */
+  constructor(
+    private readonly firestore: Firestore,
+    private readonly writer: BulkWriter,
+    private readonly ref:
+      | firestore.CollectionReference<unknown>
+      | firestore.DocumentReference<unknown>
+  ) {}
+
+  /**
+   * Recursively deletes the reference provided in the class constructor.
+   * Returns a promise that resolves when all descendants have been deleted, or
+   * if an error occurs.
+   */
+  delete(): Promise<void> {
+    assert(
+      !this.allDescendantsFetched,
+      'The recursive delete operation has already been completed.'
+    );
+
+    // Capture the error stack to preserve stack tracing across async calls.
+    this.errorStack = Error().stack!;
+
+    this.writer._verifyNotClosed();
+    this.setupStream();
+    return this.completionDeferred.promise;
+  }
+
+  /**
+   * Creates a query stream and attaches event handlers to it.
+   * @param startAfterLastSnapshot Whether to start after the last streamed
+   * snapshot.
+   * @private
+   */
+  private setupStream(startAfterLastSnapshot = false): void {
+    const stream = this.getAllDescendants(
+      this.ref instanceof CollectionReference
+        ? (this.ref as CollectionReference<unknown>)
+        : (this.ref as DocumentReference<unknown>),
+      MAX_PENDING_OPS,
+      startAfterLastSnapshot
+    );
+    this.streamInProgress = true;
+    let streamedDocsCount = 0;
+    stream
+      .on('error', err => {
+        err.code = Status.UNAVAILABLE;
+        err.stack = 'Failed to fetch children documents: ' + err.stack;
+        this.lastError = err;
+        this.onQueryEnd();
+      })
+      .on('data', (snap: QueryDocumentSnapshot) => {
+        streamedDocsCount++;
+        this.lastDocumentSnap = snap;
+        this.deleteRef(snap.ref);
+      })
+      .on('end', () => {
+        this.streamInProgress = false;
+        // If there are fewer than the number of documents specified in the
+        // limit() field, we know that the query is complete.
+        if (streamedDocsCount < MAX_PENDING_OPS) {
+          this.onQueryEnd();
+        }
+      });
+  }
+
+  /**
+   * Retrieves all descendant documents nested under the provided reference.
+   * @param ref The reference to fetch all descendants for.
+   * @param limit The number of descendants to fetch in the query.
+   * @param startAfterLastSnapshot Whether to start from the last streamed
+   * document snapshot.
+   * @private
+   * @return {Stream<QueryDocumentSnapshot>} Stream of descendant documents.
+   */
+  private getAllDescendants(
+    ref: CollectionReference<unknown> | DocumentReference<unknown>,
+    limit: number,
+    startAfterLastSnapshot: boolean
+  ): NodeJS.ReadableStream {
+    // The parent is the closest ancestor document to the location we're
+    // deleting. If we are deleting a document, the parent is the path of that
+    // document. If we are deleting a collection, the parent is the path of the
+    // document containing that collection (or the database root, if it is a
+    // root collection).
+    let parentPath = ref._resourcePath;
+    if (ref instanceof CollectionReference) {
+      parentPath = parentPath.popLast();
+    }
+    const collectionId =
+      ref instanceof CollectionReference
+        ? ref.id
+        : (ref as DocumentReference<unknown>).parent.id;
+
+    let query: Query = new Query(
+      this.firestore,
+      QueryOptions.forKindlessAllDescendants(
+        parentPath,
+        collectionId,
+        /* requireConsistency= */ false
+      )
+    );
+
+    // Query for names only to fetch empty snapshots.
+    query = query.select(FieldPath.documentId()).limit(limit);
+
+    if (ref instanceof CollectionReference) {
+      // To find all descendants of a collection reference, we need to use a
+      // composite filter that captures all documents that start with the
+      // collection prefix. The MIN_KEY constant represents the minimum key in
+      // this collection, and a null byte + the MIN_KEY represents the minimum
+      // key is the next possible collection.
+      const nullChar = String.fromCharCode(0);
+      const startAt = collectionId + '/' + REFERENCE_NAME_MIN_ID;
+      const endAt = collectionId + nullChar + '/' + REFERENCE_NAME_MIN_ID;
+      query = query
+        .where(FieldPath.documentId(), '>=', startAt)
+        .where(FieldPath.documentId(), '<', endAt);
+    }
+
+    if (startAfterLastSnapshot) {
+      query = query.startAfter(this.lastDocumentSnap);
+    }
+
+    return query.stream();
+  }
+
+  /**
+   * Called when all descendants of the provided reference have been streamed
+   * or if a permanent error occurs during the stream. Deletes the developer
+   * provided reference and wraps any errors that occurred.
+   * @private
+   */
+  private onQueryEnd(): void {
+    this.allDescendantsFetched = true;
+    if (this.ref instanceof DocumentReference) {
+      this.writer.delete(this.ref).catch(err => this.incrementErrorCount(err));
+    }
+    this.writer.flush().then(async () => {
+      if (this.lastError === undefined) {
+        this.completionDeferred.resolve();
+      } else {
+        let error = new GoogleError(
+          `${this.errorCount} ` +
+            `${this.errorCount !== 1 ? 'deletes' : 'delete'} ` +
+            'failed. The last delete failed with: '
+        );
+        if (this.lastError.code !== undefined) {
+          error.code = (this.lastError.code as number) as Status;
+        }
+        error = wrapError(error, this.errorStack);
+
+        // Wrap the BulkWriter error last to provide the full stack trace.
+        this.completionDeferred.reject(
+          this.lastError.stack
+            ? wrapError(error, this.lastError.stack ?? '')
+            : error
+        );
+      }
+    });
+  }
+
+  /**
+   * Deletes the provided reference and starts the next stream if conditions
+   * are met.
+   * @private
+   */
+  private deleteRef(docRef: DocumentReference): void {
+    this.pendingOpsCount++;
+    this.writer
+      .delete(docRef)
+      .catch(err => {
+        this.incrementErrorCount(err);
+      })
+      .then(() => {
+        this.pendingOpsCount--;
+        // We wait until the previous stream has ended in order to sure the
+        // startAfter document is correct. Starting the next stream while
+        // there are pending operations allows Firestore to maximize
+        // BulkWriter throughput.
+        if (
+          !this.allDescendantsFetched &&
+          !this.streamInProgress &&
+          this.pendingOpsCount < MIN_PENDING_OPS
+        ) {
+          this.setupStream(/* startAfterLastSnapshot= */ true);
+        }
+      });
+  }
+
+  private incrementErrorCount(err: Error): void {
+    this.errorCount++;
+    this.lastError = err;
+  }
+}

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -203,7 +203,7 @@ export function orderBy(
   return {orderBy};
 }
 
-function limit(n: number): api.IStructuredQuery {
+export function limit(n: number): api.IStructuredQuery {
   return {
     limit: {
       value: n,

--- a/dev/test/recursive-delete.ts
+++ b/dev/test/recursive-delete.ts
@@ -47,13 +47,10 @@ import {
   mergeResponses,
   successResponse,
 } from './bulk-writer';
-import {
-  MAX_REQUEST_RETRIES,
-  RECURSIVE_DELETE_QUERY_LIMIT,
-  REFERENCE_NAME_MIN_ID,
-} from '../src';
+import {MAX_REQUEST_RETRIES} from '../src';
 
 import api = google.firestore.v1;
+import {MAX_PENDING_OPS, REFERENCE_NAME_MIN_ID} from '../src/recursive-delete';
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
@@ -143,7 +140,7 @@ describe('recursiveDelete() method:', () => {
               'LESS_THAN',
               endAt('root')
             ),
-            limit(RECURSIVE_DELETE_QUERY_LIMIT)
+            limit(MAX_PENDING_OPS)
           );
           return stream();
         },
@@ -168,7 +165,7 @@ describe('recursiveDelete() method:', () => {
               'LESS_THAN',
               endAt('root/doc/nestedCol')
             ),
-            limit(RECURSIVE_DELETE_QUERY_LIMIT)
+            limit(MAX_PENDING_OPS)
           );
           return stream();
         },
@@ -187,7 +184,7 @@ describe('recursiveDelete() method:', () => {
             'root/doc',
             select('__name__'),
             allDescendants(/* kindless= */ true),
-            limit(RECURSIVE_DELETE_QUERY_LIMIT)
+            limit(MAX_PENDING_OPS)
           );
           return stream();
         },
@@ -225,7 +222,7 @@ describe('recursiveDelete() method:', () => {
                 'LESS_THAN',
                 endAt('root')
               ),
-              limit(RECURSIVE_DELETE_QUERY_LIMIT)
+              limit(MAX_PENDING_OPS)
             );
             return stream();
           }
@@ -239,7 +236,7 @@ describe('recursiveDelete() method:', () => {
 
     it('creates a second query with the correct startAfter', async () => {
       const firstStream = Array.from(
-        Array(RECURSIVE_DELETE_QUERY_LIMIT).keys()
+        Array(MAX_PENDING_OPS).keys()
       ).map((_, i) => result('doc' + i));
 
       // Use an array to store that the queryEquals() method succeeded, since
@@ -260,7 +257,7 @@ describe('recursiveDelete() method:', () => {
                 'LESS_THAN',
                 endAt('root')
               ),
-              limit(RECURSIVE_DELETE_QUERY_LIMIT)
+              limit(MAX_PENDING_OPS)
             );
             called.push(1);
             return stream(...firstStream);
@@ -282,9 +279,9 @@ describe('recursiveDelete() method:', () => {
                 referenceValue:
                   `projects/${PROJECT_ID}/databases/(default)/` +
                   'documents/collectionId/doc' +
-                  (RECURSIVE_DELETE_QUERY_LIMIT - 1),
+                  (MAX_PENDING_OPS - 1),
               }),
-              limit(RECURSIVE_DELETE_QUERY_LIMIT)
+              limit(MAX_PENDING_OPS)
             );
             called.push(2);
             return stream();

--- a/dev/test/recursive-delete.ts
+++ b/dev/test/recursive-delete.ts
@@ -32,6 +32,7 @@ import {
 import {
   allDescendants,
   fieldFilters,
+  limit,
   orderBy,
   queryEquals,
   queryEqualsWithParent,
@@ -46,7 +47,11 @@ import {
   mergeResponses,
   successResponse,
 } from './bulk-writer';
-import {MAX_REQUEST_RETRIES, REFERENCE_NAME_MIN_ID} from '../src';
+import {
+  MAX_REQUEST_RETRIES,
+  RECURSIVE_DELETE_QUERY_LIMIT,
+  REFERENCE_NAME_MIN_ID,
+} from '../src';
 
 import api = google.firestore.v1;
 
@@ -137,7 +142,8 @@ describe('recursiveDelete() method:', () => {
               '__name__',
               'LESS_THAN',
               endAt('root')
-            )
+            ),
+            limit(RECURSIVE_DELETE_QUERY_LIMIT)
           );
           return stream();
         },
@@ -161,7 +167,8 @@ describe('recursiveDelete() method:', () => {
               '__name__',
               'LESS_THAN',
               endAt('root/doc/nestedCol')
-            )
+            ),
+            limit(RECURSIVE_DELETE_QUERY_LIMIT)
           );
           return stream();
         },
@@ -179,7 +186,8 @@ describe('recursiveDelete() method:', () => {
             req,
             'root/doc',
             select('__name__'),
-            allDescendants(/* kindless= */ true)
+            allDescendants(/* kindless= */ true),
+            limit(RECURSIVE_DELETE_QUERY_LIMIT)
           );
           return stream();
         },
@@ -216,7 +224,8 @@ describe('recursiveDelete() method:', () => {
                 '__name__',
                 'LESS_THAN',
                 endAt('root')
-              )
+              ),
+              limit(RECURSIVE_DELETE_QUERY_LIMIT)
             );
             return stream();
           }
@@ -226,6 +235,82 @@ describe('recursiveDelete() method:', () => {
 
       const firestore = await createInstance(overrides);
       await firestore.recursiveDelete(firestore.collection('root'));
+    });
+
+    it('creates a second query with the correct startAfter', async () => {
+      const firstStream = Array.from(
+        Array(RECURSIVE_DELETE_QUERY_LIMIT).keys()
+      ).map((_, i) => result('doc' + i));
+
+      // Use an array to store that the queryEquals() method succeeded, since
+      // thrown errors do not result in the recursiveDelete() method failing.
+      const called: number[] = [];
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          if (called.length === 0) {
+            queryEquals(
+              request,
+              select('__name__'),
+              allDescendants(/* kindless= */ true),
+              fieldFilters(
+                '__name__',
+                'GREATER_THAN_OR_EQUAL',
+                startAt('root'),
+                '__name__',
+                'LESS_THAN',
+                endAt('root')
+              ),
+              limit(RECURSIVE_DELETE_QUERY_LIMIT)
+            );
+            called.push(1);
+            return stream(...firstStream);
+          } else if (called.length === 1) {
+            queryEquals(
+              request,
+              select('__name__'),
+              allDescendants(/* kindless= */ true),
+              orderBy('__name__', 'ASCENDING'),
+              fieldFilters(
+                '__name__',
+                'GREATER_THAN_OR_EQUAL',
+                startAt('root'),
+                '__name__',
+                'LESS_THAN',
+                endAt('root')
+              ),
+              queryStartAt(false, {
+                referenceValue:
+                  `projects/${PROJECT_ID}/databases/(default)/` +
+                  'documents/collectionId/doc' +
+                  (RECURSIVE_DELETE_QUERY_LIMIT - 1),
+              }),
+              limit(RECURSIVE_DELETE_QUERY_LIMIT)
+            );
+            called.push(2);
+            return stream();
+          } else {
+            called.push(3);
+            return stream();
+          }
+        },
+        batchWrite: () => {
+          const responses = mergeResponses(
+            Array.from(Array(500).keys()).map(() => successResponse(1))
+          );
+          return response({
+            writeResults: responses.writeResults,
+            status: responses.status,
+          });
+        },
+      };
+      const firestore = await createInstance(overrides);
+
+      // Use a custom batch size with BulkWriter to simplify the dummy
+      // batchWrite() response logic.
+      const bulkWriter = firestore.bulkWriter();
+      bulkWriter._maxBatchSize = 500;
+      await firestore.recursiveDelete(firestore.collection('root'), bulkWriter);
+      expect(called).to.deep.equal([1, 2]);
     });
   });
 


### PR DESCRIPTION
This PR changes `recursiveDelete()` to use limit queries in order to prevent OOMing caused by the query stream from loading documents faster than BulkWriter can delete. I tested different query limit sizes and found that a `limit()` of 5000 seemed to have the fastest throughput that can keep up with BulkWriter on start.

A minor optimization I made was to start the next query when there are < 1000 pending BulkWriter promises. I found that it takes some time for a new query to start, so this should prevent the BulkWriter from idling while waiting for the query to start streaming results. The maximum number of BulkWriter promises would be 6000, and in my benchmarks, this resulted in total maximum memory usage peaking under 100 MB.