### PR TITLE
Upgrade Typescript to 4.2.4

### DIFF
--- a/dev/conformance/runner.ts
+++ b/dev/conformance/runner.ts
@@ -432,7 +432,7 @@ function runTest(spec: ConformanceProto) {
     };
 
     return createInstance(overrides).then(() => {
-      return new Promise((resolve, reject) => {
+      return new Promise<void>((resolve, reject) => {
         const unlisten = watchQuery().onSnapshot(
           actualSnap => {
             const expectedSnapshot = expectedSnapshots.shift();

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -41,13 +41,13 @@ const serviceConfig = constructSettings(
  */
 export class Deferred<R> {
   promise: Promise<R>;
-  resolve: (value?: R | Promise<R>) => void = () => {};
+  resolve: (value: R | Promise<R>) => void = () => {};
   reject: (reason?: Error) => void = () => {};
 
   constructor() {
     this.promise = new Promise(
       (
-        resolve: (value?: R | Promise<R>) => void,
+        resolve: (value: R | Promise<R>) => void,
         reject: (reason?: Error) => void
       ) => {
         this.resolve = resolve;

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -458,7 +458,8 @@ describe('DocumentReference class', () => {
       emptyObject: {},
       dateValue: new Timestamp(479978400, 123000000),
       zeroDateValue: new Timestamp(0, 0),
-      pathValue: firestore.doc('col1/ref1'),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      pathValue: firestore.doc('col1/ref1') as any,
       arrayValue: ['foo', 42, 'bar'],
       emptyArray: [],
       nilValue: null,
@@ -1200,7 +1201,7 @@ describe('DocumentReference class', () => {
       await setupDeferred.promise;
       await ref.set(new Post('post', 'author'));
       const snapshot = await resultsDeferred.promise;
-      expect(snapshot.docs[0].data().toString()).to.equal('post, by author');
+      expect(snapshot?.docs[0].data().toString()).to.equal('post, by author');
       unsubscribe();
     });
   });

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -284,7 +284,7 @@ const allSupportedTypesOutput = {
       _getProjectId: () => ({projectId: PROJECT_ID, databaseId: '(default)'}),
     } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     new QualifiedResourcePath(PROJECT_ID, '(default)', 'collection', 'document')
-  ),
+  ) as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   arrayValue: ['foo', 42, 'bar'],
   emptyArray: [],
   nilValue: null,

--- a/dev/test/pool.ts
+++ b/dev/test/pool.ts
@@ -222,7 +222,7 @@ describe('Client pool', () => {
   });
 
   it('garbage collection calls destructor', () => {
-    const garbageCollect = new Deferred();
+    const garbageCollect = new Deferred<void>();
 
     const clientPool = new ClientPool<{}>(
       1,

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "proxyquire": "^2.1.3",
     "sinon": "^10.0.0",
     "ts-node": "^9.0.0",
-    "typescript": "3.8.3",
+    "typescript": "4.2.4",
     "through2": "^4.0.0",
     "@microsoft/api-documenter": "^7.8.10",
     "@microsoft/api-extractor": "^7.8.10"


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

------

I was working on adding proper typing to the Firestore `update` methods (by making `UpdateData` generic), but it needed some newer Typescript features to work.

Sorry I didn't open an issue first, I figured these changes were pretty straightforward.

The only thing I wasn't sure about here was the `as any` for `pathValue` - this was to allow the test to `delete` the key later on (it needed to be optional, and I wasn't sure about the cleanest way to do that since there is no interface defined for `allSupportedTypesObject`). 