### PR TITLE
feat: retry BatchGetDocuments RPCs that fail with errors

### DIFF
--- a/dev/src/document-reader.ts
+++ b/dev/src/document-reader.ts
@@ -1,0 +1,193 @@
+/*!
+ * Copyright 2021 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DocumentSnapshot, DocumentSnapshotBuilder} from './document';
+import {DocumentReference} from './reference';
+import {FieldPath} from './path';
+import {isPermanentRpcError} from './util';
+import {google} from '../protos/firestore_v1_proto_api';
+import {logger} from './logger';
+import {Firestore} from './index';
+
+import api = google.firestore.v1;
+
+/**
+ * A wrapper around BatchGetDocumentsRequest that retries request upon stream
+ * failure and returns ordered results.
+ *
+ * @private
+ */
+export class DocumentReader<T> {
+  /** An optional field mask to apply to this read. */
+  fieldMask?: FieldPath[];
+  /** An optional transaction ID to use for this read. */
+  transactionId?: Uint8Array;
+
+  private remainingDocuments = new Set<string>();
+  private retrievedDocuments = new Map<string, DocumentSnapshot>();
+
+  /**
+   * Internal method to retrieve multiple documents from Firestore, optionally
+   * as part of a transaction.
+   *
+   * @param firestore The Firestore instance to use.
+   * @param allDocuments The documents to receive.
+   * @returns A Promise that contains an array with the resulting documents.
+   */
+  constructor(
+    private firestore: Firestore,
+    private allDocuments: Array<DocumentReference<T>>
+  ) {
+    for (const docRef of this.allDocuments) {
+      this.remainingDocuments.add(docRef.formattedName);
+    }
+  }
+
+  /**
+   * Invokes the BatchGetDocuments RPC and returns the results.
+   *
+   * @param requestTag A unique client-assigned identifier for this request.
+   */
+  async get(requestTag: string): Promise<Array<DocumentSnapshot<T>>> {
+    await this.fetchAllDocuments(requestTag);
+
+    // BatchGetDocuments doesn't preserve document order. We use the request
+    // order to sort the resulting documents.
+    const orderedDocuments: Array<DocumentSnapshot<T>> = [];
+
+    for (const docRef of this.allDocuments) {
+      const document = this.retrievedDocuments.get(docRef.formattedName);
+      if (document !== undefined) {
+        // Recreate the DocumentSnapshot with the DocumentReference
+        // containing the original converter.
+        const finalDoc = new DocumentSnapshotBuilder(
+          docRef as DocumentReference<T>
+        );
+        finalDoc.fieldsProto = document._fieldsProto;
+        finalDoc.readTime = document.readTime;
+        finalDoc.createTime = document.createTime;
+        finalDoc.updateTime = document.updateTime;
+        orderedDocuments.push(finalDoc.build());
+      } else {
+        throw new Error(`Did not receive document for "${docRef.path}".`);
+      }
+    }
+
+    return orderedDocuments;
+  }
+
+  private async fetchAllDocuments(requestTag: string): Promise<void> {
+    while (this.remainingDocuments.size > 0) {
+      try {
+        return await this.fetchMoreDocuments(requestTag);
+      } catch (err) {
+        // If a non-transactional read failed, attempt to restart.
+        // Transactional reads are retried via the transaction runner.
+        if (
+          this.transactionId ||
+          isPermanentRpcError(err, 'batchGetDocuments')
+        ) {
+          logger(
+            'DocumentReader.fetchAllDocuments',
+            requestTag,
+            'BatchGetDocuments failed with non-retryable stream error:',
+            err
+          );
+          throw err;
+        } else {
+          logger(
+            'DocumentReader.fetchAllDocuments',
+            requestTag,
+            'BatchGetDocuments failed with retryable stream error:',
+            err
+          );
+        }
+      }
+    }
+  }
+
+  private fetchMoreDocuments(requestTag: string): Promise<void> {
+    const request: api.IBatchGetDocumentsRequest = {
+      database: this.firestore.formattedName,
+      transaction: this.transactionId,
+      documents: Array.from(this.remainingDocuments),
+    };
+
+    if (this.fieldMask) {
+      const fieldPaths = this.fieldMask.map(
+        fieldPath => (fieldPath as FieldPath).formattedName
+      );
+      request.mask = {fieldPaths};
+    }
+
+    let resultCount = 0;
+
+    return this.firestore
+      .requestStream('batchGetDocuments', request, requestTag)
+      .then(stream => {
+        return new Promise<void>((resolve, reject) => {
+          stream
+            .on('error', err => reject(err))
+            .on('data', (response: api.IBatchGetDocumentsResponse) => {
+              try {
+                let document;
+
+                if (response.found) {
+                  logger(
+                    'DocumentReader.fetchMoreDocuments',
+                    requestTag,
+                    'Received document: %s',
+                    response.found.name!
+                  );
+                  document = this.firestore.snapshot_(
+                    response.found,
+                    response.readTime!
+                  );
+                } else {
+                  logger(
+                    'DocumentReader.fetchMoreDocuments',
+                    requestTag,
+                    'Document missing: %s',
+                    response.missing!
+                  );
+                  document = this.firestore.snapshot_(
+                    response.missing!,
+                    response.readTime!
+                  );
+                }
+
+                const path = document.ref.formattedName;
+                this.remainingDocuments.delete(path);
+                this.retrievedDocuments.set(path, document);
+                ++resultCount;
+              } catch (err) {
+                reject(err);
+              }
+            })
+            .on('end', () => {
+              logger(
+                'DocumentReader.fetchMoreDocuments',
+                requestTag,
+                'Received %d results',
+                resultCount
+              );
+              resolve();
+            });
+          stream.resume();
+        });
+      });
+  }
+}

--- a/dev/src/document-reader.ts
+++ b/dev/src/document-reader.ts
@@ -40,12 +40,11 @@ export class DocumentReader<T> {
   private retrievedDocuments = new Map<string, DocumentSnapshot>();
 
   /**
-   * Internal method to retrieve multiple documents from Firestore, optionally
-   * as part of a transaction.
+   * Creates a new DocumentReader that fetches the provided documents (via
+   * `get()`).
    *
    * @param firestore The Firestore instance to use.
    * @param allDocuments The documents to get.
-   * @returns A Promise that contains an array with the resulting documents.
    */
   constructor(
     private firestore: Firestore,

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -38,7 +38,7 @@ import {
   validateMinNumberOfArguments,
   validateOptional,
 } from './validate';
-
+import {DocumentReader} from './document-reader';
 import api = proto.google.firestore.v1;
 
 /*!
@@ -125,16 +125,9 @@ export class Transaction implements firestore.Transaction {
     }
 
     if (refOrQuery instanceof DocumentReference) {
-      return this._firestore
-        .getAll_(
-          [refOrQuery],
-          /* fieldMask= */ null,
-          this._requestTag,
-          this._transactionId
-        )
-        .then(res => {
-          return Promise.resolve(res[0]);
-        });
+      const documentReader = new DocumentReader(this._firestore, [refOrQuery]);
+      documentReader.transactionId = this._transactionId;
+      return documentReader.get(this._requestTag).then(([res]) => res);
     }
 
     if (refOrQuery instanceof Query) {
@@ -191,12 +184,10 @@ export class Transaction implements firestore.Transaction {
       documentRefsOrReadOptions
     );
 
-    return this._firestore.getAll_(
-      documents,
-      fieldMask,
-      this._requestTag,
-      this._transactionId
-    );
+    const documentReader = new DocumentReader(this._firestore, documents);
+    documentReader.fieldMask = fieldMask || undefined;
+    documentReader.transactionId = this._transactionId;
+    return documentReader.get(this._requestTag);
   }
 
   /**

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -1104,29 +1104,6 @@ describe('getAll() method', () => {
     });
   });
 
-  it('handles serialization error', () => {
-    const overrides: ApiOverride = {
-      batchGetDocuments: () => {
-        return stream(found('documentId'));
-      },
-    };
-
-    return createInstance(overrides).then(firestore => {
-      firestore['snapshot_'] = () => {
-        throw new Error('Expected exception');
-      };
-
-      return firestore
-        .getAll(firestore.doc('collectionId/documentId'))
-        .then(() => {
-          throw new Error('Unexpected success in Promise');
-        })
-        .catch(err => {
-          expect(err.message).to.equal('Expected exception');
-        });
-    });
-  });
-
   it('retries based on error code', () => {
     const expectedErrorAttempts: {[key: number]: number} = {
       [Status.CANCELLED]: 1,

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -1024,31 +1024,6 @@ describe('getAll() method', () => {
     });
   });
 
-  it('handles stream exception after initialization', () => {
-    let attempts = 0;
-
-    const overrides: ApiOverride = {
-      batchGetDocuments: () => {
-        ++attempts;
-        return stream(found('documentId'), new Error('Expected exception'));
-      },
-    };
-
-    return createInstance(overrides).then(firestore => {
-      return firestore
-        .getAll(firestore.doc('collectionId/documentId'))
-        .then(() => {
-          throw new Error('Unexpected success in Promise');
-        })
-        .catch(err => {
-          // We don't retry since the stream might have already been released
-          // to the end user.
-          expect(attempts).to.equal(1);
-          expect(err.message).to.equal('Expected exception');
-        });
-    });
-  });
-
   it('handles stream exception (before first result)', () => {
     let attempts = 0;
 


### PR DESCRIPTION
This PR moves the existing logic for Firestore.getAll() to a new class and adds a new retry mechanism that is similar to the current Query RPC retry.

Fixes https://github.com/googleapis/nodejs-firestore/issues/1387