### PR TITLE
fix: do not load google-gax at client startup

### DIFF
--- a/dev/src/bundle.ts
+++ b/dev/src/bundle.ts
@@ -25,7 +25,6 @@ import {
 } from './validate';
 
 import api = google.firestore.v1;
-import BundleElement = firestore.BundleElement;
 
 const BUNDLE_VERSION = 1;
 
@@ -146,7 +145,10 @@ export class BundleBuilder {
     // Convert to a valid proto message object then take its JSON representation.
     // This take cares of stuff like converting internal byte array fields
     // to Base64 encodings.
-    const message = BundleElement.fromObject(bundleElement).toJSON();
+    // We lazy-load the Proto file to reduce cold-start times.
+    const message = require('../protos/firestore_v1_proto_api')
+      .firestore.BundleElement.fromObject(bundleElement)
+      .toJSON();
     const buffer = Buffer.from(JSON.stringify(message), 'utf-8');
     const lengthBuffer = Buffer.from(buffer.length.toString());
     return Buffer.concat([lengthBuffer, buffer]);

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -16,7 +16,7 @@
 
 import * as firestore from '@google-cloud/firestore';
 
-import {CallOptions, grpc, RetryOptions} from 'google-gax';
+import {CallOptions} from 'google-gax';
 import {Duplex, PassThrough, Transform} from 'stream';
 
 import {URL} from 'url';
@@ -96,7 +96,6 @@ export {GeoPoint} from './geo-point';
 export {CollectionGroup};
 export {QueryPartition} from './query-partition';
 export {setLogFunction} from './logger';
-export {Status as GrpcStatus} from 'google-gax';
 
 const libVersion = require('../../package.json').version;
 setLibVersion(libVersion);
@@ -122,16 +121,6 @@ setLibVersion(libVersion);
 /**
  * @namespace google.firestore.admin.v1
  */
-
-/*!
- * @see v1
- */
-let v1: unknown; // Lazy-loaded in `_runRequest()`
-
-/*!
- * @see v1beta1
- */
-let v1beta1: unknown; // Lazy-loaded upon access.
 
 /*!
  * HTTP header for the resource prefix to improve routing and project isolation
@@ -481,7 +470,7 @@ export class Firestore implements firestore.Firestore {
         let client: GapicClient;
 
         if (this._settings.ssl === false) {
-          const grpcModule = this._settings.grpc ?? grpc;
+          const grpcModule = this._settings.grpc ?? require('google-gax').grpc;
           const sslCreds = grpcModule.credentials.createInsecure();
 
           client = new module.exports.v1({
@@ -1340,7 +1329,10 @@ export class Firestore implements firestore.Firestore {
 
     if (retryCodes) {
       const retryParams = getRetryParams(methodName);
-      callOptions.retry = new RetryOptions(retryCodes, retryParams);
+      callOptions.retry = new (require('google-gax').RetryOptions)(
+        retryCodes,
+        retryParams
+      );
     }
 
     return callOptions;
@@ -1689,18 +1681,12 @@ module.exports = Object.assign(module.exports, existingExports);
  *
  * @private
  * @name Firestore.v1beta1
- * @see v1beta1
  * @type {function}
  */
 Object.defineProperty(module.exports, 'v1beta1', {
   // The v1beta1 module is very large. To avoid pulling it in from static
-  // scope, we lazy-load and cache the module.
-  get: () => {
-    if (!v1beta1) {
-      v1beta1 = require('./v1beta1');
-    }
-    return v1beta1;
-  },
+  // scope, we lazy-load the module.
+  get: () => require('./v1beta1'),
 });
 
 /**
@@ -1708,16 +1694,23 @@ Object.defineProperty(module.exports, 'v1beta1', {
  *
  * @private
  * @name Firestore.v1
- * @see v1
  * @type {function}
  */
 Object.defineProperty(module.exports, 'v1', {
   // The v1 module is very large. To avoid pulling it in from static
-  // scope, we lazy-load and cache the module.
-  get: () => {
-    if (!v1) {
-      v1 = require('./v1');
-    }
-    return v1;
-  },
+  // scope, we lazy-load  the module.
+  get: () => require('./v1beta1'),
+});
+
+/**
+ * {@link Status} factory function.
+ *
+ * @private
+ * @name Firestore.GrpcStatus
+ * @type {function}
+ */
+Object.defineProperty(module.exports, 'GrpcStatus', {
+  // The gax module is very large. To avoid pulling it in from static
+  // scope, we lazy-load the module.
+  get: () => require('google-gax').Status,
 });

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1733,7 +1733,7 @@ Object.defineProperty(module.exports, 'v1beta1', {
 Object.defineProperty(module.exports, 'v1', {
   // The v1 module is very large. To avoid pulling it in from static
   // scope, we lazy-load  the module.
-  get: () => require('./v1beta1'),
+  get: () => require('./v1'),
 });
 
 /**

--- a/dev/src/recursive-delete.ts
+++ b/dev/src/recursive-delete.ts
@@ -26,9 +26,10 @@ import Firestore, {
   QueryDocumentSnapshot,
 } from '.';
 import {Deferred, wrapError} from './util';
-import {GoogleError, Status} from 'google-gax';
+import {GoogleError} from 'google-gax';
 import {BulkWriterError} from './bulk-writer';
 import {QueryOptions} from './reference';
+import {StatusCode} from './status-code';
 
 /**
  * Datastore allowed numeric IDs where Firestore only allows strings. Numeric
@@ -163,7 +164,7 @@ export class RecursiveDelete {
     let streamedDocsCount = 0;
     stream
       .on('error', err => {
-        err.code = Status.UNAVAILABLE;
+        err.code = StatusCode.UNAVAILABLE;
         err.stack = 'Failed to fetch children documents: ' + err.stack;
         this.lastError = err;
         this.onQueryEnd();
@@ -258,13 +259,13 @@ export class RecursiveDelete {
       if (this.lastError === undefined) {
         this.completionDeferred.resolve();
       } else {
-        let error = new GoogleError(
+        let error = new (require('google-gax').GoogleError)(
           `${this.errorCount} ` +
             `${this.errorCount !== 1 ? 'deletes' : 'delete'} ` +
             'failed. The last delete failed with: '
         );
         if (this.lastError.code !== undefined) {
-          error.code = (this.lastError.code as number) as Status;
+          error.code = this.lastError.code as number;
         }
         error = wrapError(error, this.errorStack);
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -502,8 +502,10 @@ export class DocumentReference<T = firestore.DocumentData>
     validateFunction('onNext', onNext);
     validateFunction('onError', onError, {optional: true});
 
-    const watch = new DocumentWatch(this.firestore, this);
-
+    const watch: DocumentWatch<T> = new (require('./watch').DocumentWatch)(
+      this.firestore,
+      this
+    );
     return watch.onSnapshot((readTime, size, docs) => {
       for (const document of docs()) {
         if (document.ref.path === this.path) {
@@ -2247,7 +2249,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
     validateFunction('onNext', onNext);
     validateFunction('onError', onError, {optional: true});
 
-    const watch = new QueryWatch(
+    const watch: QueryWatch<T> = new (require('./watch').QueryWatch)(
       this.firestore,
       this,
       this._queryOptions.converter

--- a/dev/src/status-code.ts
+++ b/dev/src/status-code.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal copy of GRPC status code. Copied to prevent loading of google-gax
+ * at SDK startup.
+ */
+export const enum StatusCode {
+  OK = 0,
+  CANCELLED = 1,
+  UNKNOWN = 2,
+  INVALID_ARGUMENT = 3,
+  DEADLINE_EXCEEDED = 4,
+  NOT_FOUND = 5,
+  ALREADY_EXISTS = 6,
+  PERMISSION_DENIED = 7,
+  RESOURCE_EXHAUSTED = 8,
+  FAILED_PRECONDITION = 9,
+  ABORTED = 10,
+  OUT_OF_RANGE = 11,
+  UNIMPLEMENTED = 12,
+  INTERNAL = 13,
+  UNAVAILABLE = 14,
+  DATA_LOSS = 15,
+  UNAUTHENTICATED = 16,
+}

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -16,8 +16,7 @@
 
 import * as firestore from '@google-cloud/firestore';
 
-import {GoogleError, Status} from 'google-gax';
-
+import {GoogleError} from 'google-gax';
 import * as proto from '../protos/firestore_v1_proto_api';
 
 import {ExponentialBackoff} from './backoff';
@@ -25,6 +24,7 @@ import {DocumentSnapshot} from './document';
 import {Firestore, WriteBatch} from './index';
 import {logger} from './logger';
 import {FieldPath, validateFieldPath} from './path';
+import {StatusCode} from './status-code';
 import {
   DocumentReference,
   Query,
@@ -482,7 +482,7 @@ export class Transaction implements firestore.Transaction {
    * @return A Promise that resolves after the delay expired.
    */
   private async maybeBackoff(error?: GoogleError): Promise<void> {
-    if (error && error.code === Status.RESOURCE_EXHAUSTED) {
+    if ((error?.code as number | undefined) === StatusCode.RESOURCE_EXHAUSTED) {
       this._backoff.resetToMax();
     }
     await this._backoff.backoffAndWait();
@@ -590,17 +590,17 @@ function validateReadOptions(
 function isRetryableTransactionError(error: GoogleError): boolean {
   if (error.code !== undefined) {
     // This list is based on https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/core/transaction_runner.ts#L112
-    switch (error.code) {
-      case Status.ABORTED:
-      case Status.CANCELLED:
-      case Status.UNKNOWN:
-      case Status.DEADLINE_EXCEEDED:
-      case Status.INTERNAL:
-      case Status.UNAVAILABLE:
-      case Status.UNAUTHENTICATED:
-      case Status.RESOURCE_EXHAUSTED:
+    switch (error.code as number) {
+      case StatusCode.ABORTED:
+      case StatusCode.CANCELLED:
+      case StatusCode.UNKNOWN:
+      case StatusCode.DEADLINE_EXCEEDED:
+      case StatusCode.INTERNAL:
+      case StatusCode.UNAVAILABLE:
+      case StatusCode.UNAUTHENTICATED:
+      case StatusCode.RESOURCE_EXHAUSTED:
         return true;
-      case Status.INVALID_ARGUMENT:
+      case StatusCode.INVALID_ARGUMENT:
         // The Firestore backend uses "INVALID_ARGUMENT" for transactions
         // IDs that have expired. While INVALID_ARGUMENT is generally not
         // retryable, we retry this specific case.

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -144,7 +144,7 @@ export function isPermanentRpcError(
   }
 }
 
-let serviceConfig: undefined | {[k: string]: CallSettings};
+let serviceConfig: Record<string, CallSettings> | undefined;
 
 /** Lazy-loads the service config when first accessed. */
 function getServiceConfig(methodName: string): CallSettings | undefined {

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -17,23 +17,9 @@
 import {DocumentData} from '@google-cloud/firestore';
 
 import {randomBytes} from 'crypto';
-import {
-  CallSettings,
-  ClientConfig,
-  constructSettings,
-  createDefaultBackoffSettings,
-  GoogleError,
-  Status,
-} from 'google-gax';
+import {CallSettings, ClientConfig, GoogleError} from 'google-gax';
 import {BackoffSettings} from 'google-gax/build/src/gax';
 import * as gapicConfig from './v1/firestore_client_config.json';
-
-const serviceConfig = constructSettings(
-  'google.firestore.v1.Firestore',
-  gapicConfig as ClientConfig,
-  {},
-  Status
-) as {[k: string]: CallSettings};
 
 /**
  * A Promise implementation that supports deferred resolution.
@@ -158,13 +144,28 @@ export function isPermanentRpcError(
   }
 }
 
+let serviceConfig: undefined | {[k: string]: CallSettings};
+
+/** Lazy-loads the service config when first accessed. */
+function getServiceConfig(methodName: string): CallSettings | undefined {
+  if (!serviceConfig) {
+    serviceConfig = require('google-gax').constructSettings(
+      'google.firestore.v1.Firestore',
+      gapicConfig as ClientConfig,
+      {},
+      require('google-gax').Status
+    ) as {[k: string]: CallSettings};
+  }
+  return serviceConfig[methodName];
+}
+
 /**
  * Returns the list of retryable error codes specified in the service
  * configuration.
  * @private
  */
 export function getRetryCodes(methodName: string): number[] {
-  return serviceConfig[methodName]?.retry?.retryCodes ?? [];
+  return getServiceConfig(methodName)?.retry?.retryCodes ?? [];
 }
 
 /**
@@ -173,8 +174,8 @@ export function getRetryCodes(methodName: string): number[] {
  */
 export function getRetryParams(methodName: string): BackoffSettings {
   return (
-    serviceConfig[methodName]?.retry?.backoffSettings ??
-    createDefaultBackoffSettings()
+    getServiceConfig(methodName)?.retry?.backoffSettings ??
+    require('google-gax').createDefaultBackoffSettings()
   );
 }
 

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -45,7 +45,8 @@ import {
   validateMinNumberOfArguments,
   validateOptional,
 } from './validate';
-import {Status} from 'google-gax';
+import {StatusCode} from './status-code';
+
 import api = google.firestore.v1;
 
 /**
@@ -542,7 +543,7 @@ export class WriteBatch implements firestore.WriteBatch {
     const stack = Error().stack!;
 
     // Commits should also be retried when they fail with status code ABORTED.
-    const retryCodes = [Status.ABORTED, ...getRetryCodes('commit')];
+    const retryCodes = [StatusCode.ABORTED, ...getRetryCodes('commit')];
 
     return this._commit<api.CommitRequest, api.CommitResponse>({retryCodes})
       .then(response => {

--- a/dev/test/lazy-load.ts
+++ b/dev/test/lazy-load.ts
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+function isModuleLoaded(moduleName: string) {
+  return !!Object.keys(require.cache).find(
+    path => path.indexOf(`node_modules/${moduleName}`) !== -1
+  );
+}
+
+describe('Index.js', () => {
+  (isModuleLoaded('google-gax') ? it.skip : it)(
+    'does not load google-gax',
+    () => {
+      require('../src/index');
+      expect(isModuleLoaded('google-gax')).to.be.false;
+    }
+  );
+
+  (isModuleLoaded('protobufjs') ? it.skip : it)(
+    'does not load protobufjs',
+    () => {
+      require('../src/index');
+      expect(isModuleLoaded('protobufjs')).to.be.false;
+    }
+  );
+});


### PR DESCRIPTION
This improves performance for functions users that only read data from the provided DocumentSnapshot, but do not otherwise access Firestore.

Test file (from @inlined): https://gist.github.com/schmidt-sebastian/f42c30d75785fba436746f894948ecf4

Extra dependencies loaded before PR:

```
@google-cloud
@grpc
@protobufjs
abort-controller
arrify
base64-js
bignumber.js
buffer-equal-constant-time
duplexify
ecdsa-sig-formatter
end-of-stream
event-target-shim
extend
fast-deep-equal
firebase-admin
functional-red-black-tree
gaxios
gcp-metadata
google-auth-library
google-gax
gtoken
inherits
is-stream
is-stream-ended
json-bigint
jwa
jws
lodash.camelcase
long
lru-cache
node-fetch
node-forge
object-hash
once
protobufjs
readable-stream
retry-request
safe-buffer
stream-shift
util-deprecate
wrappy
yallist
```

After: 
```
@google-cloud
fast-deep-equal
firebase-admin
node-forge
```

Cold start time from firebase-functions:


Invocation | Branch (ms) | Master (ms)
-- | -- | --
0 | 1142 | 3035
1 | 1034 | 965
2 | 743 | 1080
3 | 728 | 728
4 | 662 | 738
5 | 675 | 851
6 | 644 | 791
7 | 824 | 763
8 | 970 | 716
9 | 1438 | 734
&nbsp; | &nbsp; | &nbsp;
Average | 886 | 1040
Worst Case | 1438 | 3035

Code:

```
const functions = require('firebase-functions');

exports.myFunction = functions.firestore
  .document('foo/{docId}')
  .onCreate((change, context) => { 
	  console.info('Executed for document ' + change.id);
	  setTimeout(() => process.exit(0), 1);
});   
```
