### PR TITLE
feat: add Precondition.exists to delete()

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -244,7 +244,7 @@ const MAX_CONCURRENT_REQUESTS_PER_CLIENT = 100;
  *  enforces that the document was last updated at lastUpdateTime. Fails the
  *  operation if the document was last updated at a different time.
  * @property {boolean} exists If set, enforces that the target document must
- * or must not exist. This property is only valid with delete operations.
+ * or must not exist.
  * @typedef {Object} Precondition
  */
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -243,6 +243,9 @@ const MAX_CONCURRENT_REQUESTS_PER_CLIENT = 100;
  * @property {Timestamp} lastUpdateTime The update time to enforce. If set,
  *  enforces that the document was last updated at lastUpdateTime. Fails the
  *  operation if the document was last updated at a different time.
+ * @property {boolean} exists If set, enforces that the target document must
+ * exist. This property
+ * is only valid with delete operations.
  * @typedef {Object} Precondition
  */
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -225,7 +225,7 @@ const MAX_CONCURRENT_REQUESTS_PER_CLIENT = 100;
  * [update()]{@link DocumentReference#update} and
  * [delete()]{@link DocumentReference#delete} calls in
  * [DocumentReference]{@link DocumentReference},
- * [WriteBatch]{@link WriteBatch}, and
+ * [WriteBatch]{@link WriteBatch}, [BulkWriter]({@link BulkWriter}, and
  * [Transaction]{@link Transaction}. Using Preconditions, these calls
  * can be restricted to only apply to documents that match the specified
  * conditions.
@@ -244,8 +244,7 @@ const MAX_CONCURRENT_REQUESTS_PER_CLIENT = 100;
  *  enforces that the document was last updated at lastUpdateTime. Fails the
  *  operation if the document was last updated at a different time.
  * @property {boolean} exists If set, enforces that the target document must
- * exist. This property
- * is only valid with delete operations.
+ * or must not exist. This property is only valid with delete operations.
  * @typedef {Object} Precondition
  */
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -371,6 +371,8 @@ export class DocumentReference<T = firestore.DocumentData>
    * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
    * document was last updated at lastUpdateTime. Fails the delete if the
    * document was last updated at a different time.
+   * @param {boolean=} precondition.exists If set, enforces that the target document
+   * must exist.
    * @returns {Promise.<WriteResult>} A Promise that resolves with the
    * delete time.
    *

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -371,8 +371,8 @@ export class DocumentReference<T = firestore.DocumentData>
    * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
    * document was last updated at lastUpdateTime. Fails the delete if the
    * document was last updated at a different time.
-   * @param {boolean=} precondition.exists If set, enforces that the target document
-   * must exist.
+   * @param {boolean=} precondition.exists If set, enforces that the target
+   * document must or must not exist.
    * @returns {Promise.<WriteResult>} A Promise that resolves with the
    * delete time.
    *

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -330,8 +330,8 @@ export class Transaction implements firestore.Transaction {
    * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
    * document was last updated at lastUpdateTime. Fails the transaction if the
    * document doesn't exist or was last updated at a different time.
-   * @param {boolean=} precondition.exists If set, enforces that the target document must
-   * exist.
+   * @param {boolean=} precondition.exists If set, enforces that the target
+   * document must or must not exist.
    * @returns {Transaction} This Transaction instance. Used for
    * chaining method calls.
    *

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -330,6 +330,8 @@ export class Transaction implements firestore.Transaction {
    * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
    * document was last updated at lastUpdateTime. Fails the transaction if the
    * document doesn't exist or was last updated at a different time.
+   * @param {boolean=} precondition.exists If set, enforces that the target document must
+   * exist.
    * @returns {Transaction} This Transaction instance. Used for
    * chaining method calls.
    *

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -222,6 +222,8 @@ export class WriteBatch implements firestore.WriteBatch {
    * @param {Timestamp=} precondition.lastUpdateTime If set, enforces that the
    * document was last updated at lastUpdateTime. Fails the batch if the
    * document doesn't exist or was last updated at a different time.
+   * @param {boolean= } precondition.exists If set to true, enforces that the target
+   * document must exist.
    * @returns {WriteBatch} This WriteBatch instance. Used for chaining
    * method calls.
    *

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -223,7 +223,7 @@ export class WriteBatch implements firestore.WriteBatch {
    * document was last updated at lastUpdateTime. Fails the batch if the
    * document doesn't exist or was last updated at a different time.
    * @param {boolean= } precondition.exists If set to true, enforces that the target
-   * document must exist.
+   * document must or must not exist.
    * @returns {WriteBatch} This WriteBatch instance. Used for chaining
    * method calls.
    *

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -735,6 +735,15 @@ describe('DocumentReference class', () => {
     return ref.delete();
   });
 
+  it('will fail to delete document with exists: true if doc does not exist', () => {
+    const ref = randomCol.doc();
+    return ref.delete({exists: true})
+        .then(() => Promise.reject('Delete should have failed'))
+        .catch((err: Error) => {
+          expect(err.message).to.contain('NOT_FOUND: No document to update');
+        });
+  });
+
   it('supports non-alphanumeric field names', () => {
     const ref = randomCol.doc('doc');
     return ref

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -737,11 +737,12 @@ describe('DocumentReference class', () => {
 
   it('will fail to delete document with exists: true if doc does not exist', () => {
     const ref = randomCol.doc();
-    return ref.delete({exists: true})
-        .then(() => Promise.reject('Delete should have failed'))
-        .catch((err: Error) => {
-          expect(err.message).to.contain('NOT_FOUND: No document to update');
-        });
+    return ref
+      .delete({exists: true})
+      .then(() => Promise.reject('Delete should have failed'))
+      .catch((err: Error) => {
+        expect(err.message).to.contain('NOT_FOUND: No document to update');
+      });
   });
 
   it('supports non-alphanumeric field names', () => {

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -552,7 +552,7 @@ declare namespace FirebaseFirestore {
      * document was last updated at lastUpdateTime. Fails the batch if the
      * document doesn't exist or was last updated at a different time.
      * @param precondition.exists If set, enforces that the target document
-     * must exist.
+     * must or must not exist.
      * @returns A promise that resolves with the result of the delete. If the
      * delete fails, the promise is rejected with a
      * [BulkWriterError]{@link BulkWriterError}.
@@ -880,6 +880,11 @@ declare namespace FirebaseFirestore {
      * If set, the last update time to enforce.
      */
     readonly lastUpdateTime?: Timestamp;
+
+    /**
+     * If set, enforces that the target document must or must not exist.
+     */
+    readonly exists?: boolean;
   }
 
   /**

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -551,6 +551,8 @@ declare namespace FirebaseFirestore {
      * @param precondition.lastUpdateTime If set, enforces that the
      * document was last updated at lastUpdateTime. Fails the batch if the
      * document doesn't exist or was last updated at a different time.
+     * @param precondition.exists If set, enforces that the target document
+     * must exist.
      * @returns A promise that resolves with the result of the delete. If the
      * delete fails, the promise is rejected with a
      * [BulkWriterError]{@link BulkWriterError}.


### PR DESCRIPTION
Adding `Preconditions.exists()` to documentation and TS autocomplete, as requested in [comment](https://github.com/googleapis/nodejs-firestore/issues/599#issuecomment-840093592).