### PR TITLE
chore: move transaction default max retry attempts to a const

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -138,8 +138,7 @@ const CLOUD_RESOURCE_HEADER = 'google-cloud-resource-prefix';
 export const MAX_REQUEST_RETRIES = 5;
 
 /*!
- * The maximum number of times to attempt committing a transaction before
- * failing.
+ * The maximum number of times to attempt a transaction before failing.
  */
 export const DEFAULT_MAX_TRANSACTION_ATTEMPTS = 5;
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -138,6 +138,12 @@ const CLOUD_RESOURCE_HEADER = 'google-cloud-resource-prefix';
 export const MAX_REQUEST_RETRIES = 5;
 
 /*!
+ * The maximum number of times to attempt committing a transaction before
+ * failing.
+ */
+export const DEFAULT_MAX_TRANSACTION_ATTEMPTS = 5;
+
+/*!
  * The default number of idle GRPC channel to keep.
  */
 const DEFAULT_MAX_IDLE_CHANNELS = 1;
@@ -994,10 +1000,9 @@ export class Firestore implements firestore.Firestore {
   ): Promise<T> {
     validateFunction('updateFunction', updateFunction);
 
-    const defaultAttempts = 5;
     const tag = requestTag();
 
-    let maxAttempts: number;
+    let maxAttempts = DEFAULT_MAX_TRANSACTION_ATTEMPTS;
 
     if (transactionOptions) {
       validateObject('transactionOptions', transactionOptions);
@@ -1006,9 +1011,8 @@ export class Firestore implements firestore.Firestore {
         transactionOptions.maxAttempts,
         {optional: true, minValue: 1}
       );
-      maxAttempts = transactionOptions.maxAttempts || defaultAttempts;
-    } else {
-      maxAttempts = defaultAttempts;
+      maxAttempts =
+        transactionOptions.maxAttempts || DEFAULT_MAX_TRANSACTION_ATTEMPTS;
     }
 
     const transaction = new Transaction(this, tag);


### PR DESCRIPTION
Moving it to a const for better visibility as part of b/147440261.