### PR TITLE
fix: return results from getPartitions() in order

### DIFF
--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -179,7 +179,7 @@ function compareGeoPoints(
 /*!
  * @private
  */
-function compareArrays(left: api.IValue[], right: api.IValue[]): number {
+export function compareArrays(left: api.IValue[], right: api.IValue[]): number {
   for (let i = 0; i < left.length && i < right.length; i++) {
     const valueComparison = compare(left[i], right[i]);
     if (valueComparison !== 0) {

--- a/dev/test/partition-query.ts
+++ b/dev/test/partition-query.ts
@@ -39,6 +39,8 @@ import api = google.firestore.v1;
 
 const PROJECT_ID = 'test-project';
 const DATABASE_ROOT = `projects/${PROJECT_ID}/databases/(default)`;
+const DOC1 = `${DATABASE_ROOT}/documents/coll/doc1`;
+const DOC2 = `${DATABASE_ROOT}/documents/coll/doc2`;
 
 export function partitionQueryEquals(
   actual: api.IPartitionQueryRequest | undefined,
@@ -127,7 +129,7 @@ describe('Partition Query', () => {
   it('requests one less than desired partitions', () => {
     const desiredPartitionsCount = 2;
     const cursorValue = {
-      values: [{referenceValue: 'projects/p1/databases/d1/documents/coll/doc'}],
+      values: [{referenceValue: DOC1}],
     };
 
     const overrides: ApiOverride = {
@@ -178,12 +180,12 @@ describe('Partition Query', () => {
 
     const expectedStartAt: Array<undefined | api.IValue> = [
       undefined,
-      {referenceValue: 'coll/doc1'},
-      {referenceValue: 'coll/doc2'},
+      {referenceValue: DOC1},
+      {referenceValue: DOC2},
     ];
     const expectedEndBefore: Array<undefined | api.IValue> = [
-      {referenceValue: 'coll/doc1'},
-      {referenceValue: 'coll/doc2'},
+      {referenceValue: DOC1},
+      {referenceValue: DOC2},
       undefined,
     ];
 
@@ -196,10 +198,10 @@ describe('Partition Query', () => {
 
         return stream<api.ICursor>(
           {
-            values: [{referenceValue: 'coll/doc1'}],
+            values: [{referenceValue: DOC1}],
           },
           {
-            values: [{referenceValue: 'coll/doc2'}],
+            values: [{referenceValue: DOC2}],
           }
         );
       },
@@ -285,14 +287,10 @@ describe('Partition Query', () => {
       partitionQueryStream: () => {
         return stream<api.ICursor>(
           {
-            values: [
-              {referenceValue: 'projects/p1/databases/d1/documents/coll/doc2'},
-            ],
+            values: [{referenceValue: DOC2}],
           },
           {
-            values: [
-              {referenceValue: 'projects/p1/databases/d1/documents/coll/doc1'},
-            ],
+            values: [{referenceValue: DOC1}],
           }
         );
       },

--- a/dev/test/partition-query.ts
+++ b/dev/test/partition-query.ts
@@ -18,7 +18,7 @@ import {
   QueryPartition,
 } from '@google-cloud/firestore';
 
-import {describe, it, beforeEach, afterEach} from 'mocha';
+import {afterEach, beforeEach, describe, it} from 'mocha';
 import {expect, use} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as extend from 'extend';
@@ -283,15 +283,16 @@ describe('Partition Query', () => {
 
     const overrides: ApiOverride = {
       partitionQueryStream: () => {
-        const doc1 = 'projects/p1/databases/d1/documents/coll/doc1';
-        const doc2 = 'projects/p1/databases/d1/documents/coll/doc2';
-
         return stream<api.ICursor>(
           {
-            values: [{referenceValue: doc2}],
+            values: [
+              {referenceValue: 'projects/p1/databases/d1/documents/coll/doc2'},
+            ],
           },
           {
-            values: [{referenceValue: doc1}],
+            values: [
+              {referenceValue: 'projects/p1/databases/d1/documents/coll/doc1'},
+            ],
           }
         );
       },


### PR DESCRIPTION
The Partition RPC does not guarantee that results are returned in order, which means we have to sort the partitions before we can use them as cursors.