### PR TITLE
feat: add support for optimistic transactions

### DIFF
--- a/dev/protos/firestore_v1_proto_api.d.ts
+++ b/dev/protos/firestore_v1_proto_api.d.ts
@@ -5727,6 +5727,9 @@ export namespace google {
                 /** Write delete */
                 "delete"?: (string|null);
 
+                /** Write verify */
+                verify?: (string|null);
+
                 /** Write transform */
                 transform?: (google.firestore.v1.IDocumentTransform|null);
 
@@ -5755,6 +5758,9 @@ export namespace google {
                 /** Write delete. */
                 public delete?: (string|null);
 
+                /** Write verify. */
+                public verify?: (string|null);
+
                 /** Write transform. */
                 public transform?: (google.firestore.v1.IDocumentTransform|null);
 
@@ -5768,7 +5774,7 @@ export namespace google {
                 public currentDocument?: (google.firestore.v1.IPrecondition|null);
 
                 /** Write operation. */
-                public operation?: ("update"|"delete"|"transform");
+                public operation?: ("update"|"delete"|"verify"|"transform");
 
                 /**
                  * Creates a Write message from a plain object. Also converts values to their respective internal types.

--- a/dev/protos/firestore_v1_proto_api.js
+++ b/dev/protos/firestore_v1_proto_api.js
@@ -28,21 +28,21 @@
 
     // Common aliases
     var $util = $protobuf.util;
-    
+
     // Exported root namespace
     var $root = $protobuf.roots.firestore_v1 || ($protobuf.roots.firestore_v1 = {});
-    
+
     $root.firestore = (function() {
-    
+
         /**
          * Namespace firestore.
          * @exports firestore
          * @namespace
          */
         var firestore = {};
-    
+
         firestore.BundledQuery = (function() {
-    
+
             /**
              * Properties of a BundledQuery.
              * @memberof firestore
@@ -51,7 +51,7 @@
              * @property {google.firestore.v1.IStructuredQuery|null} [structuredQuery] BundledQuery structuredQuery
              * @property {firestore.BundledQuery.LimitType|null} [limitType] BundledQuery limitType
              */
-    
+
             /**
              * Constructs a new BundledQuery.
              * @memberof firestore
@@ -66,7 +66,7 @@
                         if (properties[keys[i]] != null)
                             this[keys[i]] = properties[keys[i]];
             }
-    
+
             /**
              * BundledQuery parent.
              * @member {string} parent
@@ -74,7 +74,7 @@
              * @instance
              */
             BundledQuery.prototype.parent = "";
-    
+
             /**
              * BundledQuery structuredQuery.
              * @member {google.firestore.v1.IStructuredQuery|null|undefined} structuredQuery
@@ -82,7 +82,7 @@
              * @instance
              */
             BundledQuery.prototype.structuredQuery = null;
-    
+
             /**
              * BundledQuery limitType.
              * @member {firestore.BundledQuery.LimitType} limitType
@@ -90,10 +90,10 @@
              * @instance
              */
             BundledQuery.prototype.limitType = 0;
-    
+
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
-    
+
             /**
              * BundledQuery queryType.
              * @member {"structuredQuery"|undefined} queryType
@@ -104,7 +104,7 @@
                 get: $util.oneOfGetter($oneOfFields = ["structuredQuery"]),
                 set: $util.oneOfSetter($oneOfFields)
             });
-    
+
             /**
              * Creates a BundledQuery message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
@@ -136,7 +136,7 @@
                 }
                 return message;
             };
-    
+
             /**
              * Creates a plain object from a BundledQuery message. Also converts values to other types if specified.
              * @function toObject
@@ -165,7 +165,7 @@
                     object.limitType = options.enums === String ? $root.firestore.BundledQuery.LimitType[message.limitType] : message.limitType;
                 return object;
             };
-    
+
             /**
              * Converts this BundledQuery to JSON.
              * @function toJSON
@@ -176,7 +176,7 @@
             BundledQuery.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
-    
+
             /**
              * LimitType enum.
              * @name firestore.BundledQuery.LimitType
@@ -190,12 +190,12 @@
                 values[valuesById[1] = "LAST"] = "LAST";
                 return values;
             })();
-    
+
             return BundledQuery;
         })();
-    
+
         firestore.NamedQuery = (function() {
-    
+
             /**
              * Properties of a NamedQuery.
              * @memberof firestore
@@ -204,7 +204,7 @@
              * @property {firestore.IBundledQuery|null} [bundledQuery] NamedQuery bundledQuery
              * @property {google.protobuf.ITimestamp|null} [readTime] NamedQuery readTime
              */
-    
+
             /**
              * Constructs a new NamedQuery.
              * @memberof firestore
@@ -219,7 +219,7 @@
                         if (properties[keys[i]] != null)
                             this[keys[i]] = properties[keys[i]];
             }
-    
+
             /**
              * NamedQuery name.
              * @member {string} name
@@ -227,7 +227,7 @@
              * @instance
              */
             NamedQuery.prototype.name = "";
-    
+
             /**
              * NamedQuery bundledQuery.
              * @member {firestore.IBundledQuery|null|undefined} bundledQuery
@@ -235,7 +235,7 @@
              * @instance
              */
             NamedQuery.prototype.bundledQuery = null;
-    
+
             /**
              * NamedQuery readTime.
              * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -243,7 +243,7 @@
              * @instance
              */
             NamedQuery.prototype.readTime = null;
-    
+
             /**
              * Creates a NamedQuery message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
@@ -270,7 +270,7 @@
                 }
                 return message;
             };
-    
+
             /**
              * Creates a plain object from a NamedQuery message. Also converts values to other types if specified.
              * @function toObject
@@ -297,7 +297,7 @@
                     object.readTime = $root.google.protobuf.Timestamp.toObject(message.readTime, options);
                 return object;
             };
-    
+
             /**
              * Converts this NamedQuery to JSON.
              * @function toJSON
@@ -308,12 +308,12 @@
             NamedQuery.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
-    
+
             return NamedQuery;
         })();
-    
+
         firestore.BundledDocumentMetadata = (function() {
-    
+
             /**
              * Properties of a BundledDocumentMetadata.
              * @memberof firestore
@@ -323,7 +323,7 @@
              * @property {boolean|null} [exists] BundledDocumentMetadata exists
              * @property {Array.<string>|null} [queries] BundledDocumentMetadata queries
              */
-    
+
             /**
              * Constructs a new BundledDocumentMetadata.
              * @memberof firestore
@@ -339,7 +339,7 @@
                         if (properties[keys[i]] != null)
                             this[keys[i]] = properties[keys[i]];
             }
-    
+
             /**
              * BundledDocumentMetadata name.
              * @member {string} name
@@ -347,7 +347,7 @@
              * @instance
              */
             BundledDocumentMetadata.prototype.name = "";
-    
+
             /**
              * BundledDocumentMetadata readTime.
              * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -355,7 +355,7 @@
              * @instance
              */
             BundledDocumentMetadata.prototype.readTime = null;
-    
+
             /**
              * BundledDocumentMetadata exists.
              * @member {boolean} exists
@@ -363,7 +363,7 @@
              * @instance
              */
             BundledDocumentMetadata.prototype.exists = false;
-    
+
             /**
              * BundledDocumentMetadata queries.
              * @member {Array.<string>} queries
@@ -371,7 +371,7 @@
              * @instance
              */
             BundledDocumentMetadata.prototype.queries = $util.emptyArray;
-    
+
             /**
              * Creates a BundledDocumentMetadata message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
@@ -402,7 +402,7 @@
                 }
                 return message;
             };
-    
+
             /**
              * Creates a plain object from a BundledDocumentMetadata message. Also converts values to other types if specified.
              * @function toObject
@@ -436,7 +436,7 @@
                 }
                 return object;
             };
-    
+
             /**
              * Converts this BundledDocumentMetadata to JSON.
              * @function toJSON
@@ -447,12 +447,12 @@
             BundledDocumentMetadata.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
-    
+
             return BundledDocumentMetadata;
         })();
-    
+
         firestore.BundleMetadata = (function() {
-    
+
             /**
              * Properties of a BundleMetadata.
              * @memberof firestore
@@ -463,7 +463,7 @@
              * @property {number|null} [totalDocuments] BundleMetadata totalDocuments
              * @property {number|string|null} [totalBytes] BundleMetadata totalBytes
              */
-    
+
             /**
              * Constructs a new BundleMetadata.
              * @memberof firestore
@@ -478,7 +478,7 @@
                         if (properties[keys[i]] != null)
                             this[keys[i]] = properties[keys[i]];
             }
-    
+
             /**
              * BundleMetadata id.
              * @member {string} id
@@ -486,7 +486,7 @@
              * @instance
              */
             BundleMetadata.prototype.id = "";
-    
+
             /**
              * BundleMetadata createTime.
              * @member {google.protobuf.ITimestamp|null|undefined} createTime
@@ -494,7 +494,7 @@
              * @instance
              */
             BundleMetadata.prototype.createTime = null;
-    
+
             /**
              * BundleMetadata version.
              * @member {number} version
@@ -502,7 +502,7 @@
              * @instance
              */
             BundleMetadata.prototype.version = 0;
-    
+
             /**
              * BundleMetadata totalDocuments.
              * @member {number} totalDocuments
@@ -510,7 +510,7 @@
              * @instance
              */
             BundleMetadata.prototype.totalDocuments = 0;
-    
+
             /**
              * BundleMetadata totalBytes.
              * @member {number|string} totalBytes
@@ -518,7 +518,7 @@
              * @instance
              */
             BundleMetadata.prototype.totalBytes = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
-    
+
             /**
              * Creates a BundleMetadata message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
@@ -553,7 +553,7 @@
                         message.totalBytes = new $util.LongBits(object.totalBytes.low >>> 0, object.totalBytes.high >>> 0).toNumber(true);
                 return message;
             };
-    
+
             /**
              * Creates a plain object from a BundleMetadata message. Also converts values to other types if specified.
              * @function toObject
@@ -593,7 +593,7 @@
                         object.totalBytes = options.longs === String ? $util.Long.prototype.toString.call(message.totalBytes) : options.longs === Number ? new $util.LongBits(message.totalBytes.low >>> 0, message.totalBytes.high >>> 0).toNumber(true) : message.totalBytes;
                 return object;
             };
-    
+
             /**
              * Converts this BundleMetadata to JSON.
              * @function toJSON
@@ -604,12 +604,12 @@
             BundleMetadata.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
-    
+
             return BundleMetadata;
         })();
-    
+
         firestore.BundleElement = (function() {
-    
+
             /**
              * Properties of a BundleElement.
              * @memberof firestore
@@ -619,7 +619,7 @@
              * @property {firestore.IBundledDocumentMetadata|null} [documentMetadata] BundleElement documentMetadata
              * @property {google.firestore.v1.IDocument|null} [document] BundleElement document
              */
-    
+
             /**
              * Constructs a new BundleElement.
              * @memberof firestore
@@ -634,7 +634,7 @@
                         if (properties[keys[i]] != null)
                             this[keys[i]] = properties[keys[i]];
             }
-    
+
             /**
              * BundleElement metadata.
              * @member {firestore.IBundleMetadata|null|undefined} metadata
@@ -642,7 +642,7 @@
              * @instance
              */
             BundleElement.prototype.metadata = null;
-    
+
             /**
              * BundleElement namedQuery.
              * @member {firestore.INamedQuery|null|undefined} namedQuery
@@ -650,7 +650,7 @@
              * @instance
              */
             BundleElement.prototype.namedQuery = null;
-    
+
             /**
              * BundleElement documentMetadata.
              * @member {firestore.IBundledDocumentMetadata|null|undefined} documentMetadata
@@ -658,7 +658,7 @@
              * @instance
              */
             BundleElement.prototype.documentMetadata = null;
-    
+
             /**
              * BundleElement document.
              * @member {google.firestore.v1.IDocument|null|undefined} document
@@ -666,10 +666,10 @@
              * @instance
              */
             BundleElement.prototype.document = null;
-    
+
             // OneOf field names bound to virtual getters and setters
             var $oneOfFields;
-    
+
             /**
              * BundleElement elementType.
              * @member {"metadata"|"namedQuery"|"documentMetadata"|"document"|undefined} elementType
@@ -680,7 +680,7 @@
                 get: $util.oneOfGetter($oneOfFields = ["metadata", "namedQuery", "documentMetadata", "document"]),
                 set: $util.oneOfSetter($oneOfFields)
             });
-    
+
             /**
              * Creates a BundleElement message from a plain object. Also converts values to their respective internal types.
              * @function fromObject
@@ -715,7 +715,7 @@
                 }
                 return message;
             };
-    
+
             /**
              * Creates a plain object from a BundleElement message. Also converts values to other types if specified.
              * @function toObject
@@ -751,7 +751,7 @@
                 }
                 return object;
             };
-    
+
             /**
              * Converts this BundleElement to JSON.
              * @function toJSON
@@ -762,33 +762,33 @@
             BundleElement.prototype.toJSON = function toJSON() {
                 return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
             };
-    
+
             return BundleElement;
         })();
-    
+
         return firestore;
     })();
-    
+
     $root.google = (function() {
-    
+
         /**
          * Namespace google.
          * @exports google
          * @namespace
          */
         var google = {};
-    
+
         google.protobuf = (function() {
-    
+
             /**
              * Namespace protobuf.
              * @memberof google
              * @namespace
              */
             var protobuf = {};
-    
+
             protobuf.Timestamp = (function() {
-    
+
                 /**
                  * Properties of a Timestamp.
                  * @memberof google.protobuf
@@ -796,7 +796,7 @@
                  * @property {number|string|null} [seconds] Timestamp seconds
                  * @property {number|null} [nanos] Timestamp nanos
                  */
-    
+
                 /**
                  * Constructs a new Timestamp.
                  * @memberof google.protobuf
@@ -811,7 +811,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Timestamp seconds.
                  * @member {number|string} seconds
@@ -819,7 +819,7 @@
                  * @instance
                  */
                 Timestamp.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-    
+
                 /**
                  * Timestamp nanos.
                  * @member {number} nanos
@@ -827,7 +827,7 @@
                  * @instance
                  */
                 Timestamp.prototype.nanos = 0;
-    
+
                 /**
                  * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -853,7 +853,7 @@
                         message.nanos = object.nanos | 0;
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
                  * @function toObject
@@ -884,7 +884,7 @@
                         object.nanos = message.nanos;
                     return object;
                 };
-    
+
                 /**
                  * Converts this Timestamp to JSON.
                  * @function toJSON
@@ -895,19 +895,19 @@
                 Timestamp.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Timestamp;
             })();
-    
+
             protobuf.FileDescriptorSet = (function() {
-    
+
                 /**
                  * Properties of a FileDescriptorSet.
                  * @memberof google.protobuf
                  * @interface IFileDescriptorSet
                  * @property {Array.<google.protobuf.IFileDescriptorProto>|null} [file] FileDescriptorSet file
                  */
-    
+
                 /**
                  * Constructs a new FileDescriptorSet.
                  * @memberof google.protobuf
@@ -923,7 +923,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * FileDescriptorSet file.
                  * @member {Array.<google.protobuf.IFileDescriptorProto>} file
@@ -931,7 +931,7 @@
                  * @instance
                  */
                 FileDescriptorSet.prototype.file = $util.emptyArray;
-    
+
                 /**
                  * Creates a FileDescriptorSet message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -956,7 +956,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a FileDescriptorSet message. Also converts values to other types if specified.
                  * @function toObject
@@ -979,7 +979,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this FileDescriptorSet to JSON.
                  * @function toJSON
@@ -990,12 +990,12 @@
                 FileDescriptorSet.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return FileDescriptorSet;
             })();
-    
+
             protobuf.FileDescriptorProto = (function() {
-    
+
                 /**
                  * Properties of a FileDescriptorProto.
                  * @memberof google.protobuf
@@ -1013,7 +1013,7 @@
                  * @property {google.protobuf.ISourceCodeInfo|null} [sourceCodeInfo] FileDescriptorProto sourceCodeInfo
                  * @property {string|null} [syntax] FileDescriptorProto syntax
                  */
-    
+
                 /**
                  * Constructs a new FileDescriptorProto.
                  * @memberof google.protobuf
@@ -1035,7 +1035,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * FileDescriptorProto name.
                  * @member {string} name
@@ -1043,7 +1043,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.name = "";
-    
+
                 /**
                  * FileDescriptorProto package.
                  * @member {string} package
@@ -1051,7 +1051,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype["package"] = "";
-    
+
                 /**
                  * FileDescriptorProto dependency.
                  * @member {Array.<string>} dependency
@@ -1059,7 +1059,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.dependency = $util.emptyArray;
-    
+
                 /**
                  * FileDescriptorProto publicDependency.
                  * @member {Array.<number>} publicDependency
@@ -1067,7 +1067,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.publicDependency = $util.emptyArray;
-    
+
                 /**
                  * FileDescriptorProto weakDependency.
                  * @member {Array.<number>} weakDependency
@@ -1075,7 +1075,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.weakDependency = $util.emptyArray;
-    
+
                 /**
                  * FileDescriptorProto messageType.
                  * @member {Array.<google.protobuf.IDescriptorProto>} messageType
@@ -1083,7 +1083,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.messageType = $util.emptyArray;
-    
+
                 /**
                  * FileDescriptorProto enumType.
                  * @member {Array.<google.protobuf.IEnumDescriptorProto>} enumType
@@ -1091,7 +1091,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.enumType = $util.emptyArray;
-    
+
                 /**
                  * FileDescriptorProto service.
                  * @member {Array.<google.protobuf.IServiceDescriptorProto>} service
@@ -1099,7 +1099,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.service = $util.emptyArray;
-    
+
                 /**
                  * FileDescriptorProto extension.
                  * @member {Array.<google.protobuf.IFieldDescriptorProto>} extension
@@ -1107,7 +1107,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.extension = $util.emptyArray;
-    
+
                 /**
                  * FileDescriptorProto options.
                  * @member {google.protobuf.IFileOptions|null|undefined} options
@@ -1115,7 +1115,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.options = null;
-    
+
                 /**
                  * FileDescriptorProto sourceCodeInfo.
                  * @member {google.protobuf.ISourceCodeInfo|null|undefined} sourceCodeInfo
@@ -1123,7 +1123,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.sourceCodeInfo = null;
-    
+
                 /**
                  * FileDescriptorProto syntax.
                  * @member {string} syntax
@@ -1131,7 +1131,7 @@
                  * @instance
                  */
                 FileDescriptorProto.prototype.syntax = "";
-    
+
                 /**
                  * Creates a FileDescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -1223,7 +1223,7 @@
                         message.syntax = String(object.syntax);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a FileDescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -1300,7 +1300,7 @@
                         object.syntax = message.syntax;
                     return object;
                 };
-    
+
                 /**
                  * Converts this FileDescriptorProto to JSON.
                  * @function toJSON
@@ -1311,12 +1311,12 @@
                 FileDescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return FileDescriptorProto;
             })();
-    
+
             protobuf.DescriptorProto = (function() {
-    
+
                 /**
                  * Properties of a DescriptorProto.
                  * @memberof google.protobuf
@@ -1332,7 +1332,7 @@
                  * @property {Array.<google.protobuf.DescriptorProto.IReservedRange>|null} [reservedRange] DescriptorProto reservedRange
                  * @property {Array.<string>|null} [reservedName] DescriptorProto reservedName
                  */
-    
+
                 /**
                  * Constructs a new DescriptorProto.
                  * @memberof google.protobuf
@@ -1355,7 +1355,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * DescriptorProto name.
                  * @member {string} name
@@ -1363,7 +1363,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.name = "";
-    
+
                 /**
                  * DescriptorProto field.
                  * @member {Array.<google.protobuf.IFieldDescriptorProto>} field
@@ -1371,7 +1371,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.field = $util.emptyArray;
-    
+
                 /**
                  * DescriptorProto extension.
                  * @member {Array.<google.protobuf.IFieldDescriptorProto>} extension
@@ -1379,7 +1379,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.extension = $util.emptyArray;
-    
+
                 /**
                  * DescriptorProto nestedType.
                  * @member {Array.<google.protobuf.IDescriptorProto>} nestedType
@@ -1387,7 +1387,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.nestedType = $util.emptyArray;
-    
+
                 /**
                  * DescriptorProto enumType.
                  * @member {Array.<google.protobuf.IEnumDescriptorProto>} enumType
@@ -1395,7 +1395,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.enumType = $util.emptyArray;
-    
+
                 /**
                  * DescriptorProto extensionRange.
                  * @member {Array.<google.protobuf.DescriptorProto.IExtensionRange>} extensionRange
@@ -1403,7 +1403,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.extensionRange = $util.emptyArray;
-    
+
                 /**
                  * DescriptorProto oneofDecl.
                  * @member {Array.<google.protobuf.IOneofDescriptorProto>} oneofDecl
@@ -1411,7 +1411,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.oneofDecl = $util.emptyArray;
-    
+
                 /**
                  * DescriptorProto options.
                  * @member {google.protobuf.IMessageOptions|null|undefined} options
@@ -1419,7 +1419,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.options = null;
-    
+
                 /**
                  * DescriptorProto reservedRange.
                  * @member {Array.<google.protobuf.DescriptorProto.IReservedRange>} reservedRange
@@ -1427,7 +1427,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.reservedRange = $util.emptyArray;
-    
+
                 /**
                  * DescriptorProto reservedName.
                  * @member {Array.<string>} reservedName
@@ -1435,7 +1435,7 @@
                  * @instance
                  */
                 DescriptorProto.prototype.reservedName = $util.emptyArray;
-    
+
                 /**
                  * Creates a DescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -1534,7 +1534,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a DescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -1608,7 +1608,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this DescriptorProto to JSON.
                  * @function toJSON
@@ -1619,9 +1619,9 @@
                 DescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 DescriptorProto.ExtensionRange = (function() {
-    
+
                     /**
                      * Properties of an ExtensionRange.
                      * @memberof google.protobuf.DescriptorProto
@@ -1629,7 +1629,7 @@
                      * @property {number|null} [start] ExtensionRange start
                      * @property {number|null} [end] ExtensionRange end
                      */
-    
+
                     /**
                      * Constructs a new ExtensionRange.
                      * @memberof google.protobuf.DescriptorProto
@@ -1644,7 +1644,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ExtensionRange start.
                      * @member {number} start
@@ -1652,7 +1652,7 @@
                      * @instance
                      */
                     ExtensionRange.prototype.start = 0;
-    
+
                     /**
                      * ExtensionRange end.
                      * @member {number} end
@@ -1660,7 +1660,7 @@
                      * @instance
                      */
                     ExtensionRange.prototype.end = 0;
-    
+
                     /**
                      * Creates an ExtensionRange message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -1679,7 +1679,7 @@
                             message.end = object.end | 0;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from an ExtensionRange message. Also converts values to other types if specified.
                      * @function toObject
@@ -1703,7 +1703,7 @@
                             object.end = message.end;
                         return object;
                     };
-    
+
                     /**
                      * Converts this ExtensionRange to JSON.
                      * @function toJSON
@@ -1714,12 +1714,12 @@
                     ExtensionRange.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ExtensionRange;
                 })();
-    
+
                 DescriptorProto.ReservedRange = (function() {
-    
+
                     /**
                      * Properties of a ReservedRange.
                      * @memberof google.protobuf.DescriptorProto
@@ -1727,7 +1727,7 @@
                      * @property {number|null} [start] ReservedRange start
                      * @property {number|null} [end] ReservedRange end
                      */
-    
+
                     /**
                      * Constructs a new ReservedRange.
                      * @memberof google.protobuf.DescriptorProto
@@ -1742,7 +1742,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ReservedRange start.
                      * @member {number} start
@@ -1750,7 +1750,7 @@
                      * @instance
                      */
                     ReservedRange.prototype.start = 0;
-    
+
                     /**
                      * ReservedRange end.
                      * @member {number} end
@@ -1758,7 +1758,7 @@
                      * @instance
                      */
                     ReservedRange.prototype.end = 0;
-    
+
                     /**
                      * Creates a ReservedRange message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -1777,7 +1777,7 @@
                             message.end = object.end | 0;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a ReservedRange message. Also converts values to other types if specified.
                      * @function toObject
@@ -1801,7 +1801,7 @@
                             object.end = message.end;
                         return object;
                     };
-    
+
                     /**
                      * Converts this ReservedRange to JSON.
                      * @function toJSON
@@ -1812,15 +1812,15 @@
                     ReservedRange.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ReservedRange;
                 })();
-    
+
                 return DescriptorProto;
             })();
-    
+
             protobuf.FieldDescriptorProto = (function() {
-    
+
                 /**
                  * Properties of a FieldDescriptorProto.
                  * @memberof google.protobuf
@@ -1836,7 +1836,7 @@
                  * @property {string|null} [jsonName] FieldDescriptorProto jsonName
                  * @property {google.protobuf.IFieldOptions|null} [options] FieldDescriptorProto options
                  */
-    
+
                 /**
                  * Constructs a new FieldDescriptorProto.
                  * @memberof google.protobuf
@@ -1851,7 +1851,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * FieldDescriptorProto name.
                  * @member {string} name
@@ -1859,7 +1859,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.name = "";
-    
+
                 /**
                  * FieldDescriptorProto number.
                  * @member {number} number
@@ -1867,7 +1867,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.number = 0;
-    
+
                 /**
                  * FieldDescriptorProto label.
                  * @member {google.protobuf.FieldDescriptorProto.Label} label
@@ -1875,7 +1875,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.label = 1;
-    
+
                 /**
                  * FieldDescriptorProto type.
                  * @member {google.protobuf.FieldDescriptorProto.Type} type
@@ -1883,7 +1883,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.type = 1;
-    
+
                 /**
                  * FieldDescriptorProto typeName.
                  * @member {string} typeName
@@ -1891,7 +1891,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.typeName = "";
-    
+
                 /**
                  * FieldDescriptorProto extendee.
                  * @member {string} extendee
@@ -1899,7 +1899,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.extendee = "";
-    
+
                 /**
                  * FieldDescriptorProto defaultValue.
                  * @member {string} defaultValue
@@ -1907,7 +1907,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.defaultValue = "";
-    
+
                 /**
                  * FieldDescriptorProto oneofIndex.
                  * @member {number} oneofIndex
@@ -1915,7 +1915,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.oneofIndex = 0;
-    
+
                 /**
                  * FieldDescriptorProto jsonName.
                  * @member {string} jsonName
@@ -1923,7 +1923,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.jsonName = "";
-    
+
                 /**
                  * FieldDescriptorProto options.
                  * @member {google.protobuf.IFieldOptions|null|undefined} options
@@ -1931,7 +1931,7 @@
                  * @instance
                  */
                 FieldDescriptorProto.prototype.options = null;
-    
+
                 /**
                  * Creates a FieldDescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -2053,7 +2053,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a FieldDescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -2101,7 +2101,7 @@
                         object.jsonName = message.jsonName;
                     return object;
                 };
-    
+
                 /**
                  * Converts this FieldDescriptorProto to JSON.
                  * @function toJSON
@@ -2112,7 +2112,7 @@
                 FieldDescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 /**
                  * Type enum.
                  * @name google.protobuf.FieldDescriptorProto.Type
@@ -2158,7 +2158,7 @@
                     values[valuesById[18] = "TYPE_SINT64"] = "TYPE_SINT64";
                     return values;
                 })();
-    
+
                 /**
                  * Label enum.
                  * @name google.protobuf.FieldDescriptorProto.Label
@@ -2174,12 +2174,12 @@
                     values[valuesById[3] = "LABEL_REPEATED"] = "LABEL_REPEATED";
                     return values;
                 })();
-    
+
                 return FieldDescriptorProto;
             })();
-    
+
             protobuf.OneofDescriptorProto = (function() {
-    
+
                 /**
                  * Properties of an OneofDescriptorProto.
                  * @memberof google.protobuf
@@ -2187,7 +2187,7 @@
                  * @property {string|null} [name] OneofDescriptorProto name
                  * @property {google.protobuf.IOneofOptions|null} [options] OneofDescriptorProto options
                  */
-    
+
                 /**
                  * Constructs a new OneofDescriptorProto.
                  * @memberof google.protobuf
@@ -2202,7 +2202,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * OneofDescriptorProto name.
                  * @member {string} name
@@ -2210,7 +2210,7 @@
                  * @instance
                  */
                 OneofDescriptorProto.prototype.name = "";
-    
+
                 /**
                  * OneofDescriptorProto options.
                  * @member {google.protobuf.IOneofOptions|null|undefined} options
@@ -2218,7 +2218,7 @@
                  * @instance
                  */
                 OneofDescriptorProto.prototype.options = null;
-    
+
                 /**
                  * Creates an OneofDescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -2240,7 +2240,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an OneofDescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -2264,7 +2264,7 @@
                         object.options = $root.google.protobuf.OneofOptions.toObject(message.options, options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this OneofDescriptorProto to JSON.
                  * @function toJSON
@@ -2275,12 +2275,12 @@
                 OneofDescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return OneofDescriptorProto;
             })();
-    
+
             protobuf.EnumDescriptorProto = (function() {
-    
+
                 /**
                  * Properties of an EnumDescriptorProto.
                  * @memberof google.protobuf
@@ -2289,7 +2289,7 @@
                  * @property {Array.<google.protobuf.IEnumValueDescriptorProto>|null} [value] EnumDescriptorProto value
                  * @property {google.protobuf.IEnumOptions|null} [options] EnumDescriptorProto options
                  */
-    
+
                 /**
                  * Constructs a new EnumDescriptorProto.
                  * @memberof google.protobuf
@@ -2305,7 +2305,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * EnumDescriptorProto name.
                  * @member {string} name
@@ -2313,7 +2313,7 @@
                  * @instance
                  */
                 EnumDescriptorProto.prototype.name = "";
-    
+
                 /**
                  * EnumDescriptorProto value.
                  * @member {Array.<google.protobuf.IEnumValueDescriptorProto>} value
@@ -2321,7 +2321,7 @@
                  * @instance
                  */
                 EnumDescriptorProto.prototype.value = $util.emptyArray;
-    
+
                 /**
                  * EnumDescriptorProto options.
                  * @member {google.protobuf.IEnumOptions|null|undefined} options
@@ -2329,7 +2329,7 @@
                  * @instance
                  */
                 EnumDescriptorProto.prototype.options = null;
-    
+
                 /**
                  * Creates an EnumDescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -2361,7 +2361,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an EnumDescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -2392,7 +2392,7 @@
                         object.options = $root.google.protobuf.EnumOptions.toObject(message.options, options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this EnumDescriptorProto to JSON.
                  * @function toJSON
@@ -2403,12 +2403,12 @@
                 EnumDescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return EnumDescriptorProto;
             })();
-    
+
             protobuf.EnumValueDescriptorProto = (function() {
-    
+
                 /**
                  * Properties of an EnumValueDescriptorProto.
                  * @memberof google.protobuf
@@ -2417,7 +2417,7 @@
                  * @property {number|null} [number] EnumValueDescriptorProto number
                  * @property {google.protobuf.IEnumValueOptions|null} [options] EnumValueDescriptorProto options
                  */
-    
+
                 /**
                  * Constructs a new EnumValueDescriptorProto.
                  * @memberof google.protobuf
@@ -2432,7 +2432,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * EnumValueDescriptorProto name.
                  * @member {string} name
@@ -2440,7 +2440,7 @@
                  * @instance
                  */
                 EnumValueDescriptorProto.prototype.name = "";
-    
+
                 /**
                  * EnumValueDescriptorProto number.
                  * @member {number} number
@@ -2448,7 +2448,7 @@
                  * @instance
                  */
                 EnumValueDescriptorProto.prototype.number = 0;
-    
+
                 /**
                  * EnumValueDescriptorProto options.
                  * @member {google.protobuf.IEnumValueOptions|null|undefined} options
@@ -2456,7 +2456,7 @@
                  * @instance
                  */
                 EnumValueDescriptorProto.prototype.options = null;
-    
+
                 /**
                  * Creates an EnumValueDescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -2480,7 +2480,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an EnumValueDescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -2507,7 +2507,7 @@
                         object.options = $root.google.protobuf.EnumValueOptions.toObject(message.options, options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this EnumValueDescriptorProto to JSON.
                  * @function toJSON
@@ -2518,12 +2518,12 @@
                 EnumValueDescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return EnumValueDescriptorProto;
             })();
-    
+
             protobuf.ServiceDescriptorProto = (function() {
-    
+
                 /**
                  * Properties of a ServiceDescriptorProto.
                  * @memberof google.protobuf
@@ -2532,7 +2532,7 @@
                  * @property {Array.<google.protobuf.IMethodDescriptorProto>|null} [method] ServiceDescriptorProto method
                  * @property {google.protobuf.IServiceOptions|null} [options] ServiceDescriptorProto options
                  */
-    
+
                 /**
                  * Constructs a new ServiceDescriptorProto.
                  * @memberof google.protobuf
@@ -2548,7 +2548,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * ServiceDescriptorProto name.
                  * @member {string} name
@@ -2556,7 +2556,7 @@
                  * @instance
                  */
                 ServiceDescriptorProto.prototype.name = "";
-    
+
                 /**
                  * ServiceDescriptorProto method.
                  * @member {Array.<google.protobuf.IMethodDescriptorProto>} method
@@ -2564,7 +2564,7 @@
                  * @instance
                  */
                 ServiceDescriptorProto.prototype.method = $util.emptyArray;
-    
+
                 /**
                  * ServiceDescriptorProto options.
                  * @member {google.protobuf.IServiceOptions|null|undefined} options
@@ -2572,7 +2572,7 @@
                  * @instance
                  */
                 ServiceDescriptorProto.prototype.options = null;
-    
+
                 /**
                  * Creates a ServiceDescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -2604,7 +2604,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a ServiceDescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -2635,7 +2635,7 @@
                         object.options = $root.google.protobuf.ServiceOptions.toObject(message.options, options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this ServiceDescriptorProto to JSON.
                  * @function toJSON
@@ -2646,12 +2646,12 @@
                 ServiceDescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return ServiceDescriptorProto;
             })();
-    
+
             protobuf.MethodDescriptorProto = (function() {
-    
+
                 /**
                  * Properties of a MethodDescriptorProto.
                  * @memberof google.protobuf
@@ -2663,7 +2663,7 @@
                  * @property {boolean|null} [clientStreaming] MethodDescriptorProto clientStreaming
                  * @property {boolean|null} [serverStreaming] MethodDescriptorProto serverStreaming
                  */
-    
+
                 /**
                  * Constructs a new MethodDescriptorProto.
                  * @memberof google.protobuf
@@ -2678,7 +2678,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * MethodDescriptorProto name.
                  * @member {string} name
@@ -2686,7 +2686,7 @@
                  * @instance
                  */
                 MethodDescriptorProto.prototype.name = "";
-    
+
                 /**
                  * MethodDescriptorProto inputType.
                  * @member {string} inputType
@@ -2694,7 +2694,7 @@
                  * @instance
                  */
                 MethodDescriptorProto.prototype.inputType = "";
-    
+
                 /**
                  * MethodDescriptorProto outputType.
                  * @member {string} outputType
@@ -2702,7 +2702,7 @@
                  * @instance
                  */
                 MethodDescriptorProto.prototype.outputType = "";
-    
+
                 /**
                  * MethodDescriptorProto options.
                  * @member {google.protobuf.IMethodOptions|null|undefined} options
@@ -2710,7 +2710,7 @@
                  * @instance
                  */
                 MethodDescriptorProto.prototype.options = null;
-    
+
                 /**
                  * MethodDescriptorProto clientStreaming.
                  * @member {boolean} clientStreaming
@@ -2718,7 +2718,7 @@
                  * @instance
                  */
                 MethodDescriptorProto.prototype.clientStreaming = false;
-    
+
                 /**
                  * MethodDescriptorProto serverStreaming.
                  * @member {boolean} serverStreaming
@@ -2726,7 +2726,7 @@
                  * @instance
                  */
                 MethodDescriptorProto.prototype.serverStreaming = false;
-    
+
                 /**
                  * Creates a MethodDescriptorProto message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -2756,7 +2756,7 @@
                         message.serverStreaming = Boolean(object.serverStreaming);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a MethodDescriptorProto message. Also converts values to other types if specified.
                  * @function toObject
@@ -2792,7 +2792,7 @@
                         object.serverStreaming = message.serverStreaming;
                     return object;
                 };
-    
+
                 /**
                  * Converts this MethodDescriptorProto to JSON.
                  * @function toJSON
@@ -2803,12 +2803,12 @@
                 MethodDescriptorProto.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return MethodDescriptorProto;
             })();
-    
+
             protobuf.FileOptions = (function() {
-    
+
                 /**
                  * Properties of a FileOptions.
                  * @memberof google.protobuf
@@ -2830,7 +2830,7 @@
                  * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] FileOptions uninterpretedOption
                  * @property {Array.<google.api.IResourceDescriptor>|null} [".google.api.resourceDefinition"] FileOptions .google.api.resourceDefinition
                  */
-    
+
                 /**
                  * Constructs a new FileOptions.
                  * @memberof google.protobuf
@@ -2847,7 +2847,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * FileOptions javaPackage.
                  * @member {string} javaPackage
@@ -2855,7 +2855,7 @@
                  * @instance
                  */
                 FileOptions.prototype.javaPackage = "";
-    
+
                 /**
                  * FileOptions javaOuterClassname.
                  * @member {string} javaOuterClassname
@@ -2863,7 +2863,7 @@
                  * @instance
                  */
                 FileOptions.prototype.javaOuterClassname = "";
-    
+
                 /**
                  * FileOptions javaMultipleFiles.
                  * @member {boolean} javaMultipleFiles
@@ -2871,7 +2871,7 @@
                  * @instance
                  */
                 FileOptions.prototype.javaMultipleFiles = false;
-    
+
                 /**
                  * FileOptions javaGenerateEqualsAndHash.
                  * @member {boolean} javaGenerateEqualsAndHash
@@ -2879,7 +2879,7 @@
                  * @instance
                  */
                 FileOptions.prototype.javaGenerateEqualsAndHash = false;
-    
+
                 /**
                  * FileOptions javaStringCheckUtf8.
                  * @member {boolean} javaStringCheckUtf8
@@ -2887,7 +2887,7 @@
                  * @instance
                  */
                 FileOptions.prototype.javaStringCheckUtf8 = false;
-    
+
                 /**
                  * FileOptions optimizeFor.
                  * @member {google.protobuf.FileOptions.OptimizeMode} optimizeFor
@@ -2895,7 +2895,7 @@
                  * @instance
                  */
                 FileOptions.prototype.optimizeFor = 1;
-    
+
                 /**
                  * FileOptions goPackage.
                  * @member {string} goPackage
@@ -2903,7 +2903,7 @@
                  * @instance
                  */
                 FileOptions.prototype.goPackage = "";
-    
+
                 /**
                  * FileOptions ccGenericServices.
                  * @member {boolean} ccGenericServices
@@ -2911,7 +2911,7 @@
                  * @instance
                  */
                 FileOptions.prototype.ccGenericServices = false;
-    
+
                 /**
                  * FileOptions javaGenericServices.
                  * @member {boolean} javaGenericServices
@@ -2919,7 +2919,7 @@
                  * @instance
                  */
                 FileOptions.prototype.javaGenericServices = false;
-    
+
                 /**
                  * FileOptions pyGenericServices.
                  * @member {boolean} pyGenericServices
@@ -2927,7 +2927,7 @@
                  * @instance
                  */
                 FileOptions.prototype.pyGenericServices = false;
-    
+
                 /**
                  * FileOptions deprecated.
                  * @member {boolean} deprecated
@@ -2935,7 +2935,7 @@
                  * @instance
                  */
                 FileOptions.prototype.deprecated = false;
-    
+
                 /**
                  * FileOptions ccEnableArenas.
                  * @member {boolean} ccEnableArenas
@@ -2943,7 +2943,7 @@
                  * @instance
                  */
                 FileOptions.prototype.ccEnableArenas = false;
-    
+
                 /**
                  * FileOptions objcClassPrefix.
                  * @member {string} objcClassPrefix
@@ -2951,7 +2951,7 @@
                  * @instance
                  */
                 FileOptions.prototype.objcClassPrefix = "";
-    
+
                 /**
                  * FileOptions csharpNamespace.
                  * @member {string} csharpNamespace
@@ -2959,7 +2959,7 @@
                  * @instance
                  */
                 FileOptions.prototype.csharpNamespace = "";
-    
+
                 /**
                  * FileOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -2967,7 +2967,7 @@
                  * @instance
                  */
                 FileOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * FileOptions .google.api.resourceDefinition.
                  * @member {Array.<google.api.IResourceDescriptor>} .google.api.resourceDefinition
@@ -2975,7 +2975,7 @@
                  * @instance
                  */
                 FileOptions.prototype[".google.api.resourceDefinition"] = $util.emptyArray;
-    
+
                 /**
                  * Creates a FileOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -3050,7 +3050,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a FileOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -3124,7 +3124,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this FileOptions to JSON.
                  * @function toJSON
@@ -3135,7 +3135,7 @@
                 FileOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 /**
                  * OptimizeMode enum.
                  * @name google.protobuf.FileOptions.OptimizeMode
@@ -3151,12 +3151,12 @@
                     values[valuesById[3] = "LITE_RUNTIME"] = "LITE_RUNTIME";
                     return values;
                 })();
-    
+
                 return FileOptions;
             })();
-    
+
             protobuf.MessageOptions = (function() {
-    
+
                 /**
                  * Properties of a MessageOptions.
                  * @memberof google.protobuf
@@ -3168,7 +3168,7 @@
                  * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] MessageOptions uninterpretedOption
                  * @property {google.api.IResourceDescriptor|null} [".google.api.resource"] MessageOptions .google.api.resource
                  */
-    
+
                 /**
                  * Constructs a new MessageOptions.
                  * @memberof google.protobuf
@@ -3184,7 +3184,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * MessageOptions messageSetWireFormat.
                  * @member {boolean} messageSetWireFormat
@@ -3192,7 +3192,7 @@
                  * @instance
                  */
                 MessageOptions.prototype.messageSetWireFormat = false;
-    
+
                 /**
                  * MessageOptions noStandardDescriptorAccessor.
                  * @member {boolean} noStandardDescriptorAccessor
@@ -3200,7 +3200,7 @@
                  * @instance
                  */
                 MessageOptions.prototype.noStandardDescriptorAccessor = false;
-    
+
                 /**
                  * MessageOptions deprecated.
                  * @member {boolean} deprecated
@@ -3208,7 +3208,7 @@
                  * @instance
                  */
                 MessageOptions.prototype.deprecated = false;
-    
+
                 /**
                  * MessageOptions mapEntry.
                  * @member {boolean} mapEntry
@@ -3216,7 +3216,7 @@
                  * @instance
                  */
                 MessageOptions.prototype.mapEntry = false;
-    
+
                 /**
                  * MessageOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -3224,7 +3224,7 @@
                  * @instance
                  */
                 MessageOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * MessageOptions .google.api.resource.
                  * @member {google.api.IResourceDescriptor|null|undefined} .google.api.resource
@@ -3232,7 +3232,7 @@
                  * @instance
                  */
                 MessageOptions.prototype[".google.api.resource"] = null;
-    
+
                 /**
                  * Creates a MessageOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -3270,7 +3270,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a MessageOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -3310,7 +3310,7 @@
                         object[".google.api.resource"] = $root.google.api.ResourceDescriptor.toObject(message[".google.api.resource"], options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this MessageOptions to JSON.
                  * @function toJSON
@@ -3321,12 +3321,12 @@
                 MessageOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return MessageOptions;
             })();
-    
+
             protobuf.FieldOptions = (function() {
-    
+
                 /**
                  * Properties of a FieldOptions.
                  * @memberof google.protobuf
@@ -3341,7 +3341,7 @@
                  * @property {Array.<google.api.FieldBehavior>|null} [".google.api.fieldBehavior"] FieldOptions .google.api.fieldBehavior
                  * @property {google.api.IResourceReference|null} [".google.api.resourceReference"] FieldOptions .google.api.resourceReference
                  */
-    
+
                 /**
                  * Constructs a new FieldOptions.
                  * @memberof google.protobuf
@@ -3358,7 +3358,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * FieldOptions ctype.
                  * @member {google.protobuf.FieldOptions.CType} ctype
@@ -3366,7 +3366,7 @@
                  * @instance
                  */
                 FieldOptions.prototype.ctype = 0;
-    
+
                 /**
                  * FieldOptions packed.
                  * @member {boolean} packed
@@ -3374,7 +3374,7 @@
                  * @instance
                  */
                 FieldOptions.prototype.packed = false;
-    
+
                 /**
                  * FieldOptions jstype.
                  * @member {google.protobuf.FieldOptions.JSType} jstype
@@ -3382,7 +3382,7 @@
                  * @instance
                  */
                 FieldOptions.prototype.jstype = 0;
-    
+
                 /**
                  * FieldOptions lazy.
                  * @member {boolean} lazy
@@ -3390,7 +3390,7 @@
                  * @instance
                  */
                 FieldOptions.prototype.lazy = false;
-    
+
                 /**
                  * FieldOptions deprecated.
                  * @member {boolean} deprecated
@@ -3398,7 +3398,7 @@
                  * @instance
                  */
                 FieldOptions.prototype.deprecated = false;
-    
+
                 /**
                  * FieldOptions weak.
                  * @member {boolean} weak
@@ -3406,7 +3406,7 @@
                  * @instance
                  */
                 FieldOptions.prototype.weak = false;
-    
+
                 /**
                  * FieldOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -3414,7 +3414,7 @@
                  * @instance
                  */
                 FieldOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * FieldOptions .google.api.fieldBehavior.
                  * @member {Array.<google.api.FieldBehavior>} .google.api.fieldBehavior
@@ -3422,7 +3422,7 @@
                  * @instance
                  */
                 FieldOptions.prototype[".google.api.fieldBehavior"] = $util.emptyArray;
-    
+
                 /**
                  * FieldOptions .google.api.resourceReference.
                  * @member {google.api.IResourceReference|null|undefined} .google.api.resourceReference
@@ -3430,7 +3430,7 @@
                  * @instance
                  */
                 FieldOptions.prototype[".google.api.resourceReference"] = null;
-    
+
                 /**
                  * Creates a FieldOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -3533,7 +3533,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a FieldOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -3586,7 +3586,7 @@
                         object[".google.api.resourceReference"] = $root.google.api.ResourceReference.toObject(message[".google.api.resourceReference"], options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this FieldOptions to JSON.
                  * @function toJSON
@@ -3597,7 +3597,7 @@
                 FieldOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 /**
                  * CType enum.
                  * @name google.protobuf.FieldOptions.CType
@@ -3613,7 +3613,7 @@
                     values[valuesById[2] = "STRING_PIECE"] = "STRING_PIECE";
                     return values;
                 })();
-    
+
                 /**
                  * JSType enum.
                  * @name google.protobuf.FieldOptions.JSType
@@ -3629,19 +3629,19 @@
                     values[valuesById[2] = "JS_NUMBER"] = "JS_NUMBER";
                     return values;
                 })();
-    
+
                 return FieldOptions;
             })();
-    
+
             protobuf.OneofOptions = (function() {
-    
+
                 /**
                  * Properties of an OneofOptions.
                  * @memberof google.protobuf
                  * @interface IOneofOptions
                  * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] OneofOptions uninterpretedOption
                  */
-    
+
                 /**
                  * Constructs a new OneofOptions.
                  * @memberof google.protobuf
@@ -3657,7 +3657,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * OneofOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -3665,7 +3665,7 @@
                  * @instance
                  */
                 OneofOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * Creates an OneofOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -3690,7 +3690,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an OneofOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -3713,7 +3713,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this OneofOptions to JSON.
                  * @function toJSON
@@ -3724,12 +3724,12 @@
                 OneofOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return OneofOptions;
             })();
-    
+
             protobuf.EnumOptions = (function() {
-    
+
                 /**
                  * Properties of an EnumOptions.
                  * @memberof google.protobuf
@@ -3738,7 +3738,7 @@
                  * @property {boolean|null} [deprecated] EnumOptions deprecated
                  * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] EnumOptions uninterpretedOption
                  */
-    
+
                 /**
                  * Constructs a new EnumOptions.
                  * @memberof google.protobuf
@@ -3754,7 +3754,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * EnumOptions allowAlias.
                  * @member {boolean} allowAlias
@@ -3762,7 +3762,7 @@
                  * @instance
                  */
                 EnumOptions.prototype.allowAlias = false;
-    
+
                 /**
                  * EnumOptions deprecated.
                  * @member {boolean} deprecated
@@ -3770,7 +3770,7 @@
                  * @instance
                  */
                 EnumOptions.prototype.deprecated = false;
-    
+
                 /**
                  * EnumOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -3778,7 +3778,7 @@
                  * @instance
                  */
                 EnumOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * Creates an EnumOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -3807,7 +3807,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an EnumOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -3838,7 +3838,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this EnumOptions to JSON.
                  * @function toJSON
@@ -3849,12 +3849,12 @@
                 EnumOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return EnumOptions;
             })();
-    
+
             protobuf.EnumValueOptions = (function() {
-    
+
                 /**
                  * Properties of an EnumValueOptions.
                  * @memberof google.protobuf
@@ -3862,7 +3862,7 @@
                  * @property {boolean|null} [deprecated] EnumValueOptions deprecated
                  * @property {Array.<google.protobuf.IUninterpretedOption>|null} [uninterpretedOption] EnumValueOptions uninterpretedOption
                  */
-    
+
                 /**
                  * Constructs a new EnumValueOptions.
                  * @memberof google.protobuf
@@ -3878,7 +3878,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * EnumValueOptions deprecated.
                  * @member {boolean} deprecated
@@ -3886,7 +3886,7 @@
                  * @instance
                  */
                 EnumValueOptions.prototype.deprecated = false;
-    
+
                 /**
                  * EnumValueOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -3894,7 +3894,7 @@
                  * @instance
                  */
                 EnumValueOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * Creates an EnumValueOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -3921,7 +3921,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an EnumValueOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -3948,7 +3948,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this EnumValueOptions to JSON.
                  * @function toJSON
@@ -3959,12 +3959,12 @@
                 EnumValueOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return EnumValueOptions;
             })();
-    
+
             protobuf.ServiceOptions = (function() {
-    
+
                 /**
                  * Properties of a ServiceOptions.
                  * @memberof google.protobuf
@@ -3974,7 +3974,7 @@
                  * @property {string|null} [".google.api.defaultHost"] ServiceOptions .google.api.defaultHost
                  * @property {string|null} [".google.api.oauthScopes"] ServiceOptions .google.api.oauthScopes
                  */
-    
+
                 /**
                  * Constructs a new ServiceOptions.
                  * @memberof google.protobuf
@@ -3990,7 +3990,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * ServiceOptions deprecated.
                  * @member {boolean} deprecated
@@ -3998,7 +3998,7 @@
                  * @instance
                  */
                 ServiceOptions.prototype.deprecated = false;
-    
+
                 /**
                  * ServiceOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -4006,7 +4006,7 @@
                  * @instance
                  */
                 ServiceOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * ServiceOptions .google.api.defaultHost.
                  * @member {string} .google.api.defaultHost
@@ -4014,7 +4014,7 @@
                  * @instance
                  */
                 ServiceOptions.prototype[".google.api.defaultHost"] = "";
-    
+
                 /**
                  * ServiceOptions .google.api.oauthScopes.
                  * @member {string} .google.api.oauthScopes
@@ -4022,7 +4022,7 @@
                  * @instance
                  */
                 ServiceOptions.prototype[".google.api.oauthScopes"] = "";
-    
+
                 /**
                  * Creates a ServiceOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -4053,7 +4053,7 @@
                         message[".google.api.oauthScopes"] = String(object[".google.api.oauthScopes"]);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a ServiceOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -4087,7 +4087,7 @@
                         object[".google.api.oauthScopes"] = message[".google.api.oauthScopes"];
                     return object;
                 };
-    
+
                 /**
                  * Converts this ServiceOptions to JSON.
                  * @function toJSON
@@ -4098,12 +4098,12 @@
                 ServiceOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return ServiceOptions;
             })();
-    
+
             protobuf.MethodOptions = (function() {
-    
+
                 /**
                  * Properties of a MethodOptions.
                  * @memberof google.protobuf
@@ -4114,7 +4114,7 @@
                  * @property {Array.<string>|null} [".google.api.methodSignature"] MethodOptions .google.api.methodSignature
                  * @property {google.longrunning.IOperationInfo|null} [".google.longrunning.operationInfo"] MethodOptions .google.longrunning.operationInfo
                  */
-    
+
                 /**
                  * Constructs a new MethodOptions.
                  * @memberof google.protobuf
@@ -4131,7 +4131,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * MethodOptions deprecated.
                  * @member {boolean} deprecated
@@ -4139,7 +4139,7 @@
                  * @instance
                  */
                 MethodOptions.prototype.deprecated = false;
-    
+
                 /**
                  * MethodOptions uninterpretedOption.
                  * @member {Array.<google.protobuf.IUninterpretedOption>} uninterpretedOption
@@ -4147,7 +4147,7 @@
                  * @instance
                  */
                 MethodOptions.prototype.uninterpretedOption = $util.emptyArray;
-    
+
                 /**
                  * MethodOptions .google.api.http.
                  * @member {google.api.IHttpRule|null|undefined} .google.api.http
@@ -4155,7 +4155,7 @@
                  * @instance
                  */
                 MethodOptions.prototype[".google.api.http"] = null;
-    
+
                 /**
                  * MethodOptions .google.api.methodSignature.
                  * @member {Array.<string>} .google.api.methodSignature
@@ -4163,7 +4163,7 @@
                  * @instance
                  */
                 MethodOptions.prototype[".google.api.methodSignature"] = $util.emptyArray;
-    
+
                 /**
                  * MethodOptions .google.longrunning.operationInfo.
                  * @member {google.longrunning.IOperationInfo|null|undefined} .google.longrunning.operationInfo
@@ -4171,7 +4171,7 @@
                  * @instance
                  */
                 MethodOptions.prototype[".google.longrunning.operationInfo"] = null;
-    
+
                 /**
                  * Creates a MethodOptions message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -4215,7 +4215,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a MethodOptions message. Also converts values to other types if specified.
                  * @function toObject
@@ -4256,7 +4256,7 @@
                         object[".google.api.http"] = $root.google.api.HttpRule.toObject(message[".google.api.http"], options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this MethodOptions to JSON.
                  * @function toJSON
@@ -4267,12 +4267,12 @@
                 MethodOptions.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return MethodOptions;
             })();
-    
+
             protobuf.UninterpretedOption = (function() {
-    
+
                 /**
                  * Properties of an UninterpretedOption.
                  * @memberof google.protobuf
@@ -4285,7 +4285,7 @@
                  * @property {Uint8Array|null} [stringValue] UninterpretedOption stringValue
                  * @property {string|null} [aggregateValue] UninterpretedOption aggregateValue
                  */
-    
+
                 /**
                  * Constructs a new UninterpretedOption.
                  * @memberof google.protobuf
@@ -4301,7 +4301,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * UninterpretedOption name.
                  * @member {Array.<google.protobuf.UninterpretedOption.INamePart>} name
@@ -4309,7 +4309,7 @@
                  * @instance
                  */
                 UninterpretedOption.prototype.name = $util.emptyArray;
-    
+
                 /**
                  * UninterpretedOption identifierValue.
                  * @member {string} identifierValue
@@ -4317,7 +4317,7 @@
                  * @instance
                  */
                 UninterpretedOption.prototype.identifierValue = "";
-    
+
                 /**
                  * UninterpretedOption positiveIntValue.
                  * @member {number|string} positiveIntValue
@@ -4325,7 +4325,7 @@
                  * @instance
                  */
                 UninterpretedOption.prototype.positiveIntValue = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
-    
+
                 /**
                  * UninterpretedOption negativeIntValue.
                  * @member {number|string} negativeIntValue
@@ -4333,7 +4333,7 @@
                  * @instance
                  */
                 UninterpretedOption.prototype.negativeIntValue = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-    
+
                 /**
                  * UninterpretedOption doubleValue.
                  * @member {number} doubleValue
@@ -4341,7 +4341,7 @@
                  * @instance
                  */
                 UninterpretedOption.prototype.doubleValue = 0;
-    
+
                 /**
                  * UninterpretedOption stringValue.
                  * @member {Uint8Array} stringValue
@@ -4349,7 +4349,7 @@
                  * @instance
                  */
                 UninterpretedOption.prototype.stringValue = $util.newBuffer([]);
-    
+
                 /**
                  * UninterpretedOption aggregateValue.
                  * @member {string} aggregateValue
@@ -4357,7 +4357,7 @@
                  * @instance
                  */
                 UninterpretedOption.prototype.aggregateValue = "";
-    
+
                 /**
                  * Creates an UninterpretedOption message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -4411,7 +4411,7 @@
                         message.aggregateValue = String(object.aggregateValue);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an UninterpretedOption message. Also converts values to other types if specified.
                  * @function toObject
@@ -4474,7 +4474,7 @@
                         object.aggregateValue = message.aggregateValue;
                     return object;
                 };
-    
+
                 /**
                  * Converts this UninterpretedOption to JSON.
                  * @function toJSON
@@ -4485,9 +4485,9 @@
                 UninterpretedOption.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 UninterpretedOption.NamePart = (function() {
-    
+
                     /**
                      * Properties of a NamePart.
                      * @memberof google.protobuf.UninterpretedOption
@@ -4495,7 +4495,7 @@
                      * @property {string} namePart NamePart namePart
                      * @property {boolean} isExtension NamePart isExtension
                      */
-    
+
                     /**
                      * Constructs a new NamePart.
                      * @memberof google.protobuf.UninterpretedOption
@@ -4510,7 +4510,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * NamePart namePart.
                      * @member {string} namePart
@@ -4518,7 +4518,7 @@
                      * @instance
                      */
                     NamePart.prototype.namePart = "";
-    
+
                     /**
                      * NamePart isExtension.
                      * @member {boolean} isExtension
@@ -4526,7 +4526,7 @@
                      * @instance
                      */
                     NamePart.prototype.isExtension = false;
-    
+
                     /**
                      * Creates a NamePart message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -4545,7 +4545,7 @@
                             message.isExtension = Boolean(object.isExtension);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a NamePart message. Also converts values to other types if specified.
                      * @function toObject
@@ -4569,7 +4569,7 @@
                             object.isExtension = message.isExtension;
                         return object;
                     };
-    
+
                     /**
                      * Converts this NamePart to JSON.
                      * @function toJSON
@@ -4580,22 +4580,22 @@
                     NamePart.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return NamePart;
                 })();
-    
+
                 return UninterpretedOption;
             })();
-    
+
             protobuf.SourceCodeInfo = (function() {
-    
+
                 /**
                  * Properties of a SourceCodeInfo.
                  * @memberof google.protobuf
                  * @interface ISourceCodeInfo
                  * @property {Array.<google.protobuf.SourceCodeInfo.ILocation>|null} [location] SourceCodeInfo location
                  */
-    
+
                 /**
                  * Constructs a new SourceCodeInfo.
                  * @memberof google.protobuf
@@ -4611,7 +4611,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * SourceCodeInfo location.
                  * @member {Array.<google.protobuf.SourceCodeInfo.ILocation>} location
@@ -4619,7 +4619,7 @@
                  * @instance
                  */
                 SourceCodeInfo.prototype.location = $util.emptyArray;
-    
+
                 /**
                  * Creates a SourceCodeInfo message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -4644,7 +4644,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a SourceCodeInfo message. Also converts values to other types if specified.
                  * @function toObject
@@ -4667,7 +4667,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this SourceCodeInfo to JSON.
                  * @function toJSON
@@ -4678,9 +4678,9 @@
                 SourceCodeInfo.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 SourceCodeInfo.Location = (function() {
-    
+
                     /**
                      * Properties of a Location.
                      * @memberof google.protobuf.SourceCodeInfo
@@ -4691,7 +4691,7 @@
                      * @property {string|null} [trailingComments] Location trailingComments
                      * @property {Array.<string>|null} [leadingDetachedComments] Location leadingDetachedComments
                      */
-    
+
                     /**
                      * Constructs a new Location.
                      * @memberof google.protobuf.SourceCodeInfo
@@ -4709,7 +4709,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Location path.
                      * @member {Array.<number>} path
@@ -4717,7 +4717,7 @@
                      * @instance
                      */
                     Location.prototype.path = $util.emptyArray;
-    
+
                     /**
                      * Location span.
                      * @member {Array.<number>} span
@@ -4725,7 +4725,7 @@
                      * @instance
                      */
                     Location.prototype.span = $util.emptyArray;
-    
+
                     /**
                      * Location leadingComments.
                      * @member {string} leadingComments
@@ -4733,7 +4733,7 @@
                      * @instance
                      */
                     Location.prototype.leadingComments = "";
-    
+
                     /**
                      * Location trailingComments.
                      * @member {string} trailingComments
@@ -4741,7 +4741,7 @@
                      * @instance
                      */
                     Location.prototype.trailingComments = "";
-    
+
                     /**
                      * Location leadingDetachedComments.
                      * @member {Array.<string>} leadingDetachedComments
@@ -4749,7 +4749,7 @@
                      * @instance
                      */
                     Location.prototype.leadingDetachedComments = $util.emptyArray;
-    
+
                     /**
                      * Creates a Location message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -4789,7 +4789,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a Location message. Also converts values to other types if specified.
                      * @function toObject
@@ -4833,7 +4833,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this Location to JSON.
                      * @function toJSON
@@ -4844,22 +4844,22 @@
                     Location.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return Location;
                 })();
-    
+
                 return SourceCodeInfo;
             })();
-    
+
             protobuf.GeneratedCodeInfo = (function() {
-    
+
                 /**
                  * Properties of a GeneratedCodeInfo.
                  * @memberof google.protobuf
                  * @interface IGeneratedCodeInfo
                  * @property {Array.<google.protobuf.GeneratedCodeInfo.IAnnotation>|null} [annotation] GeneratedCodeInfo annotation
                  */
-    
+
                 /**
                  * Constructs a new GeneratedCodeInfo.
                  * @memberof google.protobuf
@@ -4875,7 +4875,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * GeneratedCodeInfo annotation.
                  * @member {Array.<google.protobuf.GeneratedCodeInfo.IAnnotation>} annotation
@@ -4883,7 +4883,7 @@
                  * @instance
                  */
                 GeneratedCodeInfo.prototype.annotation = $util.emptyArray;
-    
+
                 /**
                  * Creates a GeneratedCodeInfo message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -4908,7 +4908,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a GeneratedCodeInfo message. Also converts values to other types if specified.
                  * @function toObject
@@ -4931,7 +4931,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this GeneratedCodeInfo to JSON.
                  * @function toJSON
@@ -4942,9 +4942,9 @@
                 GeneratedCodeInfo.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 GeneratedCodeInfo.Annotation = (function() {
-    
+
                     /**
                      * Properties of an Annotation.
                      * @memberof google.protobuf.GeneratedCodeInfo
@@ -4954,7 +4954,7 @@
                      * @property {number|null} [begin] Annotation begin
                      * @property {number|null} [end] Annotation end
                      */
-    
+
                     /**
                      * Constructs a new Annotation.
                      * @memberof google.protobuf.GeneratedCodeInfo
@@ -4970,7 +4970,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Annotation path.
                      * @member {Array.<number>} path
@@ -4978,7 +4978,7 @@
                      * @instance
                      */
                     Annotation.prototype.path = $util.emptyArray;
-    
+
                     /**
                      * Annotation sourceFile.
                      * @member {string} sourceFile
@@ -4986,7 +4986,7 @@
                      * @instance
                      */
                     Annotation.prototype.sourceFile = "";
-    
+
                     /**
                      * Annotation begin.
                      * @member {number} begin
@@ -4994,7 +4994,7 @@
                      * @instance
                      */
                     Annotation.prototype.begin = 0;
-    
+
                     /**
                      * Annotation end.
                      * @member {number} end
@@ -5002,7 +5002,7 @@
                      * @instance
                      */
                     Annotation.prototype.end = 0;
-    
+
                     /**
                      * Creates an Annotation message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -5030,7 +5030,7 @@
                             message.end = object.end | 0;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from an Annotation message. Also converts values to other types if specified.
                      * @function toObject
@@ -5064,7 +5064,7 @@
                             object.end = message.end;
                         return object;
                     };
-    
+
                     /**
                      * Converts this Annotation to JSON.
                      * @function toJSON
@@ -5075,22 +5075,22 @@
                     Annotation.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return Annotation;
                 })();
-    
+
                 return GeneratedCodeInfo;
             })();
-    
+
             protobuf.Struct = (function() {
-    
+
                 /**
                  * Properties of a Struct.
                  * @memberof google.protobuf
                  * @interface IStruct
                  * @property {Object.<string,google.protobuf.IValue>|null} [fields] Struct fields
                  */
-    
+
                 /**
                  * Constructs a new Struct.
                  * @memberof google.protobuf
@@ -5106,7 +5106,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Struct fields.
                  * @member {Object.<string,google.protobuf.IValue>} fields
@@ -5114,7 +5114,7 @@
                  * @instance
                  */
                 Struct.prototype.fields = $util.emptyObject;
-    
+
                 /**
                  * Creates a Struct message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5139,7 +5139,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a Struct message. Also converts values to other types if specified.
                  * @function toObject
@@ -5163,7 +5163,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this Struct to JSON.
                  * @function toJSON
@@ -5174,12 +5174,12 @@
                 Struct.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Struct;
             })();
-    
+
             protobuf.Value = (function() {
-    
+
                 /**
                  * Properties of a Value.
                  * @memberof google.protobuf
@@ -5191,7 +5191,7 @@
                  * @property {google.protobuf.IStruct|null} [structValue] Value structValue
                  * @property {google.protobuf.IListValue|null} [listValue] Value listValue
                  */
-    
+
                 /**
                  * Constructs a new Value.
                  * @memberof google.protobuf
@@ -5206,7 +5206,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Value nullValue.
                  * @member {google.protobuf.NullValue|null|undefined} nullValue
@@ -5214,7 +5214,7 @@
                  * @instance
                  */
                 Value.prototype.nullValue = null;
-    
+
                 /**
                  * Value numberValue.
                  * @member {number|null|undefined} numberValue
@@ -5222,7 +5222,7 @@
                  * @instance
                  */
                 Value.prototype.numberValue = null;
-    
+
                 /**
                  * Value stringValue.
                  * @member {string|null|undefined} stringValue
@@ -5230,7 +5230,7 @@
                  * @instance
                  */
                 Value.prototype.stringValue = null;
-    
+
                 /**
                  * Value boolValue.
                  * @member {boolean|null|undefined} boolValue
@@ -5238,7 +5238,7 @@
                  * @instance
                  */
                 Value.prototype.boolValue = null;
-    
+
                 /**
                  * Value structValue.
                  * @member {google.protobuf.IStruct|null|undefined} structValue
@@ -5246,7 +5246,7 @@
                  * @instance
                  */
                 Value.prototype.structValue = null;
-    
+
                 /**
                  * Value listValue.
                  * @member {google.protobuf.IListValue|null|undefined} listValue
@@ -5254,10 +5254,10 @@
                  * @instance
                  */
                 Value.prototype.listValue = null;
-    
+
                 // OneOf field names bound to virtual getters and setters
                 var $oneOfFields;
-    
+
                 /**
                  * Value kind.
                  * @member {"nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue"|undefined} kind
@@ -5268,7 +5268,7 @@
                     get: $util.oneOfGetter($oneOfFields = ["nullValue", "numberValue", "stringValue", "boolValue", "structValue", "listValue"]),
                     set: $util.oneOfSetter($oneOfFields)
                 });
-    
+
                 /**
                  * Creates a Value message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5305,7 +5305,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a Value message. Also converts values to other types if specified.
                  * @function toObject
@@ -5351,7 +5351,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this Value to JSON.
                  * @function toJSON
@@ -5362,10 +5362,10 @@
                 Value.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Value;
             })();
-    
+
             /**
              * NullValue enum.
              * @name google.protobuf.NullValue
@@ -5377,16 +5377,16 @@
                 values[valuesById[0] = "NULL_VALUE"] = "NULL_VALUE";
                 return values;
             })();
-    
+
             protobuf.ListValue = (function() {
-    
+
                 /**
                  * Properties of a ListValue.
                  * @memberof google.protobuf
                  * @interface IListValue
                  * @property {Array.<google.protobuf.IValue>|null} [values] ListValue values
                  */
-    
+
                 /**
                  * Constructs a new ListValue.
                  * @memberof google.protobuf
@@ -5402,7 +5402,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * ListValue values.
                  * @member {Array.<google.protobuf.IValue>} values
@@ -5410,7 +5410,7 @@
                  * @instance
                  */
                 ListValue.prototype.values = $util.emptyArray;
-    
+
                 /**
                  * Creates a ListValue message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5435,7 +5435,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a ListValue message. Also converts values to other types if specified.
                  * @function toObject
@@ -5458,7 +5458,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this ListValue to JSON.
                  * @function toJSON
@@ -5469,18 +5469,18 @@
                 ListValue.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return ListValue;
             })();
-    
+
             protobuf.Empty = (function() {
-    
+
                 /**
                  * Properties of an Empty.
                  * @memberof google.protobuf
                  * @interface IEmpty
                  */
-    
+
                 /**
                  * Constructs a new Empty.
                  * @memberof google.protobuf
@@ -5495,7 +5495,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Creates an Empty message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5509,7 +5509,7 @@
                         return object;
                     return new $root.google.protobuf.Empty();
                 };
-    
+
                 /**
                  * Creates a plain object from an Empty message. Also converts values to other types if specified.
                  * @function toObject
@@ -5522,7 +5522,7 @@
                 Empty.toObject = function toObject() {
                     return {};
                 };
-    
+
                 /**
                  * Converts this Empty to JSON.
                  * @function toJSON
@@ -5533,19 +5533,19 @@
                 Empty.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Empty;
             })();
-    
+
             protobuf.DoubleValue = (function() {
-    
+
                 /**
                  * Properties of a DoubleValue.
                  * @memberof google.protobuf
                  * @interface IDoubleValue
                  * @property {number|null} [value] DoubleValue value
                  */
-    
+
                 /**
                  * Constructs a new DoubleValue.
                  * @memberof google.protobuf
@@ -5560,7 +5560,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * DoubleValue value.
                  * @member {number} value
@@ -5568,7 +5568,7 @@
                  * @instance
                  */
                 DoubleValue.prototype.value = 0;
-    
+
                 /**
                  * Creates a DoubleValue message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5585,7 +5585,7 @@
                         message.value = Number(object.value);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a DoubleValue message. Also converts values to other types if specified.
                  * @function toObject
@@ -5605,7 +5605,7 @@
                         object.value = options.json && !isFinite(message.value) ? String(message.value) : message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this DoubleValue to JSON.
                  * @function toJSON
@@ -5616,19 +5616,19 @@
                 DoubleValue.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return DoubleValue;
             })();
-    
+
             protobuf.FloatValue = (function() {
-    
+
                 /**
                  * Properties of a FloatValue.
                  * @memberof google.protobuf
                  * @interface IFloatValue
                  * @property {number|null} [value] FloatValue value
                  */
-    
+
                 /**
                  * Constructs a new FloatValue.
                  * @memberof google.protobuf
@@ -5643,7 +5643,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * FloatValue value.
                  * @member {number} value
@@ -5651,7 +5651,7 @@
                  * @instance
                  */
                 FloatValue.prototype.value = 0;
-    
+
                 /**
                  * Creates a FloatValue message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5668,7 +5668,7 @@
                         message.value = Number(object.value);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a FloatValue message. Also converts values to other types if specified.
                  * @function toObject
@@ -5688,7 +5688,7 @@
                         object.value = options.json && !isFinite(message.value) ? String(message.value) : message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this FloatValue to JSON.
                  * @function toJSON
@@ -5699,19 +5699,19 @@
                 FloatValue.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return FloatValue;
             })();
-    
+
             protobuf.Int64Value = (function() {
-    
+
                 /**
                  * Properties of an Int64Value.
                  * @memberof google.protobuf
                  * @interface IInt64Value
                  * @property {number|string|null} [value] Int64Value value
                  */
-    
+
                 /**
                  * Constructs a new Int64Value.
                  * @memberof google.protobuf
@@ -5726,7 +5726,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Int64Value value.
                  * @member {number|string} value
@@ -5734,7 +5734,7 @@
                  * @instance
                  */
                 Int64Value.prototype.value = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-    
+
                 /**
                  * Creates an Int64Value message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5758,7 +5758,7 @@
                             message.value = new $util.LongBits(object.value.low >>> 0, object.value.high >>> 0).toNumber();
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an Int64Value message. Also converts values to other types if specified.
                  * @function toObject
@@ -5785,7 +5785,7 @@
                             object.value = options.longs === String ? $util.Long.prototype.toString.call(message.value) : options.longs === Number ? new $util.LongBits(message.value.low >>> 0, message.value.high >>> 0).toNumber() : message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this Int64Value to JSON.
                  * @function toJSON
@@ -5796,19 +5796,19 @@
                 Int64Value.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Int64Value;
             })();
-    
+
             protobuf.UInt64Value = (function() {
-    
+
                 /**
                  * Properties of a UInt64Value.
                  * @memberof google.protobuf
                  * @interface IUInt64Value
                  * @property {number|string|null} [value] UInt64Value value
                  */
-    
+
                 /**
                  * Constructs a new UInt64Value.
                  * @memberof google.protobuf
@@ -5823,7 +5823,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * UInt64Value value.
                  * @member {number|string} value
@@ -5831,7 +5831,7 @@
                  * @instance
                  */
                 UInt64Value.prototype.value = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
-    
+
                 /**
                  * Creates a UInt64Value message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5855,7 +5855,7 @@
                             message.value = new $util.LongBits(object.value.low >>> 0, object.value.high >>> 0).toNumber(true);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a UInt64Value message. Also converts values to other types if specified.
                  * @function toObject
@@ -5882,7 +5882,7 @@
                             object.value = options.longs === String ? $util.Long.prototype.toString.call(message.value) : options.longs === Number ? new $util.LongBits(message.value.low >>> 0, message.value.high >>> 0).toNumber(true) : message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this UInt64Value to JSON.
                  * @function toJSON
@@ -5893,19 +5893,19 @@
                 UInt64Value.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return UInt64Value;
             })();
-    
+
             protobuf.Int32Value = (function() {
-    
+
                 /**
                  * Properties of an Int32Value.
                  * @memberof google.protobuf
                  * @interface IInt32Value
                  * @property {number|null} [value] Int32Value value
                  */
-    
+
                 /**
                  * Constructs a new Int32Value.
                  * @memberof google.protobuf
@@ -5920,7 +5920,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Int32Value value.
                  * @member {number} value
@@ -5928,7 +5928,7 @@
                  * @instance
                  */
                 Int32Value.prototype.value = 0;
-    
+
                 /**
                  * Creates an Int32Value message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -5945,7 +5945,7 @@
                         message.value = object.value | 0;
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an Int32Value message. Also converts values to other types if specified.
                  * @function toObject
@@ -5965,7 +5965,7 @@
                         object.value = message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this Int32Value to JSON.
                  * @function toJSON
@@ -5976,19 +5976,19 @@
                 Int32Value.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Int32Value;
             })();
-    
+
             protobuf.UInt32Value = (function() {
-    
+
                 /**
                  * Properties of a UInt32Value.
                  * @memberof google.protobuf
                  * @interface IUInt32Value
                  * @property {number|null} [value] UInt32Value value
                  */
-    
+
                 /**
                  * Constructs a new UInt32Value.
                  * @memberof google.protobuf
@@ -6003,7 +6003,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * UInt32Value value.
                  * @member {number} value
@@ -6011,7 +6011,7 @@
                  * @instance
                  */
                 UInt32Value.prototype.value = 0;
-    
+
                 /**
                  * Creates a UInt32Value message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -6028,7 +6028,7 @@
                         message.value = object.value >>> 0;
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a UInt32Value message. Also converts values to other types if specified.
                  * @function toObject
@@ -6048,7 +6048,7 @@
                         object.value = message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this UInt32Value to JSON.
                  * @function toJSON
@@ -6059,19 +6059,19 @@
                 UInt32Value.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return UInt32Value;
             })();
-    
+
             protobuf.BoolValue = (function() {
-    
+
                 /**
                  * Properties of a BoolValue.
                  * @memberof google.protobuf
                  * @interface IBoolValue
                  * @property {boolean|null} [value] BoolValue value
                  */
-    
+
                 /**
                  * Constructs a new BoolValue.
                  * @memberof google.protobuf
@@ -6086,7 +6086,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * BoolValue value.
                  * @member {boolean} value
@@ -6094,7 +6094,7 @@
                  * @instance
                  */
                 BoolValue.prototype.value = false;
-    
+
                 /**
                  * Creates a BoolValue message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -6111,7 +6111,7 @@
                         message.value = Boolean(object.value);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a BoolValue message. Also converts values to other types if specified.
                  * @function toObject
@@ -6131,7 +6131,7 @@
                         object.value = message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this BoolValue to JSON.
                  * @function toJSON
@@ -6142,19 +6142,19 @@
                 BoolValue.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return BoolValue;
             })();
-    
+
             protobuf.StringValue = (function() {
-    
+
                 /**
                  * Properties of a StringValue.
                  * @memberof google.protobuf
                  * @interface IStringValue
                  * @property {string|null} [value] StringValue value
                  */
-    
+
                 /**
                  * Constructs a new StringValue.
                  * @memberof google.protobuf
@@ -6169,7 +6169,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * StringValue value.
                  * @member {string} value
@@ -6177,7 +6177,7 @@
                  * @instance
                  */
                 StringValue.prototype.value = "";
-    
+
                 /**
                  * Creates a StringValue message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -6194,7 +6194,7 @@
                         message.value = String(object.value);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a StringValue message. Also converts values to other types if specified.
                  * @function toObject
@@ -6214,7 +6214,7 @@
                         object.value = message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this StringValue to JSON.
                  * @function toJSON
@@ -6225,19 +6225,19 @@
                 StringValue.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return StringValue;
             })();
-    
+
             protobuf.BytesValue = (function() {
-    
+
                 /**
                  * Properties of a BytesValue.
                  * @memberof google.protobuf
                  * @interface IBytesValue
                  * @property {Uint8Array|null} [value] BytesValue value
                  */
-    
+
                 /**
                  * Constructs a new BytesValue.
                  * @memberof google.protobuf
@@ -6252,7 +6252,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * BytesValue value.
                  * @member {Uint8Array} value
@@ -6260,7 +6260,7 @@
                  * @instance
                  */
                 BytesValue.prototype.value = $util.newBuffer([]);
-    
+
                 /**
                  * Creates a BytesValue message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -6280,7 +6280,7 @@
                             message.value = object.value;
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a BytesValue message. Also converts values to other types if specified.
                  * @function toObject
@@ -6306,7 +6306,7 @@
                         object.value = options.bytes === String ? $util.base64.encode(message.value, 0, message.value.length) : options.bytes === Array ? Array.prototype.slice.call(message.value) : message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this BytesValue to JSON.
                  * @function toJSON
@@ -6317,12 +6317,12 @@
                 BytesValue.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return BytesValue;
             })();
-    
+
             protobuf.Any = (function() {
-    
+
                 /**
                  * Properties of an Any.
                  * @memberof google.protobuf
@@ -6330,7 +6330,7 @@
                  * @property {string|null} [type_url] Any type_url
                  * @property {Uint8Array|null} [value] Any value
                  */
-    
+
                 /**
                  * Constructs a new Any.
                  * @memberof google.protobuf
@@ -6345,7 +6345,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Any type_url.
                  * @member {string} type_url
@@ -6353,7 +6353,7 @@
                  * @instance
                  */
                 Any.prototype.type_url = "";
-    
+
                 /**
                  * Any value.
                  * @member {Uint8Array} value
@@ -6361,7 +6361,7 @@
                  * @instance
                  */
                 Any.prototype.value = $util.newBuffer([]);
-    
+
                 /**
                  * Creates an Any message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -6383,7 +6383,7 @@
                             message.value = object.value;
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an Any message. Also converts values to other types if specified.
                  * @function toObject
@@ -6413,7 +6413,7 @@
                         object.value = options.bytes === String ? $util.base64.encode(message.value, 0, message.value.length) : options.bytes === Array ? Array.prototype.slice.call(message.value) : message.value;
                     return object;
                 };
-    
+
                 /**
                  * Converts this Any to JSON.
                  * @function toJSON
@@ -6424,19 +6424,19 @@
                 Any.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Any;
             })();
-    
+
             protobuf.FieldMask = (function() {
-    
+
                 /**
                  * Properties of a FieldMask.
                  * @memberof google.protobuf
                  * @interface IFieldMask
                  * @property {Array.<string>|null} [paths] FieldMask paths
                  */
-    
+
                 /**
                  * Constructs a new FieldMask.
                  * @memberof google.protobuf
@@ -6452,7 +6452,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * FieldMask paths.
                  * @member {Array.<string>} paths
@@ -6460,7 +6460,7 @@
                  * @instance
                  */
                 FieldMask.prototype.paths = $util.emptyArray;
-    
+
                 /**
                  * Creates a FieldMask message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -6482,7 +6482,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a FieldMask message. Also converts values to other types if specified.
                  * @function toObject
@@ -6505,7 +6505,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this FieldMask to JSON.
                  * @function toJSON
@@ -6516,12 +6516,12 @@
                 FieldMask.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return FieldMask;
             })();
-    
+
             protobuf.Duration = (function() {
-    
+
                 /**
                  * Properties of a Duration.
                  * @memberof google.protobuf
@@ -6529,7 +6529,7 @@
                  * @property {number|string|null} [seconds] Duration seconds
                  * @property {number|null} [nanos] Duration nanos
                  */
-    
+
                 /**
                  * Constructs a new Duration.
                  * @memberof google.protobuf
@@ -6544,7 +6544,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Duration seconds.
                  * @member {number|string} seconds
@@ -6552,7 +6552,7 @@
                  * @instance
                  */
                 Duration.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-    
+
                 /**
                  * Duration nanos.
                  * @member {number} nanos
@@ -6560,7 +6560,7 @@
                  * @instance
                  */
                 Duration.prototype.nanos = 0;
-    
+
                 /**
                  * Creates a Duration message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -6586,7 +6586,7 @@
                         message.nanos = object.nanos | 0;
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a Duration message. Also converts values to other types if specified.
                  * @function toObject
@@ -6617,7 +6617,7 @@
                         object.nanos = message.nanos;
                     return object;
                 };
-    
+
                 /**
                  * Converts this Duration to JSON.
                  * @function toJSON
@@ -6628,40 +6628,40 @@
                 Duration.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Duration;
             })();
-    
+
             return protobuf;
         })();
-    
+
         google.firestore = (function() {
-    
+
             /**
              * Namespace firestore.
              * @memberof google
              * @namespace
              */
             var firestore = {};
-    
+
             firestore.v1 = (function() {
-    
+
                 /**
                  * Namespace v1.
                  * @memberof google.firestore
                  * @namespace
                  */
                 var v1 = {};
-    
+
                 v1.DocumentMask = (function() {
-    
+
                     /**
                      * Properties of a DocumentMask.
                      * @memberof google.firestore.v1
                      * @interface IDocumentMask
                      * @property {Array.<string>|null} [fieldPaths] DocumentMask fieldPaths
                      */
-    
+
                     /**
                      * Constructs a new DocumentMask.
                      * @memberof google.firestore.v1
@@ -6677,7 +6677,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * DocumentMask fieldPaths.
                      * @member {Array.<string>} fieldPaths
@@ -6685,7 +6685,7 @@
                      * @instance
                      */
                     DocumentMask.prototype.fieldPaths = $util.emptyArray;
-    
+
                     /**
                      * Creates a DocumentMask message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -6707,7 +6707,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a DocumentMask message. Also converts values to other types if specified.
                      * @function toObject
@@ -6730,7 +6730,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this DocumentMask to JSON.
                      * @function toJSON
@@ -6741,12 +6741,12 @@
                     DocumentMask.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return DocumentMask;
                 })();
-    
+
                 v1.Precondition = (function() {
-    
+
                     /**
                      * Properties of a Precondition.
                      * @memberof google.firestore.v1
@@ -6754,7 +6754,7 @@
                      * @property {boolean|null} [exists] Precondition exists
                      * @property {google.protobuf.ITimestamp|null} [updateTime] Precondition updateTime
                      */
-    
+
                     /**
                      * Constructs a new Precondition.
                      * @memberof google.firestore.v1
@@ -6769,7 +6769,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Precondition exists.
                      * @member {boolean|null|undefined} exists
@@ -6777,7 +6777,7 @@
                      * @instance
                      */
                     Precondition.prototype.exists = null;
-    
+
                     /**
                      * Precondition updateTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} updateTime
@@ -6785,10 +6785,10 @@
                      * @instance
                      */
                     Precondition.prototype.updateTime = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * Precondition conditionType.
                      * @member {"exists"|"updateTime"|undefined} conditionType
@@ -6799,7 +6799,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["exists", "updateTime"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a Precondition message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -6821,7 +6821,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a Precondition message. Also converts values to other types if specified.
                      * @function toObject
@@ -6847,7 +6847,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this Precondition to JSON.
                      * @function toJSON
@@ -6858,12 +6858,12 @@
                     Precondition.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return Precondition;
                 })();
-    
+
                 v1.TransactionOptions = (function() {
-    
+
                     /**
                      * Properties of a TransactionOptions.
                      * @memberof google.firestore.v1
@@ -6871,7 +6871,7 @@
                      * @property {google.firestore.v1.TransactionOptions.IReadOnly|null} [readOnly] TransactionOptions readOnly
                      * @property {google.firestore.v1.TransactionOptions.IReadWrite|null} [readWrite] TransactionOptions readWrite
                      */
-    
+
                     /**
                      * Constructs a new TransactionOptions.
                      * @memberof google.firestore.v1
@@ -6886,7 +6886,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * TransactionOptions readOnly.
                      * @member {google.firestore.v1.TransactionOptions.IReadOnly|null|undefined} readOnly
@@ -6894,7 +6894,7 @@
                      * @instance
                      */
                     TransactionOptions.prototype.readOnly = null;
-    
+
                     /**
                      * TransactionOptions readWrite.
                      * @member {google.firestore.v1.TransactionOptions.IReadWrite|null|undefined} readWrite
@@ -6902,10 +6902,10 @@
                      * @instance
                      */
                     TransactionOptions.prototype.readWrite = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * TransactionOptions mode.
                      * @member {"readOnly"|"readWrite"|undefined} mode
@@ -6916,7 +6916,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["readOnly", "readWrite"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a TransactionOptions message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -6941,7 +6941,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a TransactionOptions message. Also converts values to other types if specified.
                      * @function toObject
@@ -6967,7 +6967,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this TransactionOptions to JSON.
                      * @function toJSON
@@ -6978,16 +6978,16 @@
                     TransactionOptions.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     TransactionOptions.ReadWrite = (function() {
-    
+
                         /**
                          * Properties of a ReadWrite.
                          * @memberof google.firestore.v1.TransactionOptions
                          * @interface IReadWrite
                          * @property {Uint8Array|null} [retryTransaction] ReadWrite retryTransaction
                          */
-    
+
                         /**
                          * Constructs a new ReadWrite.
                          * @memberof google.firestore.v1.TransactionOptions
@@ -7002,7 +7002,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * ReadWrite retryTransaction.
                          * @member {Uint8Array} retryTransaction
@@ -7010,7 +7010,7 @@
                          * @instance
                          */
                         ReadWrite.prototype.retryTransaction = $util.newBuffer([]);
-    
+
                         /**
                          * Creates a ReadWrite message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -7030,7 +7030,7 @@
                                     message.retryTransaction = object.retryTransaction;
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a ReadWrite message. Also converts values to other types if specified.
                          * @function toObject
@@ -7056,7 +7056,7 @@
                                 object.retryTransaction = options.bytes === String ? $util.base64.encode(message.retryTransaction, 0, message.retryTransaction.length) : options.bytes === Array ? Array.prototype.slice.call(message.retryTransaction) : message.retryTransaction;
                             return object;
                         };
-    
+
                         /**
                          * Converts this ReadWrite to JSON.
                          * @function toJSON
@@ -7067,19 +7067,19 @@
                         ReadWrite.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return ReadWrite;
                     })();
-    
+
                     TransactionOptions.ReadOnly = (function() {
-    
+
                         /**
                          * Properties of a ReadOnly.
                          * @memberof google.firestore.v1.TransactionOptions
                          * @interface IReadOnly
                          * @property {google.protobuf.ITimestamp|null} [readTime] ReadOnly readTime
                          */
-    
+
                         /**
                          * Constructs a new ReadOnly.
                          * @memberof google.firestore.v1.TransactionOptions
@@ -7094,7 +7094,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * ReadOnly readTime.
                          * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -7102,10 +7102,10 @@
                          * @instance
                          */
                         ReadOnly.prototype.readTime = null;
-    
+
                         // OneOf field names bound to virtual getters and setters
                         var $oneOfFields;
-    
+
                         /**
                          * ReadOnly consistencySelector.
                          * @member {"readTime"|undefined} consistencySelector
@@ -7116,7 +7116,7 @@
                             get: $util.oneOfGetter($oneOfFields = ["readTime"]),
                             set: $util.oneOfSetter($oneOfFields)
                         });
-    
+
                         /**
                          * Creates a ReadOnly message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -7136,7 +7136,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a ReadOnly message. Also converts values to other types if specified.
                          * @function toObject
@@ -7157,7 +7157,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this ReadOnly to JSON.
                          * @function toJSON
@@ -7168,15 +7168,15 @@
                         ReadOnly.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return ReadOnly;
                     })();
-    
+
                     return TransactionOptions;
                 })();
-    
+
                 v1.Document = (function() {
-    
+
                     /**
                      * Properties of a Document.
                      * @memberof google.firestore.v1
@@ -7186,7 +7186,7 @@
                      * @property {google.protobuf.ITimestamp|null} [createTime] Document createTime
                      * @property {google.protobuf.ITimestamp|null} [updateTime] Document updateTime
                      */
-    
+
                     /**
                      * Constructs a new Document.
                      * @memberof google.firestore.v1
@@ -7202,7 +7202,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Document name.
                      * @member {string} name
@@ -7210,7 +7210,7 @@
                      * @instance
                      */
                     Document.prototype.name = "";
-    
+
                     /**
                      * Document fields.
                      * @member {Object.<string,google.firestore.v1.IValue>} fields
@@ -7218,7 +7218,7 @@
                      * @instance
                      */
                     Document.prototype.fields = $util.emptyObject;
-    
+
                     /**
                      * Document createTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} createTime
@@ -7226,7 +7226,7 @@
                      * @instance
                      */
                     Document.prototype.createTime = null;
-    
+
                     /**
                      * Document updateTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} updateTime
@@ -7234,7 +7234,7 @@
                      * @instance
                      */
                     Document.prototype.updateTime = null;
-    
+
                     /**
                      * Creates a Document message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -7271,7 +7271,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a Document message. Also converts values to other types if specified.
                      * @function toObject
@@ -7306,7 +7306,7 @@
                             object.updateTime = $root.google.protobuf.Timestamp.toObject(message.updateTime, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this Document to JSON.
                      * @function toJSON
@@ -7317,12 +7317,12 @@
                     Document.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return Document;
                 })();
-    
+
                 v1.Value = (function() {
-    
+
                     /**
                      * Properties of a Value.
                      * @memberof google.firestore.v1
@@ -7339,7 +7339,7 @@
                      * @property {google.firestore.v1.IArrayValue|null} [arrayValue] Value arrayValue
                      * @property {google.firestore.v1.IMapValue|null} [mapValue] Value mapValue
                      */
-    
+
                     /**
                      * Constructs a new Value.
                      * @memberof google.firestore.v1
@@ -7354,7 +7354,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Value nullValue.
                      * @member {google.protobuf.NullValue|null|undefined} nullValue
@@ -7362,7 +7362,7 @@
                      * @instance
                      */
                     Value.prototype.nullValue = null;
-    
+
                     /**
                      * Value booleanValue.
                      * @member {boolean|null|undefined} booleanValue
@@ -7370,7 +7370,7 @@
                      * @instance
                      */
                     Value.prototype.booleanValue = null;
-    
+
                     /**
                      * Value integerValue.
                      * @member {number|string|null|undefined} integerValue
@@ -7378,7 +7378,7 @@
                      * @instance
                      */
                     Value.prototype.integerValue = null;
-    
+
                     /**
                      * Value doubleValue.
                      * @member {number|null|undefined} doubleValue
@@ -7386,7 +7386,7 @@
                      * @instance
                      */
                     Value.prototype.doubleValue = null;
-    
+
                     /**
                      * Value timestampValue.
                      * @member {google.protobuf.ITimestamp|null|undefined} timestampValue
@@ -7394,7 +7394,7 @@
                      * @instance
                      */
                     Value.prototype.timestampValue = null;
-    
+
                     /**
                      * Value stringValue.
                      * @member {string|null|undefined} stringValue
@@ -7402,7 +7402,7 @@
                      * @instance
                      */
                     Value.prototype.stringValue = null;
-    
+
                     /**
                      * Value bytesValue.
                      * @member {Uint8Array|null|undefined} bytesValue
@@ -7410,7 +7410,7 @@
                      * @instance
                      */
                     Value.prototype.bytesValue = null;
-    
+
                     /**
                      * Value referenceValue.
                      * @member {string|null|undefined} referenceValue
@@ -7418,7 +7418,7 @@
                      * @instance
                      */
                     Value.prototype.referenceValue = null;
-    
+
                     /**
                      * Value geoPointValue.
                      * @member {google.type.ILatLng|null|undefined} geoPointValue
@@ -7426,7 +7426,7 @@
                      * @instance
                      */
                     Value.prototype.geoPointValue = null;
-    
+
                     /**
                      * Value arrayValue.
                      * @member {google.firestore.v1.IArrayValue|null|undefined} arrayValue
@@ -7434,7 +7434,7 @@
                      * @instance
                      */
                     Value.prototype.arrayValue = null;
-    
+
                     /**
                      * Value mapValue.
                      * @member {google.firestore.v1.IMapValue|null|undefined} mapValue
@@ -7442,10 +7442,10 @@
                      * @instance
                      */
                     Value.prototype.mapValue = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * Value valueType.
                      * @member {"nullValue"|"booleanValue"|"integerValue"|"doubleValue"|"timestampValue"|"stringValue"|"bytesValue"|"referenceValue"|"geoPointValue"|"arrayValue"|"mapValue"|undefined} valueType
@@ -7456,7 +7456,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["nullValue", "booleanValue", "integerValue", "doubleValue", "timestampValue", "stringValue", "bytesValue", "referenceValue", "geoPointValue", "arrayValue", "mapValue"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a Value message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -7519,7 +7519,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a Value message. Also converts values to other types if specified.
                      * @function toObject
@@ -7593,7 +7593,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this Value to JSON.
                      * @function toJSON
@@ -7604,19 +7604,19 @@
                     Value.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return Value;
                 })();
-    
+
                 v1.ArrayValue = (function() {
-    
+
                     /**
                      * Properties of an ArrayValue.
                      * @memberof google.firestore.v1
                      * @interface IArrayValue
                      * @property {Array.<google.firestore.v1.IValue>|null} [values] ArrayValue values
                      */
-    
+
                     /**
                      * Constructs a new ArrayValue.
                      * @memberof google.firestore.v1
@@ -7632,7 +7632,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ArrayValue values.
                      * @member {Array.<google.firestore.v1.IValue>} values
@@ -7640,7 +7640,7 @@
                      * @instance
                      */
                     ArrayValue.prototype.values = $util.emptyArray;
-    
+
                     /**
                      * Creates an ArrayValue message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -7665,7 +7665,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from an ArrayValue message. Also converts values to other types if specified.
                      * @function toObject
@@ -7688,7 +7688,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this ArrayValue to JSON.
                      * @function toJSON
@@ -7699,19 +7699,19 @@
                     ArrayValue.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ArrayValue;
                 })();
-    
+
                 v1.MapValue = (function() {
-    
+
                     /**
                      * Properties of a MapValue.
                      * @memberof google.firestore.v1
                      * @interface IMapValue
                      * @property {Object.<string,google.firestore.v1.IValue>|null} [fields] MapValue fields
                      */
-    
+
                     /**
                      * Constructs a new MapValue.
                      * @memberof google.firestore.v1
@@ -7727,7 +7727,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * MapValue fields.
                      * @member {Object.<string,google.firestore.v1.IValue>} fields
@@ -7735,7 +7735,7 @@
                      * @instance
                      */
                     MapValue.prototype.fields = $util.emptyObject;
-    
+
                     /**
                      * Creates a MapValue message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -7760,7 +7760,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a MapValue message. Also converts values to other types if specified.
                      * @function toObject
@@ -7784,7 +7784,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this MapValue to JSON.
                      * @function toJSON
@@ -7795,12 +7795,12 @@
                     MapValue.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return MapValue;
                 })();
-    
+
                 v1.Firestore = (function() {
-    
+
                     /**
                      * Constructs a new Firestore service.
                      * @memberof google.firestore.v1
@@ -7814,9 +7814,9 @@
                     function Firestore(rpcImpl, requestDelimited, responseDelimited) {
                         $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
                     }
-    
+
                     (Firestore.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Firestore;
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#getDocument}.
                      * @memberof google.firestore.v1.Firestore
@@ -7825,7 +7825,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.Document} [response] Document
                      */
-    
+
                     /**
                      * Calls GetDocument.
                      * @function getDocument
@@ -7839,7 +7839,7 @@
                     Object.defineProperty(Firestore.prototype.getDocument = function getDocument(request, callback) {
                         return this.rpcCall(getDocument, $root.google.firestore.v1.GetDocumentRequest, $root.google.firestore.v1.Document, request, callback);
                     }, "name", { value: "GetDocument" });
-    
+
                     /**
                      * Calls GetDocument.
                      * @function getDocument
@@ -7849,7 +7849,7 @@
                      * @returns {Promise<google.firestore.v1.Document>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#listDocuments}.
                      * @memberof google.firestore.v1.Firestore
@@ -7858,7 +7858,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.ListDocumentsResponse} [response] ListDocumentsResponse
                      */
-    
+
                     /**
                      * Calls ListDocuments.
                      * @function listDocuments
@@ -7872,7 +7872,7 @@
                     Object.defineProperty(Firestore.prototype.listDocuments = function listDocuments(request, callback) {
                         return this.rpcCall(listDocuments, $root.google.firestore.v1.ListDocumentsRequest, $root.google.firestore.v1.ListDocumentsResponse, request, callback);
                     }, "name", { value: "ListDocuments" });
-    
+
                     /**
                      * Calls ListDocuments.
                      * @function listDocuments
@@ -7882,7 +7882,7 @@
                      * @returns {Promise<google.firestore.v1.ListDocumentsResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#updateDocument}.
                      * @memberof google.firestore.v1.Firestore
@@ -7891,7 +7891,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.Document} [response] Document
                      */
-    
+
                     /**
                      * Calls UpdateDocument.
                      * @function updateDocument
@@ -7905,7 +7905,7 @@
                     Object.defineProperty(Firestore.prototype.updateDocument = function updateDocument(request, callback) {
                         return this.rpcCall(updateDocument, $root.google.firestore.v1.UpdateDocumentRequest, $root.google.firestore.v1.Document, request, callback);
                     }, "name", { value: "UpdateDocument" });
-    
+
                     /**
                      * Calls UpdateDocument.
                      * @function updateDocument
@@ -7915,7 +7915,7 @@
                      * @returns {Promise<google.firestore.v1.Document>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#deleteDocument}.
                      * @memberof google.firestore.v1.Firestore
@@ -7924,7 +7924,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.protobuf.Empty} [response] Empty
                      */
-    
+
                     /**
                      * Calls DeleteDocument.
                      * @function deleteDocument
@@ -7938,7 +7938,7 @@
                     Object.defineProperty(Firestore.prototype.deleteDocument = function deleteDocument(request, callback) {
                         return this.rpcCall(deleteDocument, $root.google.firestore.v1.DeleteDocumentRequest, $root.google.protobuf.Empty, request, callback);
                     }, "name", { value: "DeleteDocument" });
-    
+
                     /**
                      * Calls DeleteDocument.
                      * @function deleteDocument
@@ -7948,7 +7948,7 @@
                      * @returns {Promise<google.protobuf.Empty>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#batchGetDocuments}.
                      * @memberof google.firestore.v1.Firestore
@@ -7957,7 +7957,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.BatchGetDocumentsResponse} [response] BatchGetDocumentsResponse
                      */
-    
+
                     /**
                      * Calls BatchGetDocuments.
                      * @function batchGetDocuments
@@ -7971,7 +7971,7 @@
                     Object.defineProperty(Firestore.prototype.batchGetDocuments = function batchGetDocuments(request, callback) {
                         return this.rpcCall(batchGetDocuments, $root.google.firestore.v1.BatchGetDocumentsRequest, $root.google.firestore.v1.BatchGetDocumentsResponse, request, callback);
                     }, "name", { value: "BatchGetDocuments" });
-    
+
                     /**
                      * Calls BatchGetDocuments.
                      * @function batchGetDocuments
@@ -7981,7 +7981,7 @@
                      * @returns {Promise<google.firestore.v1.BatchGetDocumentsResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#beginTransaction}.
                      * @memberof google.firestore.v1.Firestore
@@ -7990,7 +7990,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.BeginTransactionResponse} [response] BeginTransactionResponse
                      */
-    
+
                     /**
                      * Calls BeginTransaction.
                      * @function beginTransaction
@@ -8004,7 +8004,7 @@
                     Object.defineProperty(Firestore.prototype.beginTransaction = function beginTransaction(request, callback) {
                         return this.rpcCall(beginTransaction, $root.google.firestore.v1.BeginTransactionRequest, $root.google.firestore.v1.BeginTransactionResponse, request, callback);
                     }, "name", { value: "BeginTransaction" });
-    
+
                     /**
                      * Calls BeginTransaction.
                      * @function beginTransaction
@@ -8014,7 +8014,7 @@
                      * @returns {Promise<google.firestore.v1.BeginTransactionResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#commit}.
                      * @memberof google.firestore.v1.Firestore
@@ -8023,7 +8023,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.CommitResponse} [response] CommitResponse
                      */
-    
+
                     /**
                      * Calls Commit.
                      * @function commit
@@ -8037,7 +8037,7 @@
                     Object.defineProperty(Firestore.prototype.commit = function commit(request, callback) {
                         return this.rpcCall(commit, $root.google.firestore.v1.CommitRequest, $root.google.firestore.v1.CommitResponse, request, callback);
                     }, "name", { value: "Commit" });
-    
+
                     /**
                      * Calls Commit.
                      * @function commit
@@ -8047,7 +8047,7 @@
                      * @returns {Promise<google.firestore.v1.CommitResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#rollback}.
                      * @memberof google.firestore.v1.Firestore
@@ -8056,7 +8056,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.protobuf.Empty} [response] Empty
                      */
-    
+
                     /**
                      * Calls Rollback.
                      * @function rollback
@@ -8070,7 +8070,7 @@
                     Object.defineProperty(Firestore.prototype.rollback = function rollback(request, callback) {
                         return this.rpcCall(rollback, $root.google.firestore.v1.RollbackRequest, $root.google.protobuf.Empty, request, callback);
                     }, "name", { value: "Rollback" });
-    
+
                     /**
                      * Calls Rollback.
                      * @function rollback
@@ -8080,7 +8080,7 @@
                      * @returns {Promise<google.protobuf.Empty>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#runQuery}.
                      * @memberof google.firestore.v1.Firestore
@@ -8089,7 +8089,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.RunQueryResponse} [response] RunQueryResponse
                      */
-    
+
                     /**
                      * Calls RunQuery.
                      * @function runQuery
@@ -8103,7 +8103,7 @@
                     Object.defineProperty(Firestore.prototype.runQuery = function runQuery(request, callback) {
                         return this.rpcCall(runQuery, $root.google.firestore.v1.RunQueryRequest, $root.google.firestore.v1.RunQueryResponse, request, callback);
                     }, "name", { value: "RunQuery" });
-    
+
                     /**
                      * Calls RunQuery.
                      * @function runQuery
@@ -8113,7 +8113,7 @@
                      * @returns {Promise<google.firestore.v1.RunQueryResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#partitionQuery}.
                      * @memberof google.firestore.v1.Firestore
@@ -8122,7 +8122,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.PartitionQueryResponse} [response] PartitionQueryResponse
                      */
-    
+
                     /**
                      * Calls PartitionQuery.
                      * @function partitionQuery
@@ -8136,7 +8136,7 @@
                     Object.defineProperty(Firestore.prototype.partitionQuery = function partitionQuery(request, callback) {
                         return this.rpcCall(partitionQuery, $root.google.firestore.v1.PartitionQueryRequest, $root.google.firestore.v1.PartitionQueryResponse, request, callback);
                     }, "name", { value: "PartitionQuery" });
-    
+
                     /**
                      * Calls PartitionQuery.
                      * @function partitionQuery
@@ -8146,7 +8146,7 @@
                      * @returns {Promise<google.firestore.v1.PartitionQueryResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#write}.
                      * @memberof google.firestore.v1.Firestore
@@ -8155,7 +8155,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.WriteResponse} [response] WriteResponse
                      */
-    
+
                     /**
                      * Calls Write.
                      * @function write
@@ -8169,7 +8169,7 @@
                     Object.defineProperty(Firestore.prototype.write = function write(request, callback) {
                         return this.rpcCall(write, $root.google.firestore.v1.WriteRequest, $root.google.firestore.v1.WriteResponse, request, callback);
                     }, "name", { value: "Write" });
-    
+
                     /**
                      * Calls Write.
                      * @function write
@@ -8179,7 +8179,7 @@
                      * @returns {Promise<google.firestore.v1.WriteResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#listen}.
                      * @memberof google.firestore.v1.Firestore
@@ -8188,7 +8188,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.ListenResponse} [response] ListenResponse
                      */
-    
+
                     /**
                      * Calls Listen.
                      * @function listen
@@ -8202,7 +8202,7 @@
                     Object.defineProperty(Firestore.prototype.listen = function listen(request, callback) {
                         return this.rpcCall(listen, $root.google.firestore.v1.ListenRequest, $root.google.firestore.v1.ListenResponse, request, callback);
                     }, "name", { value: "Listen" });
-    
+
                     /**
                      * Calls Listen.
                      * @function listen
@@ -8212,7 +8212,7 @@
                      * @returns {Promise<google.firestore.v1.ListenResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#listCollectionIds}.
                      * @memberof google.firestore.v1.Firestore
@@ -8221,7 +8221,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.ListCollectionIdsResponse} [response] ListCollectionIdsResponse
                      */
-    
+
                     /**
                      * Calls ListCollectionIds.
                      * @function listCollectionIds
@@ -8235,7 +8235,7 @@
                     Object.defineProperty(Firestore.prototype.listCollectionIds = function listCollectionIds(request, callback) {
                         return this.rpcCall(listCollectionIds, $root.google.firestore.v1.ListCollectionIdsRequest, $root.google.firestore.v1.ListCollectionIdsResponse, request, callback);
                     }, "name", { value: "ListCollectionIds" });
-    
+
                     /**
                      * Calls ListCollectionIds.
                      * @function listCollectionIds
@@ -8245,7 +8245,7 @@
                      * @returns {Promise<google.firestore.v1.ListCollectionIdsResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#batchWrite}.
                      * @memberof google.firestore.v1.Firestore
@@ -8254,7 +8254,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.BatchWriteResponse} [response] BatchWriteResponse
                      */
-    
+
                     /**
                      * Calls BatchWrite.
                      * @function batchWrite
@@ -8268,7 +8268,7 @@
                     Object.defineProperty(Firestore.prototype.batchWrite = function batchWrite(request, callback) {
                         return this.rpcCall(batchWrite, $root.google.firestore.v1.BatchWriteRequest, $root.google.firestore.v1.BatchWriteResponse, request, callback);
                     }, "name", { value: "BatchWrite" });
-    
+
                     /**
                      * Calls BatchWrite.
                      * @function batchWrite
@@ -8278,7 +8278,7 @@
                      * @returns {Promise<google.firestore.v1.BatchWriteResponse>} Promise
                      * @variation 2
                      */
-    
+
                     /**
                      * Callback as used by {@link google.firestore.v1.Firestore#createDocument}.
                      * @memberof google.firestore.v1.Firestore
@@ -8287,7 +8287,7 @@
                      * @param {Error|null} error Error, if any
                      * @param {google.firestore.v1.Document} [response] Document
                      */
-    
+
                     /**
                      * Calls CreateDocument.
                      * @function createDocument
@@ -8301,7 +8301,7 @@
                     Object.defineProperty(Firestore.prototype.createDocument = function createDocument(request, callback) {
                         return this.rpcCall(createDocument, $root.google.firestore.v1.CreateDocumentRequest, $root.google.firestore.v1.Document, request, callback);
                     }, "name", { value: "CreateDocument" });
-    
+
                     /**
                      * Calls CreateDocument.
                      * @function createDocument
@@ -8311,12 +8311,12 @@
                      * @returns {Promise<google.firestore.v1.Document>} Promise
                      * @variation 2
                      */
-    
+
                     return Firestore;
                 })();
-    
+
                 v1.GetDocumentRequest = (function() {
-    
+
                     /**
                      * Properties of a GetDocumentRequest.
                      * @memberof google.firestore.v1
@@ -8326,7 +8326,7 @@
                      * @property {Uint8Array|null} [transaction] GetDocumentRequest transaction
                      * @property {google.protobuf.ITimestamp|null} [readTime] GetDocumentRequest readTime
                      */
-    
+
                     /**
                      * Constructs a new GetDocumentRequest.
                      * @memberof google.firestore.v1
@@ -8341,7 +8341,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * GetDocumentRequest name.
                      * @member {string} name
@@ -8349,7 +8349,7 @@
                      * @instance
                      */
                     GetDocumentRequest.prototype.name = "";
-    
+
                     /**
                      * GetDocumentRequest mask.
                      * @member {google.firestore.v1.IDocumentMask|null|undefined} mask
@@ -8357,7 +8357,7 @@
                      * @instance
                      */
                     GetDocumentRequest.prototype.mask = null;
-    
+
                     /**
                      * GetDocumentRequest transaction.
                      * @member {Uint8Array|null|undefined} transaction
@@ -8365,7 +8365,7 @@
                      * @instance
                      */
                     GetDocumentRequest.prototype.transaction = null;
-    
+
                     /**
                      * GetDocumentRequest readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -8373,10 +8373,10 @@
                      * @instance
                      */
                     GetDocumentRequest.prototype.readTime = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * GetDocumentRequest consistencySelector.
                      * @member {"transaction"|"readTime"|undefined} consistencySelector
@@ -8387,7 +8387,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["transaction", "readTime"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a GetDocumentRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -8419,7 +8419,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a GetDocumentRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -8453,7 +8453,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this GetDocumentRequest to JSON.
                      * @function toJSON
@@ -8464,12 +8464,12 @@
                     GetDocumentRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return GetDocumentRequest;
                 })();
-    
+
                 v1.ListDocumentsRequest = (function() {
-    
+
                     /**
                      * Properties of a ListDocumentsRequest.
                      * @memberof google.firestore.v1
@@ -8484,7 +8484,7 @@
                      * @property {google.protobuf.ITimestamp|null} [readTime] ListDocumentsRequest readTime
                      * @property {boolean|null} [showMissing] ListDocumentsRequest showMissing
                      */
-    
+
                     /**
                      * Constructs a new ListDocumentsRequest.
                      * @memberof google.firestore.v1
@@ -8499,7 +8499,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ListDocumentsRequest parent.
                      * @member {string} parent
@@ -8507,7 +8507,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.parent = "";
-    
+
                     /**
                      * ListDocumentsRequest collectionId.
                      * @member {string} collectionId
@@ -8515,7 +8515,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.collectionId = "";
-    
+
                     /**
                      * ListDocumentsRequest pageSize.
                      * @member {number} pageSize
@@ -8523,7 +8523,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.pageSize = 0;
-    
+
                     /**
                      * ListDocumentsRequest pageToken.
                      * @member {string} pageToken
@@ -8531,7 +8531,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.pageToken = "";
-    
+
                     /**
                      * ListDocumentsRequest orderBy.
                      * @member {string} orderBy
@@ -8539,7 +8539,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.orderBy = "";
-    
+
                     /**
                      * ListDocumentsRequest mask.
                      * @member {google.firestore.v1.IDocumentMask|null|undefined} mask
@@ -8547,7 +8547,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.mask = null;
-    
+
                     /**
                      * ListDocumentsRequest transaction.
                      * @member {Uint8Array|null|undefined} transaction
@@ -8555,7 +8555,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.transaction = null;
-    
+
                     /**
                      * ListDocumentsRequest readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -8563,7 +8563,7 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.readTime = null;
-    
+
                     /**
                      * ListDocumentsRequest showMissing.
                      * @member {boolean} showMissing
@@ -8571,10 +8571,10 @@
                      * @instance
                      */
                     ListDocumentsRequest.prototype.showMissing = false;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * ListDocumentsRequest consistencySelector.
                      * @member {"transaction"|"readTime"|undefined} consistencySelector
@@ -8585,7 +8585,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["transaction", "readTime"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a ListDocumentsRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -8627,7 +8627,7 @@
                             message.showMissing = Boolean(object.showMissing);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a ListDocumentsRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -8676,7 +8676,7 @@
                             object.showMissing = message.showMissing;
                         return object;
                     };
-    
+
                     /**
                      * Converts this ListDocumentsRequest to JSON.
                      * @function toJSON
@@ -8687,12 +8687,12 @@
                     ListDocumentsRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ListDocumentsRequest;
                 })();
-    
+
                 v1.ListDocumentsResponse = (function() {
-    
+
                     /**
                      * Properties of a ListDocumentsResponse.
                      * @memberof google.firestore.v1
@@ -8700,7 +8700,7 @@
                      * @property {Array.<google.firestore.v1.IDocument>|null} [documents] ListDocumentsResponse documents
                      * @property {string|null} [nextPageToken] ListDocumentsResponse nextPageToken
                      */
-    
+
                     /**
                      * Constructs a new ListDocumentsResponse.
                      * @memberof google.firestore.v1
@@ -8716,7 +8716,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ListDocumentsResponse documents.
                      * @member {Array.<google.firestore.v1.IDocument>} documents
@@ -8724,7 +8724,7 @@
                      * @instance
                      */
                     ListDocumentsResponse.prototype.documents = $util.emptyArray;
-    
+
                     /**
                      * ListDocumentsResponse nextPageToken.
                      * @member {string} nextPageToken
@@ -8732,7 +8732,7 @@
                      * @instance
                      */
                     ListDocumentsResponse.prototype.nextPageToken = "";
-    
+
                     /**
                      * Creates a ListDocumentsResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -8759,7 +8759,7 @@
                             message.nextPageToken = String(object.nextPageToken);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a ListDocumentsResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -8786,7 +8786,7 @@
                             object.nextPageToken = message.nextPageToken;
                         return object;
                     };
-    
+
                     /**
                      * Converts this ListDocumentsResponse to JSON.
                      * @function toJSON
@@ -8797,12 +8797,12 @@
                     ListDocumentsResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ListDocumentsResponse;
                 })();
-    
+
                 v1.CreateDocumentRequest = (function() {
-    
+
                     /**
                      * Properties of a CreateDocumentRequest.
                      * @memberof google.firestore.v1
@@ -8813,7 +8813,7 @@
                      * @property {google.firestore.v1.IDocument|null} [document] CreateDocumentRequest document
                      * @property {google.firestore.v1.IDocumentMask|null} [mask] CreateDocumentRequest mask
                      */
-    
+
                     /**
                      * Constructs a new CreateDocumentRequest.
                      * @memberof google.firestore.v1
@@ -8828,7 +8828,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * CreateDocumentRequest parent.
                      * @member {string} parent
@@ -8836,7 +8836,7 @@
                      * @instance
                      */
                     CreateDocumentRequest.prototype.parent = "";
-    
+
                     /**
                      * CreateDocumentRequest collectionId.
                      * @member {string} collectionId
@@ -8844,7 +8844,7 @@
                      * @instance
                      */
                     CreateDocumentRequest.prototype.collectionId = "";
-    
+
                     /**
                      * CreateDocumentRequest documentId.
                      * @member {string} documentId
@@ -8852,7 +8852,7 @@
                      * @instance
                      */
                     CreateDocumentRequest.prototype.documentId = "";
-    
+
                     /**
                      * CreateDocumentRequest document.
                      * @member {google.firestore.v1.IDocument|null|undefined} document
@@ -8860,7 +8860,7 @@
                      * @instance
                      */
                     CreateDocumentRequest.prototype.document = null;
-    
+
                     /**
                      * CreateDocumentRequest mask.
                      * @member {google.firestore.v1.IDocumentMask|null|undefined} mask
@@ -8868,7 +8868,7 @@
                      * @instance
                      */
                     CreateDocumentRequest.prototype.mask = null;
-    
+
                     /**
                      * Creates a CreateDocumentRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -8899,7 +8899,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a CreateDocumentRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -8932,7 +8932,7 @@
                             object.mask = $root.google.firestore.v1.DocumentMask.toObject(message.mask, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this CreateDocumentRequest to JSON.
                      * @function toJSON
@@ -8943,12 +8943,12 @@
                     CreateDocumentRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return CreateDocumentRequest;
                 })();
-    
+
                 v1.UpdateDocumentRequest = (function() {
-    
+
                     /**
                      * Properties of an UpdateDocumentRequest.
                      * @memberof google.firestore.v1
@@ -8958,7 +8958,7 @@
                      * @property {google.firestore.v1.IDocumentMask|null} [mask] UpdateDocumentRequest mask
                      * @property {google.firestore.v1.IPrecondition|null} [currentDocument] UpdateDocumentRequest currentDocument
                      */
-    
+
                     /**
                      * Constructs a new UpdateDocumentRequest.
                      * @memberof google.firestore.v1
@@ -8973,7 +8973,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * UpdateDocumentRequest document.
                      * @member {google.firestore.v1.IDocument|null|undefined} document
@@ -8981,7 +8981,7 @@
                      * @instance
                      */
                     UpdateDocumentRequest.prototype.document = null;
-    
+
                     /**
                      * UpdateDocumentRequest updateMask.
                      * @member {google.firestore.v1.IDocumentMask|null|undefined} updateMask
@@ -8989,7 +8989,7 @@
                      * @instance
                      */
                     UpdateDocumentRequest.prototype.updateMask = null;
-    
+
                     /**
                      * UpdateDocumentRequest mask.
                      * @member {google.firestore.v1.IDocumentMask|null|undefined} mask
@@ -8997,7 +8997,7 @@
                      * @instance
                      */
                     UpdateDocumentRequest.prototype.mask = null;
-    
+
                     /**
                      * UpdateDocumentRequest currentDocument.
                      * @member {google.firestore.v1.IPrecondition|null|undefined} currentDocument
@@ -9005,7 +9005,7 @@
                      * @instance
                      */
                     UpdateDocumentRequest.prototype.currentDocument = null;
-    
+
                     /**
                      * Creates an UpdateDocumentRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9040,7 +9040,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from an UpdateDocumentRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -9070,7 +9070,7 @@
                             object.currentDocument = $root.google.firestore.v1.Precondition.toObject(message.currentDocument, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this UpdateDocumentRequest to JSON.
                      * @function toJSON
@@ -9081,12 +9081,12 @@
                     UpdateDocumentRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return UpdateDocumentRequest;
                 })();
-    
+
                 v1.DeleteDocumentRequest = (function() {
-    
+
                     /**
                      * Properties of a DeleteDocumentRequest.
                      * @memberof google.firestore.v1
@@ -9094,7 +9094,7 @@
                      * @property {string|null} [name] DeleteDocumentRequest name
                      * @property {google.firestore.v1.IPrecondition|null} [currentDocument] DeleteDocumentRequest currentDocument
                      */
-    
+
                     /**
                      * Constructs a new DeleteDocumentRequest.
                      * @memberof google.firestore.v1
@@ -9109,7 +9109,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * DeleteDocumentRequest name.
                      * @member {string} name
@@ -9117,7 +9117,7 @@
                      * @instance
                      */
                     DeleteDocumentRequest.prototype.name = "";
-    
+
                     /**
                      * DeleteDocumentRequest currentDocument.
                      * @member {google.firestore.v1.IPrecondition|null|undefined} currentDocument
@@ -9125,7 +9125,7 @@
                      * @instance
                      */
                     DeleteDocumentRequest.prototype.currentDocument = null;
-    
+
                     /**
                      * Creates a DeleteDocumentRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9147,7 +9147,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a DeleteDocumentRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -9171,7 +9171,7 @@
                             object.currentDocument = $root.google.firestore.v1.Precondition.toObject(message.currentDocument, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this DeleteDocumentRequest to JSON.
                      * @function toJSON
@@ -9182,12 +9182,12 @@
                     DeleteDocumentRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return DeleteDocumentRequest;
                 })();
-    
+
                 v1.BatchGetDocumentsRequest = (function() {
-    
+
                     /**
                      * Properties of a BatchGetDocumentsRequest.
                      * @memberof google.firestore.v1
@@ -9199,7 +9199,7 @@
                      * @property {google.firestore.v1.ITransactionOptions|null} [newTransaction] BatchGetDocumentsRequest newTransaction
                      * @property {google.protobuf.ITimestamp|null} [readTime] BatchGetDocumentsRequest readTime
                      */
-    
+
                     /**
                      * Constructs a new BatchGetDocumentsRequest.
                      * @memberof google.firestore.v1
@@ -9215,7 +9215,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * BatchGetDocumentsRequest database.
                      * @member {string} database
@@ -9223,7 +9223,7 @@
                      * @instance
                      */
                     BatchGetDocumentsRequest.prototype.database = "";
-    
+
                     /**
                      * BatchGetDocumentsRequest documents.
                      * @member {Array.<string>} documents
@@ -9231,7 +9231,7 @@
                      * @instance
                      */
                     BatchGetDocumentsRequest.prototype.documents = $util.emptyArray;
-    
+
                     /**
                      * BatchGetDocumentsRequest mask.
                      * @member {google.firestore.v1.IDocumentMask|null|undefined} mask
@@ -9239,7 +9239,7 @@
                      * @instance
                      */
                     BatchGetDocumentsRequest.prototype.mask = null;
-    
+
                     /**
                      * BatchGetDocumentsRequest transaction.
                      * @member {Uint8Array|null|undefined} transaction
@@ -9247,7 +9247,7 @@
                      * @instance
                      */
                     BatchGetDocumentsRequest.prototype.transaction = null;
-    
+
                     /**
                      * BatchGetDocumentsRequest newTransaction.
                      * @member {google.firestore.v1.ITransactionOptions|null|undefined} newTransaction
@@ -9255,7 +9255,7 @@
                      * @instance
                      */
                     BatchGetDocumentsRequest.prototype.newTransaction = null;
-    
+
                     /**
                      * BatchGetDocumentsRequest readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -9263,10 +9263,10 @@
                      * @instance
                      */
                     BatchGetDocumentsRequest.prototype.readTime = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * BatchGetDocumentsRequest consistencySelector.
                      * @member {"transaction"|"newTransaction"|"readTime"|undefined} consistencySelector
@@ -9277,7 +9277,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["transaction", "newTransaction", "readTime"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a BatchGetDocumentsRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9321,7 +9321,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a BatchGetDocumentsRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -9367,7 +9367,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this BatchGetDocumentsRequest to JSON.
                      * @function toJSON
@@ -9378,12 +9378,12 @@
                     BatchGetDocumentsRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return BatchGetDocumentsRequest;
                 })();
-    
+
                 v1.BatchGetDocumentsResponse = (function() {
-    
+
                     /**
                      * Properties of a BatchGetDocumentsResponse.
                      * @memberof google.firestore.v1
@@ -9393,7 +9393,7 @@
                      * @property {Uint8Array|null} [transaction] BatchGetDocumentsResponse transaction
                      * @property {google.protobuf.ITimestamp|null} [readTime] BatchGetDocumentsResponse readTime
                      */
-    
+
                     /**
                      * Constructs a new BatchGetDocumentsResponse.
                      * @memberof google.firestore.v1
@@ -9408,7 +9408,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * BatchGetDocumentsResponse found.
                      * @member {google.firestore.v1.IDocument|null|undefined} found
@@ -9416,7 +9416,7 @@
                      * @instance
                      */
                     BatchGetDocumentsResponse.prototype.found = null;
-    
+
                     /**
                      * BatchGetDocumentsResponse missing.
                      * @member {string|null|undefined} missing
@@ -9424,7 +9424,7 @@
                      * @instance
                      */
                     BatchGetDocumentsResponse.prototype.missing = null;
-    
+
                     /**
                      * BatchGetDocumentsResponse transaction.
                      * @member {Uint8Array} transaction
@@ -9432,7 +9432,7 @@
                      * @instance
                      */
                     BatchGetDocumentsResponse.prototype.transaction = $util.newBuffer([]);
-    
+
                     /**
                      * BatchGetDocumentsResponse readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -9440,10 +9440,10 @@
                      * @instance
                      */
                     BatchGetDocumentsResponse.prototype.readTime = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * BatchGetDocumentsResponse result.
                      * @member {"found"|"missing"|undefined} result
@@ -9454,7 +9454,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["found", "missing"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a BatchGetDocumentsResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9486,7 +9486,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a BatchGetDocumentsResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -9526,7 +9526,7 @@
                             object.readTime = $root.google.protobuf.Timestamp.toObject(message.readTime, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this BatchGetDocumentsResponse to JSON.
                      * @function toJSON
@@ -9537,12 +9537,12 @@
                     BatchGetDocumentsResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return BatchGetDocumentsResponse;
                 })();
-    
+
                 v1.BeginTransactionRequest = (function() {
-    
+
                     /**
                      * Properties of a BeginTransactionRequest.
                      * @memberof google.firestore.v1
@@ -9550,7 +9550,7 @@
                      * @property {string|null} [database] BeginTransactionRequest database
                      * @property {google.firestore.v1.ITransactionOptions|null} [options] BeginTransactionRequest options
                      */
-    
+
                     /**
                      * Constructs a new BeginTransactionRequest.
                      * @memberof google.firestore.v1
@@ -9565,7 +9565,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * BeginTransactionRequest database.
                      * @member {string} database
@@ -9573,7 +9573,7 @@
                      * @instance
                      */
                     BeginTransactionRequest.prototype.database = "";
-    
+
                     /**
                      * BeginTransactionRequest options.
                      * @member {google.firestore.v1.ITransactionOptions|null|undefined} options
@@ -9581,7 +9581,7 @@
                      * @instance
                      */
                     BeginTransactionRequest.prototype.options = null;
-    
+
                     /**
                      * Creates a BeginTransactionRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9603,7 +9603,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a BeginTransactionRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -9627,7 +9627,7 @@
                             object.options = $root.google.firestore.v1.TransactionOptions.toObject(message.options, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this BeginTransactionRequest to JSON.
                      * @function toJSON
@@ -9638,19 +9638,19 @@
                     BeginTransactionRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return BeginTransactionRequest;
                 })();
-    
+
                 v1.BeginTransactionResponse = (function() {
-    
+
                     /**
                      * Properties of a BeginTransactionResponse.
                      * @memberof google.firestore.v1
                      * @interface IBeginTransactionResponse
                      * @property {Uint8Array|null} [transaction] BeginTransactionResponse transaction
                      */
-    
+
                     /**
                      * Constructs a new BeginTransactionResponse.
                      * @memberof google.firestore.v1
@@ -9665,7 +9665,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * BeginTransactionResponse transaction.
                      * @member {Uint8Array} transaction
@@ -9673,7 +9673,7 @@
                      * @instance
                      */
                     BeginTransactionResponse.prototype.transaction = $util.newBuffer([]);
-    
+
                     /**
                      * Creates a BeginTransactionResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9693,7 +9693,7 @@
                                 message.transaction = object.transaction;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a BeginTransactionResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -9719,7 +9719,7 @@
                             object.transaction = options.bytes === String ? $util.base64.encode(message.transaction, 0, message.transaction.length) : options.bytes === Array ? Array.prototype.slice.call(message.transaction) : message.transaction;
                         return object;
                     };
-    
+
                     /**
                      * Converts this BeginTransactionResponse to JSON.
                      * @function toJSON
@@ -9730,12 +9730,12 @@
                     BeginTransactionResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return BeginTransactionResponse;
                 })();
-    
+
                 v1.CommitRequest = (function() {
-    
+
                     /**
                      * Properties of a CommitRequest.
                      * @memberof google.firestore.v1
@@ -9744,7 +9744,7 @@
                      * @property {Array.<google.firestore.v1.IWrite>|null} [writes] CommitRequest writes
                      * @property {Uint8Array|null} [transaction] CommitRequest transaction
                      */
-    
+
                     /**
                      * Constructs a new CommitRequest.
                      * @memberof google.firestore.v1
@@ -9760,7 +9760,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * CommitRequest database.
                      * @member {string} database
@@ -9768,7 +9768,7 @@
                      * @instance
                      */
                     CommitRequest.prototype.database = "";
-    
+
                     /**
                      * CommitRequest writes.
                      * @member {Array.<google.firestore.v1.IWrite>} writes
@@ -9776,7 +9776,7 @@
                      * @instance
                      */
                     CommitRequest.prototype.writes = $util.emptyArray;
-    
+
                     /**
                      * CommitRequest transaction.
                      * @member {Uint8Array} transaction
@@ -9784,7 +9784,7 @@
                      * @instance
                      */
                     CommitRequest.prototype.transaction = $util.newBuffer([]);
-    
+
                     /**
                      * Creates a CommitRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9816,7 +9816,7 @@
                                 message.transaction = object.transaction;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a CommitRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -9853,7 +9853,7 @@
                             object.transaction = options.bytes === String ? $util.base64.encode(message.transaction, 0, message.transaction.length) : options.bytes === Array ? Array.prototype.slice.call(message.transaction) : message.transaction;
                         return object;
                     };
-    
+
                     /**
                      * Converts this CommitRequest to JSON.
                      * @function toJSON
@@ -9864,12 +9864,12 @@
                     CommitRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return CommitRequest;
                 })();
-    
+
                 v1.CommitResponse = (function() {
-    
+
                     /**
                      * Properties of a CommitResponse.
                      * @memberof google.firestore.v1
@@ -9877,7 +9877,7 @@
                      * @property {Array.<google.firestore.v1.IWriteResult>|null} [writeResults] CommitResponse writeResults
                      * @property {google.protobuf.ITimestamp|null} [commitTime] CommitResponse commitTime
                      */
-    
+
                     /**
                      * Constructs a new CommitResponse.
                      * @memberof google.firestore.v1
@@ -9893,7 +9893,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * CommitResponse writeResults.
                      * @member {Array.<google.firestore.v1.IWriteResult>} writeResults
@@ -9901,7 +9901,7 @@
                      * @instance
                      */
                     CommitResponse.prototype.writeResults = $util.emptyArray;
-    
+
                     /**
                      * CommitResponse commitTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} commitTime
@@ -9909,7 +9909,7 @@
                      * @instance
                      */
                     CommitResponse.prototype.commitTime = null;
-    
+
                     /**
                      * Creates a CommitResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -9939,7 +9939,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a CommitResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -9966,7 +9966,7 @@
                             object.commitTime = $root.google.protobuf.Timestamp.toObject(message.commitTime, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this CommitResponse to JSON.
                      * @function toJSON
@@ -9977,12 +9977,12 @@
                     CommitResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return CommitResponse;
                 })();
-    
+
                 v1.RollbackRequest = (function() {
-    
+
                     /**
                      * Properties of a RollbackRequest.
                      * @memberof google.firestore.v1
@@ -9990,7 +9990,7 @@
                      * @property {string|null} [database] RollbackRequest database
                      * @property {Uint8Array|null} [transaction] RollbackRequest transaction
                      */
-    
+
                     /**
                      * Constructs a new RollbackRequest.
                      * @memberof google.firestore.v1
@@ -10005,7 +10005,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * RollbackRequest database.
                      * @member {string} database
@@ -10013,7 +10013,7 @@
                      * @instance
                      */
                     RollbackRequest.prototype.database = "";
-    
+
                     /**
                      * RollbackRequest transaction.
                      * @member {Uint8Array} transaction
@@ -10021,7 +10021,7 @@
                      * @instance
                      */
                     RollbackRequest.prototype.transaction = $util.newBuffer([]);
-    
+
                     /**
                      * Creates a RollbackRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -10043,7 +10043,7 @@
                                 message.transaction = object.transaction;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a RollbackRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -10073,7 +10073,7 @@
                             object.transaction = options.bytes === String ? $util.base64.encode(message.transaction, 0, message.transaction.length) : options.bytes === Array ? Array.prototype.slice.call(message.transaction) : message.transaction;
                         return object;
                     };
-    
+
                     /**
                      * Converts this RollbackRequest to JSON.
                      * @function toJSON
@@ -10084,12 +10084,12 @@
                     RollbackRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return RollbackRequest;
                 })();
-    
+
                 v1.RunQueryRequest = (function() {
-    
+
                     /**
                      * Properties of a RunQueryRequest.
                      * @memberof google.firestore.v1
@@ -10100,7 +10100,7 @@
                      * @property {google.firestore.v1.ITransactionOptions|null} [newTransaction] RunQueryRequest newTransaction
                      * @property {google.protobuf.ITimestamp|null} [readTime] RunQueryRequest readTime
                      */
-    
+
                     /**
                      * Constructs a new RunQueryRequest.
                      * @memberof google.firestore.v1
@@ -10115,7 +10115,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * RunQueryRequest parent.
                      * @member {string} parent
@@ -10123,7 +10123,7 @@
                      * @instance
                      */
                     RunQueryRequest.prototype.parent = "";
-    
+
                     /**
                      * RunQueryRequest structuredQuery.
                      * @member {google.firestore.v1.IStructuredQuery|null|undefined} structuredQuery
@@ -10131,7 +10131,7 @@
                      * @instance
                      */
                     RunQueryRequest.prototype.structuredQuery = null;
-    
+
                     /**
                      * RunQueryRequest transaction.
                      * @member {Uint8Array|null|undefined} transaction
@@ -10139,7 +10139,7 @@
                      * @instance
                      */
                     RunQueryRequest.prototype.transaction = null;
-    
+
                     /**
                      * RunQueryRequest newTransaction.
                      * @member {google.firestore.v1.ITransactionOptions|null|undefined} newTransaction
@@ -10147,7 +10147,7 @@
                      * @instance
                      */
                     RunQueryRequest.prototype.newTransaction = null;
-    
+
                     /**
                      * RunQueryRequest readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -10155,10 +10155,10 @@
                      * @instance
                      */
                     RunQueryRequest.prototype.readTime = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * RunQueryRequest queryType.
                      * @member {"structuredQuery"|undefined} queryType
@@ -10169,7 +10169,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["structuredQuery"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * RunQueryRequest consistencySelector.
                      * @member {"transaction"|"newTransaction"|"readTime"|undefined} consistencySelector
@@ -10180,7 +10180,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["transaction", "newTransaction", "readTime"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a RunQueryRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -10217,7 +10217,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a RunQueryRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -10257,7 +10257,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this RunQueryRequest to JSON.
                      * @function toJSON
@@ -10268,12 +10268,12 @@
                     RunQueryRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return RunQueryRequest;
                 })();
-    
+
                 v1.RunQueryResponse = (function() {
-    
+
                     /**
                      * Properties of a RunQueryResponse.
                      * @memberof google.firestore.v1
@@ -10283,7 +10283,7 @@
                      * @property {google.protobuf.ITimestamp|null} [readTime] RunQueryResponse readTime
                      * @property {number|null} [skippedResults] RunQueryResponse skippedResults
                      */
-    
+
                     /**
                      * Constructs a new RunQueryResponse.
                      * @memberof google.firestore.v1
@@ -10298,7 +10298,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * RunQueryResponse transaction.
                      * @member {Uint8Array} transaction
@@ -10306,7 +10306,7 @@
                      * @instance
                      */
                     RunQueryResponse.prototype.transaction = $util.newBuffer([]);
-    
+
                     /**
                      * RunQueryResponse document.
                      * @member {google.firestore.v1.IDocument|null|undefined} document
@@ -10314,7 +10314,7 @@
                      * @instance
                      */
                     RunQueryResponse.prototype.document = null;
-    
+
                     /**
                      * RunQueryResponse readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -10322,7 +10322,7 @@
                      * @instance
                      */
                     RunQueryResponse.prototype.readTime = null;
-    
+
                     /**
                      * RunQueryResponse skippedResults.
                      * @member {number} skippedResults
@@ -10330,7 +10330,7 @@
                      * @instance
                      */
                     RunQueryResponse.prototype.skippedResults = 0;
-    
+
                     /**
                      * Creates a RunQueryResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -10362,7 +10362,7 @@
                             message.skippedResults = object.skippedResults | 0;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a RunQueryResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -10398,7 +10398,7 @@
                             object.skippedResults = message.skippedResults;
                         return object;
                     };
-    
+
                     /**
                      * Converts this RunQueryResponse to JSON.
                      * @function toJSON
@@ -10409,12 +10409,12 @@
                     RunQueryResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return RunQueryResponse;
                 })();
-    
+
                 v1.PartitionQueryRequest = (function() {
-    
+
                     /**
                      * Properties of a PartitionQueryRequest.
                      * @memberof google.firestore.v1
@@ -10425,7 +10425,7 @@
                      * @property {string|null} [pageToken] PartitionQueryRequest pageToken
                      * @property {number|null} [pageSize] PartitionQueryRequest pageSize
                      */
-    
+
                     /**
                      * Constructs a new PartitionQueryRequest.
                      * @memberof google.firestore.v1
@@ -10440,7 +10440,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * PartitionQueryRequest parent.
                      * @member {string} parent
@@ -10448,7 +10448,7 @@
                      * @instance
                      */
                     PartitionQueryRequest.prototype.parent = "";
-    
+
                     /**
                      * PartitionQueryRequest structuredQuery.
                      * @member {google.firestore.v1.IStructuredQuery|null|undefined} structuredQuery
@@ -10456,7 +10456,7 @@
                      * @instance
                      */
                     PartitionQueryRequest.prototype.structuredQuery = null;
-    
+
                     /**
                      * PartitionQueryRequest partitionCount.
                      * @member {number|string} partitionCount
@@ -10464,7 +10464,7 @@
                      * @instance
                      */
                     PartitionQueryRequest.prototype.partitionCount = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-    
+
                     /**
                      * PartitionQueryRequest pageToken.
                      * @member {string} pageToken
@@ -10472,7 +10472,7 @@
                      * @instance
                      */
                     PartitionQueryRequest.prototype.pageToken = "";
-    
+
                     /**
                      * PartitionQueryRequest pageSize.
                      * @member {number} pageSize
@@ -10480,10 +10480,10 @@
                      * @instance
                      */
                     PartitionQueryRequest.prototype.pageSize = 0;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * PartitionQueryRequest queryType.
                      * @member {"structuredQuery"|undefined} queryType
@@ -10494,7 +10494,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["structuredQuery"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a PartitionQueryRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -10529,7 +10529,7 @@
                             message.pageSize = object.pageSize | 0;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a PartitionQueryRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -10571,7 +10571,7 @@
                             object.pageSize = message.pageSize;
                         return object;
                     };
-    
+
                     /**
                      * Converts this PartitionQueryRequest to JSON.
                      * @function toJSON
@@ -10582,12 +10582,12 @@
                     PartitionQueryRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return PartitionQueryRequest;
                 })();
-    
+
                 v1.PartitionQueryResponse = (function() {
-    
+
                     /**
                      * Properties of a PartitionQueryResponse.
                      * @memberof google.firestore.v1
@@ -10595,7 +10595,7 @@
                      * @property {Array.<google.firestore.v1.ICursor>|null} [partitions] PartitionQueryResponse partitions
                      * @property {string|null} [nextPageToken] PartitionQueryResponse nextPageToken
                      */
-    
+
                     /**
                      * Constructs a new PartitionQueryResponse.
                      * @memberof google.firestore.v1
@@ -10611,7 +10611,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * PartitionQueryResponse partitions.
                      * @member {Array.<google.firestore.v1.ICursor>} partitions
@@ -10619,7 +10619,7 @@
                      * @instance
                      */
                     PartitionQueryResponse.prototype.partitions = $util.emptyArray;
-    
+
                     /**
                      * PartitionQueryResponse nextPageToken.
                      * @member {string} nextPageToken
@@ -10627,7 +10627,7 @@
                      * @instance
                      */
                     PartitionQueryResponse.prototype.nextPageToken = "";
-    
+
                     /**
                      * Creates a PartitionQueryResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -10654,7 +10654,7 @@
                             message.nextPageToken = String(object.nextPageToken);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a PartitionQueryResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -10681,7 +10681,7 @@
                             object.nextPageToken = message.nextPageToken;
                         return object;
                     };
-    
+
                     /**
                      * Converts this PartitionQueryResponse to JSON.
                      * @function toJSON
@@ -10692,12 +10692,12 @@
                     PartitionQueryResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return PartitionQueryResponse;
                 })();
-    
+
                 v1.WriteRequest = (function() {
-    
+
                     /**
                      * Properties of a WriteRequest.
                      * @memberof google.firestore.v1
@@ -10708,7 +10708,7 @@
                      * @property {Uint8Array|null} [streamToken] WriteRequest streamToken
                      * @property {Object.<string,string>|null} [labels] WriteRequest labels
                      */
-    
+
                     /**
                      * Constructs a new WriteRequest.
                      * @memberof google.firestore.v1
@@ -10725,7 +10725,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * WriteRequest database.
                      * @member {string} database
@@ -10733,7 +10733,7 @@
                      * @instance
                      */
                     WriteRequest.prototype.database = "";
-    
+
                     /**
                      * WriteRequest streamId.
                      * @member {string} streamId
@@ -10741,7 +10741,7 @@
                      * @instance
                      */
                     WriteRequest.prototype.streamId = "";
-    
+
                     /**
                      * WriteRequest writes.
                      * @member {Array.<google.firestore.v1.IWrite>} writes
@@ -10749,7 +10749,7 @@
                      * @instance
                      */
                     WriteRequest.prototype.writes = $util.emptyArray;
-    
+
                     /**
                      * WriteRequest streamToken.
                      * @member {Uint8Array} streamToken
@@ -10757,7 +10757,7 @@
                      * @instance
                      */
                     WriteRequest.prototype.streamToken = $util.newBuffer([]);
-    
+
                     /**
                      * WriteRequest labels.
                      * @member {Object.<string,string>} labels
@@ -10765,7 +10765,7 @@
                      * @instance
                      */
                     WriteRequest.prototype.labels = $util.emptyObject;
-    
+
                     /**
                      * Creates a WriteRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -10806,7 +10806,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a WriteRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -10854,7 +10854,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this WriteRequest to JSON.
                      * @function toJSON
@@ -10865,12 +10865,12 @@
                     WriteRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return WriteRequest;
                 })();
-    
+
                 v1.WriteResponse = (function() {
-    
+
                     /**
                      * Properties of a WriteResponse.
                      * @memberof google.firestore.v1
@@ -10880,7 +10880,7 @@
                      * @property {Array.<google.firestore.v1.IWriteResult>|null} [writeResults] WriteResponse writeResults
                      * @property {google.protobuf.ITimestamp|null} [commitTime] WriteResponse commitTime
                      */
-    
+
                     /**
                      * Constructs a new WriteResponse.
                      * @memberof google.firestore.v1
@@ -10896,7 +10896,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * WriteResponse streamId.
                      * @member {string} streamId
@@ -10904,7 +10904,7 @@
                      * @instance
                      */
                     WriteResponse.prototype.streamId = "";
-    
+
                     /**
                      * WriteResponse streamToken.
                      * @member {Uint8Array} streamToken
@@ -10912,7 +10912,7 @@
                      * @instance
                      */
                     WriteResponse.prototype.streamToken = $util.newBuffer([]);
-    
+
                     /**
                      * WriteResponse writeResults.
                      * @member {Array.<google.firestore.v1.IWriteResult>} writeResults
@@ -10920,7 +10920,7 @@
                      * @instance
                      */
                     WriteResponse.prototype.writeResults = $util.emptyArray;
-    
+
                     /**
                      * WriteResponse commitTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} commitTime
@@ -10928,7 +10928,7 @@
                      * @instance
                      */
                     WriteResponse.prototype.commitTime = null;
-    
+
                     /**
                      * Creates a WriteResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -10965,7 +10965,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a WriteResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -11005,7 +11005,7 @@
                             object.commitTime = $root.google.protobuf.Timestamp.toObject(message.commitTime, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this WriteResponse to JSON.
                      * @function toJSON
@@ -11016,12 +11016,12 @@
                     WriteResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return WriteResponse;
                 })();
-    
+
                 v1.ListenRequest = (function() {
-    
+
                     /**
                      * Properties of a ListenRequest.
                      * @memberof google.firestore.v1
@@ -11031,7 +11031,7 @@
                      * @property {number|null} [removeTarget] ListenRequest removeTarget
                      * @property {Object.<string,string>|null} [labels] ListenRequest labels
                      */
-    
+
                     /**
                      * Constructs a new ListenRequest.
                      * @memberof google.firestore.v1
@@ -11047,7 +11047,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ListenRequest database.
                      * @member {string} database
@@ -11055,7 +11055,7 @@
                      * @instance
                      */
                     ListenRequest.prototype.database = "";
-    
+
                     /**
                      * ListenRequest addTarget.
                      * @member {google.firestore.v1.ITarget|null|undefined} addTarget
@@ -11063,7 +11063,7 @@
                      * @instance
                      */
                     ListenRequest.prototype.addTarget = null;
-    
+
                     /**
                      * ListenRequest removeTarget.
                      * @member {number|null|undefined} removeTarget
@@ -11071,7 +11071,7 @@
                      * @instance
                      */
                     ListenRequest.prototype.removeTarget = null;
-    
+
                     /**
                      * ListenRequest labels.
                      * @member {Object.<string,string>} labels
@@ -11079,10 +11079,10 @@
                      * @instance
                      */
                     ListenRequest.prototype.labels = $util.emptyObject;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * ListenRequest targetChange.
                      * @member {"addTarget"|"removeTarget"|undefined} targetChange
@@ -11093,7 +11093,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["addTarget", "removeTarget"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a ListenRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -11124,7 +11124,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a ListenRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -11162,7 +11162,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this ListenRequest to JSON.
                      * @function toJSON
@@ -11173,12 +11173,12 @@
                     ListenRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ListenRequest;
                 })();
-    
+
                 v1.ListenResponse = (function() {
-    
+
                     /**
                      * Properties of a ListenResponse.
                      * @memberof google.firestore.v1
@@ -11189,7 +11189,7 @@
                      * @property {google.firestore.v1.IDocumentRemove|null} [documentRemove] ListenResponse documentRemove
                      * @property {google.firestore.v1.IExistenceFilter|null} [filter] ListenResponse filter
                      */
-    
+
                     /**
                      * Constructs a new ListenResponse.
                      * @memberof google.firestore.v1
@@ -11204,7 +11204,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ListenResponse targetChange.
                      * @member {google.firestore.v1.ITargetChange|null|undefined} targetChange
@@ -11212,7 +11212,7 @@
                      * @instance
                      */
                     ListenResponse.prototype.targetChange = null;
-    
+
                     /**
                      * ListenResponse documentChange.
                      * @member {google.firestore.v1.IDocumentChange|null|undefined} documentChange
@@ -11220,7 +11220,7 @@
                      * @instance
                      */
                     ListenResponse.prototype.documentChange = null;
-    
+
                     /**
                      * ListenResponse documentDelete.
                      * @member {google.firestore.v1.IDocumentDelete|null|undefined} documentDelete
@@ -11228,7 +11228,7 @@
                      * @instance
                      */
                     ListenResponse.prototype.documentDelete = null;
-    
+
                     /**
                      * ListenResponse documentRemove.
                      * @member {google.firestore.v1.IDocumentRemove|null|undefined} documentRemove
@@ -11236,7 +11236,7 @@
                      * @instance
                      */
                     ListenResponse.prototype.documentRemove = null;
-    
+
                     /**
                      * ListenResponse filter.
                      * @member {google.firestore.v1.IExistenceFilter|null|undefined} filter
@@ -11244,10 +11244,10 @@
                      * @instance
                      */
                     ListenResponse.prototype.filter = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * ListenResponse responseType.
                      * @member {"targetChange"|"documentChange"|"documentDelete"|"documentRemove"|"filter"|undefined} responseType
@@ -11258,7 +11258,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["targetChange", "documentChange", "documentDelete", "documentRemove", "filter"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a ListenResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -11298,7 +11298,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a ListenResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -11339,7 +11339,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this ListenResponse to JSON.
                      * @function toJSON
@@ -11350,12 +11350,12 @@
                     ListenResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ListenResponse;
                 })();
-    
+
                 v1.Target = (function() {
-    
+
                     /**
                      * Properties of a Target.
                      * @memberof google.firestore.v1
@@ -11367,7 +11367,7 @@
                      * @property {number|null} [targetId] Target targetId
                      * @property {boolean|null} [once] Target once
                      */
-    
+
                     /**
                      * Constructs a new Target.
                      * @memberof google.firestore.v1
@@ -11382,7 +11382,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Target query.
                      * @member {google.firestore.v1.Target.IQueryTarget|null|undefined} query
@@ -11390,7 +11390,7 @@
                      * @instance
                      */
                     Target.prototype.query = null;
-    
+
                     /**
                      * Target documents.
                      * @member {google.firestore.v1.Target.IDocumentsTarget|null|undefined} documents
@@ -11398,7 +11398,7 @@
                      * @instance
                      */
                     Target.prototype.documents = null;
-    
+
                     /**
                      * Target resumeToken.
                      * @member {Uint8Array|null|undefined} resumeToken
@@ -11406,7 +11406,7 @@
                      * @instance
                      */
                     Target.prototype.resumeToken = null;
-    
+
                     /**
                      * Target readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -11414,7 +11414,7 @@
                      * @instance
                      */
                     Target.prototype.readTime = null;
-    
+
                     /**
                      * Target targetId.
                      * @member {number} targetId
@@ -11422,7 +11422,7 @@
                      * @instance
                      */
                     Target.prototype.targetId = 0;
-    
+
                     /**
                      * Target once.
                      * @member {boolean} once
@@ -11430,10 +11430,10 @@
                      * @instance
                      */
                     Target.prototype.once = false;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * Target targetType.
                      * @member {"query"|"documents"|undefined} targetType
@@ -11444,7 +11444,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["query", "documents"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Target resumeType.
                      * @member {"resumeToken"|"readTime"|undefined} resumeType
@@ -11455,7 +11455,7 @@
                         get: $util.oneOfGetter($oneOfFields = ["resumeToken", "readTime"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a Target message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -11494,7 +11494,7 @@
                             message.once = Boolean(object.once);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a Target message. Also converts values to other types if specified.
                      * @function toObject
@@ -11538,7 +11538,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this Target to JSON.
                      * @function toJSON
@@ -11549,16 +11549,16 @@
                     Target.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     Target.DocumentsTarget = (function() {
-    
+
                         /**
                          * Properties of a DocumentsTarget.
                          * @memberof google.firestore.v1.Target
                          * @interface IDocumentsTarget
                          * @property {Array.<string>|null} [documents] DocumentsTarget documents
                          */
-    
+
                         /**
                          * Constructs a new DocumentsTarget.
                          * @memberof google.firestore.v1.Target
@@ -11574,7 +11574,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * DocumentsTarget documents.
                          * @member {Array.<string>} documents
@@ -11582,7 +11582,7 @@
                          * @instance
                          */
                         DocumentsTarget.prototype.documents = $util.emptyArray;
-    
+
                         /**
                          * Creates a DocumentsTarget message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -11604,7 +11604,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a DocumentsTarget message. Also converts values to other types if specified.
                          * @function toObject
@@ -11627,7 +11627,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this DocumentsTarget to JSON.
                          * @function toJSON
@@ -11638,12 +11638,12 @@
                         DocumentsTarget.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return DocumentsTarget;
                     })();
-    
+
                     Target.QueryTarget = (function() {
-    
+
                         /**
                          * Properties of a QueryTarget.
                          * @memberof google.firestore.v1.Target
@@ -11651,7 +11651,7 @@
                          * @property {string|null} [parent] QueryTarget parent
                          * @property {google.firestore.v1.IStructuredQuery|null} [structuredQuery] QueryTarget structuredQuery
                          */
-    
+
                         /**
                          * Constructs a new QueryTarget.
                          * @memberof google.firestore.v1.Target
@@ -11666,7 +11666,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * QueryTarget parent.
                          * @member {string} parent
@@ -11674,7 +11674,7 @@
                          * @instance
                          */
                         QueryTarget.prototype.parent = "";
-    
+
                         /**
                          * QueryTarget structuredQuery.
                          * @member {google.firestore.v1.IStructuredQuery|null|undefined} structuredQuery
@@ -11682,10 +11682,10 @@
                          * @instance
                          */
                         QueryTarget.prototype.structuredQuery = null;
-    
+
                         // OneOf field names bound to virtual getters and setters
                         var $oneOfFields;
-    
+
                         /**
                          * QueryTarget queryType.
                          * @member {"structuredQuery"|undefined} queryType
@@ -11696,7 +11696,7 @@
                             get: $util.oneOfGetter($oneOfFields = ["structuredQuery"]),
                             set: $util.oneOfSetter($oneOfFields)
                         });
-    
+
                         /**
                          * Creates a QueryTarget message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -11718,7 +11718,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a QueryTarget message. Also converts values to other types if specified.
                          * @function toObject
@@ -11743,7 +11743,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this QueryTarget to JSON.
                          * @function toJSON
@@ -11754,15 +11754,15 @@
                         QueryTarget.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return QueryTarget;
                     })();
-    
+
                     return Target;
                 })();
-    
+
                 v1.TargetChange = (function() {
-    
+
                     /**
                      * Properties of a TargetChange.
                      * @memberof google.firestore.v1
@@ -11773,7 +11773,7 @@
                      * @property {Uint8Array|null} [resumeToken] TargetChange resumeToken
                      * @property {google.protobuf.ITimestamp|null} [readTime] TargetChange readTime
                      */
-    
+
                     /**
                      * Constructs a new TargetChange.
                      * @memberof google.firestore.v1
@@ -11789,7 +11789,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * TargetChange targetChangeType.
                      * @member {google.firestore.v1.TargetChange.TargetChangeType} targetChangeType
@@ -11797,7 +11797,7 @@
                      * @instance
                      */
                     TargetChange.prototype.targetChangeType = 0;
-    
+
                     /**
                      * TargetChange targetIds.
                      * @member {Array.<number>} targetIds
@@ -11805,7 +11805,7 @@
                      * @instance
                      */
                     TargetChange.prototype.targetIds = $util.emptyArray;
-    
+
                     /**
                      * TargetChange cause.
                      * @member {google.rpc.IStatus|null|undefined} cause
@@ -11813,7 +11813,7 @@
                      * @instance
                      */
                     TargetChange.prototype.cause = null;
-    
+
                     /**
                      * TargetChange resumeToken.
                      * @member {Uint8Array} resumeToken
@@ -11821,7 +11821,7 @@
                      * @instance
                      */
                     TargetChange.prototype.resumeToken = $util.newBuffer([]);
-    
+
                     /**
                      * TargetChange readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -11829,7 +11829,7 @@
                      * @instance
                      */
                     TargetChange.prototype.readTime = null;
-    
+
                     /**
                      * Creates a TargetChange message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -11888,7 +11888,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a TargetChange message. Also converts values to other types if specified.
                      * @function toObject
@@ -11931,7 +11931,7 @@
                             object.readTime = $root.google.protobuf.Timestamp.toObject(message.readTime, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this TargetChange to JSON.
                      * @function toJSON
@@ -11942,7 +11942,7 @@
                     TargetChange.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     /**
                      * TargetChangeType enum.
                      * @name google.firestore.v1.TargetChange.TargetChangeType
@@ -11962,12 +11962,12 @@
                         values[valuesById[4] = "RESET"] = "RESET";
                         return values;
                     })();
-    
+
                     return TargetChange;
                 })();
-    
+
                 v1.ListCollectionIdsRequest = (function() {
-    
+
                     /**
                      * Properties of a ListCollectionIdsRequest.
                      * @memberof google.firestore.v1
@@ -11976,7 +11976,7 @@
                      * @property {number|null} [pageSize] ListCollectionIdsRequest pageSize
                      * @property {string|null} [pageToken] ListCollectionIdsRequest pageToken
                      */
-    
+
                     /**
                      * Constructs a new ListCollectionIdsRequest.
                      * @memberof google.firestore.v1
@@ -11991,7 +11991,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ListCollectionIdsRequest parent.
                      * @member {string} parent
@@ -11999,7 +11999,7 @@
                      * @instance
                      */
                     ListCollectionIdsRequest.prototype.parent = "";
-    
+
                     /**
                      * ListCollectionIdsRequest pageSize.
                      * @member {number} pageSize
@@ -12007,7 +12007,7 @@
                      * @instance
                      */
                     ListCollectionIdsRequest.prototype.pageSize = 0;
-    
+
                     /**
                      * ListCollectionIdsRequest pageToken.
                      * @member {string} pageToken
@@ -12015,7 +12015,7 @@
                      * @instance
                      */
                     ListCollectionIdsRequest.prototype.pageToken = "";
-    
+
                     /**
                      * Creates a ListCollectionIdsRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -12036,7 +12036,7 @@
                             message.pageToken = String(object.pageToken);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a ListCollectionIdsRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -12063,7 +12063,7 @@
                             object.pageToken = message.pageToken;
                         return object;
                     };
-    
+
                     /**
                      * Converts this ListCollectionIdsRequest to JSON.
                      * @function toJSON
@@ -12074,12 +12074,12 @@
                     ListCollectionIdsRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ListCollectionIdsRequest;
                 })();
-    
+
                 v1.ListCollectionIdsResponse = (function() {
-    
+
                     /**
                      * Properties of a ListCollectionIdsResponse.
                      * @memberof google.firestore.v1
@@ -12087,7 +12087,7 @@
                      * @property {Array.<string>|null} [collectionIds] ListCollectionIdsResponse collectionIds
                      * @property {string|null} [nextPageToken] ListCollectionIdsResponse nextPageToken
                      */
-    
+
                     /**
                      * Constructs a new ListCollectionIdsResponse.
                      * @memberof google.firestore.v1
@@ -12103,7 +12103,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ListCollectionIdsResponse collectionIds.
                      * @member {Array.<string>} collectionIds
@@ -12111,7 +12111,7 @@
                      * @instance
                      */
                     ListCollectionIdsResponse.prototype.collectionIds = $util.emptyArray;
-    
+
                     /**
                      * ListCollectionIdsResponse nextPageToken.
                      * @member {string} nextPageToken
@@ -12119,7 +12119,7 @@
                      * @instance
                      */
                     ListCollectionIdsResponse.prototype.nextPageToken = "";
-    
+
                     /**
                      * Creates a ListCollectionIdsResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -12143,7 +12143,7 @@
                             message.nextPageToken = String(object.nextPageToken);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a ListCollectionIdsResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -12170,7 +12170,7 @@
                             object.nextPageToken = message.nextPageToken;
                         return object;
                     };
-    
+
                     /**
                      * Converts this ListCollectionIdsResponse to JSON.
                      * @function toJSON
@@ -12181,12 +12181,12 @@
                     ListCollectionIdsResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ListCollectionIdsResponse;
                 })();
-    
+
                 v1.BatchWriteRequest = (function() {
-    
+
                     /**
                      * Properties of a BatchWriteRequest.
                      * @memberof google.firestore.v1
@@ -12195,7 +12195,7 @@
                      * @property {Array.<google.firestore.v1.IWrite>|null} [writes] BatchWriteRequest writes
                      * @property {Object.<string,string>|null} [labels] BatchWriteRequest labels
                      */
-    
+
                     /**
                      * Constructs a new BatchWriteRequest.
                      * @memberof google.firestore.v1
@@ -12212,7 +12212,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * BatchWriteRequest database.
                      * @member {string} database
@@ -12220,7 +12220,7 @@
                      * @instance
                      */
                     BatchWriteRequest.prototype.database = "";
-    
+
                     /**
                      * BatchWriteRequest writes.
                      * @member {Array.<google.firestore.v1.IWrite>} writes
@@ -12228,7 +12228,7 @@
                      * @instance
                      */
                     BatchWriteRequest.prototype.writes = $util.emptyArray;
-    
+
                     /**
                      * BatchWriteRequest labels.
                      * @member {Object.<string,string>} labels
@@ -12236,7 +12236,7 @@
                      * @instance
                      */
                     BatchWriteRequest.prototype.labels = $util.emptyObject;
-    
+
                     /**
                      * Creates a BatchWriteRequest message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -12270,7 +12270,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a BatchWriteRequest message. Also converts values to other types if specified.
                      * @function toObject
@@ -12305,7 +12305,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this BatchWriteRequest to JSON.
                      * @function toJSON
@@ -12316,12 +12316,12 @@
                     BatchWriteRequest.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return BatchWriteRequest;
                 })();
-    
+
                 v1.BatchWriteResponse = (function() {
-    
+
                     /**
                      * Properties of a BatchWriteResponse.
                      * @memberof google.firestore.v1
@@ -12329,7 +12329,7 @@
                      * @property {Array.<google.firestore.v1.IWriteResult>|null} [writeResults] BatchWriteResponse writeResults
                      * @property {Array.<google.rpc.IStatus>|null} [status] BatchWriteResponse status
                      */
-    
+
                     /**
                      * Constructs a new BatchWriteResponse.
                      * @memberof google.firestore.v1
@@ -12346,7 +12346,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * BatchWriteResponse writeResults.
                      * @member {Array.<google.firestore.v1.IWriteResult>} writeResults
@@ -12354,7 +12354,7 @@
                      * @instance
                      */
                     BatchWriteResponse.prototype.writeResults = $util.emptyArray;
-    
+
                     /**
                      * BatchWriteResponse status.
                      * @member {Array.<google.rpc.IStatus>} status
@@ -12362,7 +12362,7 @@
                      * @instance
                      */
                     BatchWriteResponse.prototype.status = $util.emptyArray;
-    
+
                     /**
                      * Creates a BatchWriteResponse message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -12397,7 +12397,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a BatchWriteResponse message. Also converts values to other types if specified.
                      * @function toObject
@@ -12427,7 +12427,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this BatchWriteResponse to JSON.
                      * @function toJSON
@@ -12438,12 +12438,12 @@
                     BatchWriteResponse.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return BatchWriteResponse;
                 })();
-    
+
                 v1.StructuredQuery = (function() {
-    
+
                     /**
                      * Properties of a StructuredQuery.
                      * @memberof google.firestore.v1
@@ -12457,7 +12457,7 @@
                      * @property {number|null} [offset] StructuredQuery offset
                      * @property {google.protobuf.IInt32Value|null} [limit] StructuredQuery limit
                      */
-    
+
                     /**
                      * Constructs a new StructuredQuery.
                      * @memberof google.firestore.v1
@@ -12474,7 +12474,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * StructuredQuery select.
                      * @member {google.firestore.v1.StructuredQuery.IProjection|null|undefined} select
@@ -12482,7 +12482,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.select = null;
-    
+
                     /**
                      * StructuredQuery from.
                      * @member {Array.<google.firestore.v1.StructuredQuery.ICollectionSelector>} from
@@ -12490,7 +12490,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.from = $util.emptyArray;
-    
+
                     /**
                      * StructuredQuery where.
                      * @member {google.firestore.v1.StructuredQuery.IFilter|null|undefined} where
@@ -12498,7 +12498,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.where = null;
-    
+
                     /**
                      * StructuredQuery orderBy.
                      * @member {Array.<google.firestore.v1.StructuredQuery.IOrder>} orderBy
@@ -12506,7 +12506,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.orderBy = $util.emptyArray;
-    
+
                     /**
                      * StructuredQuery startAt.
                      * @member {google.firestore.v1.ICursor|null|undefined} startAt
@@ -12514,7 +12514,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.startAt = null;
-    
+
                     /**
                      * StructuredQuery endAt.
                      * @member {google.firestore.v1.ICursor|null|undefined} endAt
@@ -12522,7 +12522,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.endAt = null;
-    
+
                     /**
                      * StructuredQuery offset.
                      * @member {number} offset
@@ -12530,7 +12530,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.offset = 0;
-    
+
                     /**
                      * StructuredQuery limit.
                      * @member {google.protobuf.IInt32Value|null|undefined} limit
@@ -12538,7 +12538,7 @@
                      * @instance
                      */
                     StructuredQuery.prototype.limit = null;
-    
+
                     /**
                      * Creates a StructuredQuery message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -12600,7 +12600,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a StructuredQuery message. Also converts values to other types if specified.
                      * @function toObject
@@ -12650,7 +12650,7 @@
                             object.endAt = $root.google.firestore.v1.Cursor.toObject(message.endAt, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this StructuredQuery to JSON.
                      * @function toJSON
@@ -12661,9 +12661,9 @@
                     StructuredQuery.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     StructuredQuery.CollectionSelector = (function() {
-    
+
                         /**
                          * Properties of a CollectionSelector.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -12671,7 +12671,7 @@
                          * @property {string|null} [collectionId] CollectionSelector collectionId
                          * @property {boolean|null} [allDescendants] CollectionSelector allDescendants
                          */
-    
+
                         /**
                          * Constructs a new CollectionSelector.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -12686,7 +12686,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * CollectionSelector collectionId.
                          * @member {string} collectionId
@@ -12694,7 +12694,7 @@
                          * @instance
                          */
                         CollectionSelector.prototype.collectionId = "";
-    
+
                         /**
                          * CollectionSelector allDescendants.
                          * @member {boolean} allDescendants
@@ -12702,7 +12702,7 @@
                          * @instance
                          */
                         CollectionSelector.prototype.allDescendants = false;
-    
+
                         /**
                          * Creates a CollectionSelector message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -12721,7 +12721,7 @@
                                 message.allDescendants = Boolean(object.allDescendants);
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a CollectionSelector message. Also converts values to other types if specified.
                          * @function toObject
@@ -12745,7 +12745,7 @@
                                 object.allDescendants = message.allDescendants;
                             return object;
                         };
-    
+
                         /**
                          * Converts this CollectionSelector to JSON.
                          * @function toJSON
@@ -12756,12 +12756,12 @@
                         CollectionSelector.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return CollectionSelector;
                     })();
-    
+
                     StructuredQuery.Filter = (function() {
-    
+
                         /**
                          * Properties of a Filter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -12770,7 +12770,7 @@
                          * @property {google.firestore.v1.StructuredQuery.IFieldFilter|null} [fieldFilter] Filter fieldFilter
                          * @property {google.firestore.v1.StructuredQuery.IUnaryFilter|null} [unaryFilter] Filter unaryFilter
                          */
-    
+
                         /**
                          * Constructs a new Filter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -12785,7 +12785,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * Filter compositeFilter.
                          * @member {google.firestore.v1.StructuredQuery.ICompositeFilter|null|undefined} compositeFilter
@@ -12793,7 +12793,7 @@
                          * @instance
                          */
                         Filter.prototype.compositeFilter = null;
-    
+
                         /**
                          * Filter fieldFilter.
                          * @member {google.firestore.v1.StructuredQuery.IFieldFilter|null|undefined} fieldFilter
@@ -12801,7 +12801,7 @@
                          * @instance
                          */
                         Filter.prototype.fieldFilter = null;
-    
+
                         /**
                          * Filter unaryFilter.
                          * @member {google.firestore.v1.StructuredQuery.IUnaryFilter|null|undefined} unaryFilter
@@ -12809,10 +12809,10 @@
                          * @instance
                          */
                         Filter.prototype.unaryFilter = null;
-    
+
                         // OneOf field names bound to virtual getters and setters
                         var $oneOfFields;
-    
+
                         /**
                          * Filter filterType.
                          * @member {"compositeFilter"|"fieldFilter"|"unaryFilter"|undefined} filterType
@@ -12823,7 +12823,7 @@
                             get: $util.oneOfGetter($oneOfFields = ["compositeFilter", "fieldFilter", "unaryFilter"]),
                             set: $util.oneOfSetter($oneOfFields)
                         });
-    
+
                         /**
                          * Creates a Filter message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -12853,7 +12853,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a Filter message. Also converts values to other types if specified.
                          * @function toObject
@@ -12884,7 +12884,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this Filter to JSON.
                          * @function toJSON
@@ -12895,12 +12895,12 @@
                         Filter.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return Filter;
                     })();
-    
+
                     StructuredQuery.CompositeFilter = (function() {
-    
+
                         /**
                          * Properties of a CompositeFilter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -12908,7 +12908,7 @@
                          * @property {google.firestore.v1.StructuredQuery.CompositeFilter.Operator|null} [op] CompositeFilter op
                          * @property {Array.<google.firestore.v1.StructuredQuery.IFilter>|null} [filters] CompositeFilter filters
                          */
-    
+
                         /**
                          * Constructs a new CompositeFilter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -12924,7 +12924,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * CompositeFilter op.
                          * @member {google.firestore.v1.StructuredQuery.CompositeFilter.Operator} op
@@ -12932,7 +12932,7 @@
                          * @instance
                          */
                         CompositeFilter.prototype.op = 0;
-    
+
                         /**
                          * CompositeFilter filters.
                          * @member {Array.<google.firestore.v1.StructuredQuery.IFilter>} filters
@@ -12940,7 +12940,7 @@
                          * @instance
                          */
                         CompositeFilter.prototype.filters = $util.emptyArray;
-    
+
                         /**
                          * Creates a CompositeFilter message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -12975,7 +12975,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a CompositeFilter message. Also converts values to other types if specified.
                          * @function toObject
@@ -13002,7 +13002,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this CompositeFilter to JSON.
                          * @function toJSON
@@ -13013,7 +13013,7 @@
                         CompositeFilter.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         /**
                          * Operator enum.
                          * @name google.firestore.v1.StructuredQuery.CompositeFilter.Operator
@@ -13027,12 +13027,12 @@
                             values[valuesById[1] = "AND"] = "AND";
                             return values;
                         })();
-    
+
                         return CompositeFilter;
                     })();
-    
+
                     StructuredQuery.FieldFilter = (function() {
-    
+
                         /**
                          * Properties of a FieldFilter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13041,7 +13041,7 @@
                          * @property {google.firestore.v1.StructuredQuery.FieldFilter.Operator|null} [op] FieldFilter op
                          * @property {google.firestore.v1.IValue|null} [value] FieldFilter value
                          */
-    
+
                         /**
                          * Constructs a new FieldFilter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13056,7 +13056,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * FieldFilter field.
                          * @member {google.firestore.v1.StructuredQuery.IFieldReference|null|undefined} field
@@ -13064,7 +13064,7 @@
                          * @instance
                          */
                         FieldFilter.prototype.field = null;
-    
+
                         /**
                          * FieldFilter op.
                          * @member {google.firestore.v1.StructuredQuery.FieldFilter.Operator} op
@@ -13072,7 +13072,7 @@
                          * @instance
                          */
                         FieldFilter.prototype.op = 0;
-    
+
                         /**
                          * FieldFilter value.
                          * @member {google.firestore.v1.IValue|null|undefined} value
@@ -13080,7 +13080,7 @@
                          * @instance
                          */
                         FieldFilter.prototype.value = null;
-    
+
                         /**
                          * Creates a FieldFilter message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -13151,7 +13151,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a FieldFilter message. Also converts values to other types if specified.
                          * @function toObject
@@ -13178,7 +13178,7 @@
                                 object.value = $root.google.firestore.v1.Value.toObject(message.value, options);
                             return object;
                         };
-    
+
                         /**
                          * Converts this FieldFilter to JSON.
                          * @function toJSON
@@ -13189,7 +13189,7 @@
                         FieldFilter.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         /**
                          * Operator enum.
                          * @name google.firestore.v1.StructuredQuery.FieldFilter.Operator
@@ -13221,12 +13221,12 @@
                             values[valuesById[10] = "NOT_IN"] = "NOT_IN";
                             return values;
                         })();
-    
+
                         return FieldFilter;
                     })();
-    
+
                     StructuredQuery.UnaryFilter = (function() {
-    
+
                         /**
                          * Properties of an UnaryFilter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13234,7 +13234,7 @@
                          * @property {google.firestore.v1.StructuredQuery.UnaryFilter.Operator|null} [op] UnaryFilter op
                          * @property {google.firestore.v1.StructuredQuery.IFieldReference|null} [field] UnaryFilter field
                          */
-    
+
                         /**
                          * Constructs a new UnaryFilter.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13249,7 +13249,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * UnaryFilter op.
                          * @member {google.firestore.v1.StructuredQuery.UnaryFilter.Operator} op
@@ -13257,7 +13257,7 @@
                          * @instance
                          */
                         UnaryFilter.prototype.op = 0;
-    
+
                         /**
                          * UnaryFilter field.
                          * @member {google.firestore.v1.StructuredQuery.IFieldReference|null|undefined} field
@@ -13265,10 +13265,10 @@
                          * @instance
                          */
                         UnaryFilter.prototype.field = null;
-    
+
                         // OneOf field names bound to virtual getters and setters
                         var $oneOfFields;
-    
+
                         /**
                          * UnaryFilter operandType.
                          * @member {"field"|undefined} operandType
@@ -13279,7 +13279,7 @@
                             get: $util.oneOfGetter($oneOfFields = ["field"]),
                             set: $util.oneOfSetter($oneOfFields)
                         });
-    
+
                         /**
                          * Creates an UnaryFilter message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -13321,7 +13321,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from an UnaryFilter message. Also converts values to other types if specified.
                          * @function toObject
@@ -13346,7 +13346,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this UnaryFilter to JSON.
                          * @function toJSON
@@ -13357,7 +13357,7 @@
                         UnaryFilter.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         /**
                          * Operator enum.
                          * @name google.firestore.v1.StructuredQuery.UnaryFilter.Operator
@@ -13377,12 +13377,12 @@
                             values[valuesById[5] = "IS_NOT_NULL"] = "IS_NOT_NULL";
                             return values;
                         })();
-    
+
                         return UnaryFilter;
                     })();
-    
+
                     StructuredQuery.Order = (function() {
-    
+
                         /**
                          * Properties of an Order.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13390,7 +13390,7 @@
                          * @property {google.firestore.v1.StructuredQuery.IFieldReference|null} [field] Order field
                          * @property {google.firestore.v1.StructuredQuery.Direction|null} [direction] Order direction
                          */
-    
+
                         /**
                          * Constructs a new Order.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13405,7 +13405,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * Order field.
                          * @member {google.firestore.v1.StructuredQuery.IFieldReference|null|undefined} field
@@ -13413,7 +13413,7 @@
                          * @instance
                          */
                         Order.prototype.field = null;
-    
+
                         /**
                          * Order direction.
                          * @member {google.firestore.v1.StructuredQuery.Direction} direction
@@ -13421,7 +13421,7 @@
                          * @instance
                          */
                         Order.prototype.direction = 0;
-    
+
                         /**
                          * Creates an Order message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -13455,7 +13455,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from an Order message. Also converts values to other types if specified.
                          * @function toObject
@@ -13479,7 +13479,7 @@
                                 object.direction = options.enums === String ? $root.google.firestore.v1.StructuredQuery.Direction[message.direction] : message.direction;
                             return object;
                         };
-    
+
                         /**
                          * Converts this Order to JSON.
                          * @function toJSON
@@ -13490,19 +13490,19 @@
                         Order.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return Order;
                     })();
-    
+
                     StructuredQuery.FieldReference = (function() {
-    
+
                         /**
                          * Properties of a FieldReference.
                          * @memberof google.firestore.v1.StructuredQuery
                          * @interface IFieldReference
                          * @property {string|null} [fieldPath] FieldReference fieldPath
                          */
-    
+
                         /**
                          * Constructs a new FieldReference.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13517,7 +13517,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * FieldReference fieldPath.
                          * @member {string} fieldPath
@@ -13525,7 +13525,7 @@
                          * @instance
                          */
                         FieldReference.prototype.fieldPath = "";
-    
+
                         /**
                          * Creates a FieldReference message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -13542,7 +13542,7 @@
                                 message.fieldPath = String(object.fieldPath);
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a FieldReference message. Also converts values to other types if specified.
                          * @function toObject
@@ -13562,7 +13562,7 @@
                                 object.fieldPath = message.fieldPath;
                             return object;
                         };
-    
+
                         /**
                          * Converts this FieldReference to JSON.
                          * @function toJSON
@@ -13573,19 +13573,19 @@
                         FieldReference.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return FieldReference;
                     })();
-    
+
                     StructuredQuery.Projection = (function() {
-    
+
                         /**
                          * Properties of a Projection.
                          * @memberof google.firestore.v1.StructuredQuery
                          * @interface IProjection
                          * @property {Array.<google.firestore.v1.StructuredQuery.IFieldReference>|null} [fields] Projection fields
                          */
-    
+
                         /**
                          * Constructs a new Projection.
                          * @memberof google.firestore.v1.StructuredQuery
@@ -13601,7 +13601,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * Projection fields.
                          * @member {Array.<google.firestore.v1.StructuredQuery.IFieldReference>} fields
@@ -13609,7 +13609,7 @@
                          * @instance
                          */
                         Projection.prototype.fields = $util.emptyArray;
-    
+
                         /**
                          * Creates a Projection message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -13634,7 +13634,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a Projection message. Also converts values to other types if specified.
                          * @function toObject
@@ -13657,7 +13657,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this Projection to JSON.
                          * @function toJSON
@@ -13668,10 +13668,10 @@
                         Projection.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         return Projection;
                     })();
-    
+
                     /**
                      * Direction enum.
                      * @name google.firestore.v1.StructuredQuery.Direction
@@ -13687,12 +13687,12 @@
                         values[valuesById[2] = "DESCENDING"] = "DESCENDING";
                         return values;
                     })();
-    
+
                     return StructuredQuery;
                 })();
-    
+
                 v1.Cursor = (function() {
-    
+
                     /**
                      * Properties of a Cursor.
                      * @memberof google.firestore.v1
@@ -13700,7 +13700,7 @@
                      * @property {Array.<google.firestore.v1.IValue>|null} [values] Cursor values
                      * @property {boolean|null} [before] Cursor before
                      */
-    
+
                     /**
                      * Constructs a new Cursor.
                      * @memberof google.firestore.v1
@@ -13716,7 +13716,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Cursor values.
                      * @member {Array.<google.firestore.v1.IValue>} values
@@ -13724,7 +13724,7 @@
                      * @instance
                      */
                     Cursor.prototype.values = $util.emptyArray;
-    
+
                     /**
                      * Cursor before.
                      * @member {boolean} before
@@ -13732,7 +13732,7 @@
                      * @instance
                      */
                     Cursor.prototype.before = false;
-    
+
                     /**
                      * Creates a Cursor message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -13759,7 +13759,7 @@
                             message.before = Boolean(object.before);
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a Cursor message. Also converts values to other types if specified.
                      * @function toObject
@@ -13786,7 +13786,7 @@
                             object.before = message.before;
                         return object;
                     };
-    
+
                     /**
                      * Converts this Cursor to JSON.
                      * @function toJSON
@@ -13797,24 +13797,25 @@
                     Cursor.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return Cursor;
                 })();
-    
+
                 v1.Write = (function() {
-    
+
                     /**
                      * Properties of a Write.
                      * @memberof google.firestore.v1
                      * @interface IWrite
                      * @property {google.firestore.v1.IDocument|null} [update] Write update
                      * @property {string|null} ["delete"] Write delete
+                     * @property {string|null} [verify] Write verify
                      * @property {google.firestore.v1.IDocumentTransform|null} [transform] Write transform
                      * @property {google.firestore.v1.IDocumentMask|null} [updateMask] Write updateMask
                      * @property {Array.<google.firestore.v1.DocumentTransform.IFieldTransform>|null} [updateTransforms] Write updateTransforms
                      * @property {google.firestore.v1.IPrecondition|null} [currentDocument] Write currentDocument
                      */
-    
+
                     /**
                      * Constructs a new Write.
                      * @memberof google.firestore.v1
@@ -13830,7 +13831,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * Write update.
                      * @member {google.firestore.v1.IDocument|null|undefined} update
@@ -13838,7 +13839,7 @@
                      * @instance
                      */
                     Write.prototype.update = null;
-    
+
                     /**
                      * Write delete.
                      * @member {string|null|undefined} delete
@@ -13846,7 +13847,15 @@
                      * @instance
                      */
                     Write.prototype["delete"] = null;
-    
+
+                    /**
+                     * Write verify.
+                     * @member {string|null|undefined} verify
+                     * @memberof google.firestore.v1.Write
+                     * @instance
+                     */
+                    Write.prototype.verify = null;
+
                     /**
                      * Write transform.
                      * @member {google.firestore.v1.IDocumentTransform|null|undefined} transform
@@ -13854,7 +13863,7 @@
                      * @instance
                      */
                     Write.prototype.transform = null;
-    
+
                     /**
                      * Write updateMask.
                      * @member {google.firestore.v1.IDocumentMask|null|undefined} updateMask
@@ -13862,7 +13871,7 @@
                      * @instance
                      */
                     Write.prototype.updateMask = null;
-    
+
                     /**
                      * Write updateTransforms.
                      * @member {Array.<google.firestore.v1.DocumentTransform.IFieldTransform>} updateTransforms
@@ -13870,7 +13879,7 @@
                      * @instance
                      */
                     Write.prototype.updateTransforms = $util.emptyArray;
-    
+
                     /**
                      * Write currentDocument.
                      * @member {google.firestore.v1.IPrecondition|null|undefined} currentDocument
@@ -13878,21 +13887,21 @@
                      * @instance
                      */
                     Write.prototype.currentDocument = null;
-    
+
                     // OneOf field names bound to virtual getters and setters
                     var $oneOfFields;
-    
+
                     /**
                      * Write operation.
-                     * @member {"update"|"delete"|"transform"|undefined} operation
+                     * @member {"update"|"delete"|"verify"|"transform"|undefined} operation
                      * @memberof google.firestore.v1.Write
                      * @instance
                      */
                     Object.defineProperty(Write.prototype, "operation", {
-                        get: $util.oneOfGetter($oneOfFields = ["update", "delete", "transform"]),
+                        get: $util.oneOfGetter($oneOfFields = ["update", "delete", "verify", "transform"]),
                         set: $util.oneOfSetter($oneOfFields)
                     });
-    
+
                     /**
                      * Creates a Write message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -13912,6 +13921,8 @@
                         }
                         if (object["delete"] != null)
                             message["delete"] = String(object["delete"]);
+                        if (object.verify != null)
+                            message.verify = String(object.verify);
                         if (object.transform != null) {
                             if (typeof object.transform !== "object")
                                 throw TypeError(".google.firestore.v1.Write.transform: object expected");
@@ -13939,7 +13950,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a Write message. Also converts values to other types if specified.
                      * @function toObject
@@ -13973,6 +13984,11 @@
                             object.updateMask = $root.google.firestore.v1.DocumentMask.toObject(message.updateMask, options);
                         if (message.currentDocument != null && message.hasOwnProperty("currentDocument"))
                             object.currentDocument = $root.google.firestore.v1.Precondition.toObject(message.currentDocument, options);
+                        if (message.verify != null && message.hasOwnProperty("verify")) {
+                            object.verify = message.verify;
+                            if (options.oneofs)
+                                object.operation = "verify";
+                        }
                         if (message.transform != null && message.hasOwnProperty("transform")) {
                             object.transform = $root.google.firestore.v1.DocumentTransform.toObject(message.transform, options);
                             if (options.oneofs)
@@ -13985,7 +14001,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this Write to JSON.
                      * @function toJSON
@@ -13996,12 +14012,12 @@
                     Write.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return Write;
                 })();
-    
+
                 v1.DocumentTransform = (function() {
-    
+
                     /**
                      * Properties of a DocumentTransform.
                      * @memberof google.firestore.v1
@@ -14009,7 +14025,7 @@
                      * @property {string|null} [document] DocumentTransform document
                      * @property {Array.<google.firestore.v1.DocumentTransform.IFieldTransform>|null} [fieldTransforms] DocumentTransform fieldTransforms
                      */
-    
+
                     /**
                      * Constructs a new DocumentTransform.
                      * @memberof google.firestore.v1
@@ -14025,7 +14041,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * DocumentTransform document.
                      * @member {string} document
@@ -14033,7 +14049,7 @@
                      * @instance
                      */
                     DocumentTransform.prototype.document = "";
-    
+
                     /**
                      * DocumentTransform fieldTransforms.
                      * @member {Array.<google.firestore.v1.DocumentTransform.IFieldTransform>} fieldTransforms
@@ -14041,7 +14057,7 @@
                      * @instance
                      */
                     DocumentTransform.prototype.fieldTransforms = $util.emptyArray;
-    
+
                     /**
                      * Creates a DocumentTransform message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -14068,7 +14084,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a DocumentTransform message. Also converts values to other types if specified.
                      * @function toObject
@@ -14095,7 +14111,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this DocumentTransform to JSON.
                      * @function toJSON
@@ -14106,9 +14122,9 @@
                     DocumentTransform.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     DocumentTransform.FieldTransform = (function() {
-    
+
                         /**
                          * Properties of a FieldTransform.
                          * @memberof google.firestore.v1.DocumentTransform
@@ -14121,7 +14137,7 @@
                          * @property {google.firestore.v1.IArrayValue|null} [appendMissingElements] FieldTransform appendMissingElements
                          * @property {google.firestore.v1.IArrayValue|null} [removeAllFromArray] FieldTransform removeAllFromArray
                          */
-    
+
                         /**
                          * Constructs a new FieldTransform.
                          * @memberof google.firestore.v1.DocumentTransform
@@ -14136,7 +14152,7 @@
                                     if (properties[keys[i]] != null)
                                         this[keys[i]] = properties[keys[i]];
                         }
-    
+
                         /**
                          * FieldTransform fieldPath.
                          * @member {string} fieldPath
@@ -14144,7 +14160,7 @@
                          * @instance
                          */
                         FieldTransform.prototype.fieldPath = "";
-    
+
                         /**
                          * FieldTransform setToServerValue.
                          * @member {google.firestore.v1.DocumentTransform.FieldTransform.ServerValue|null|undefined} setToServerValue
@@ -14152,7 +14168,7 @@
                          * @instance
                          */
                         FieldTransform.prototype.setToServerValue = null;
-    
+
                         /**
                          * FieldTransform increment.
                          * @member {google.firestore.v1.IValue|null|undefined} increment
@@ -14160,7 +14176,7 @@
                          * @instance
                          */
                         FieldTransform.prototype.increment = null;
-    
+
                         /**
                          * FieldTransform maximum.
                          * @member {google.firestore.v1.IValue|null|undefined} maximum
@@ -14168,7 +14184,7 @@
                          * @instance
                          */
                         FieldTransform.prototype.maximum = null;
-    
+
                         /**
                          * FieldTransform minimum.
                          * @member {google.firestore.v1.IValue|null|undefined} minimum
@@ -14176,7 +14192,7 @@
                          * @instance
                          */
                         FieldTransform.prototype.minimum = null;
-    
+
                         /**
                          * FieldTransform appendMissingElements.
                          * @member {google.firestore.v1.IArrayValue|null|undefined} appendMissingElements
@@ -14184,7 +14200,7 @@
                          * @instance
                          */
                         FieldTransform.prototype.appendMissingElements = null;
-    
+
                         /**
                          * FieldTransform removeAllFromArray.
                          * @member {google.firestore.v1.IArrayValue|null|undefined} removeAllFromArray
@@ -14192,10 +14208,10 @@
                          * @instance
                          */
                         FieldTransform.prototype.removeAllFromArray = null;
-    
+
                         // OneOf field names bound to virtual getters and setters
                         var $oneOfFields;
-    
+
                         /**
                          * FieldTransform transformType.
                          * @member {"setToServerValue"|"increment"|"maximum"|"minimum"|"appendMissingElements"|"removeAllFromArray"|undefined} transformType
@@ -14206,7 +14222,7 @@
                             get: $util.oneOfGetter($oneOfFields = ["setToServerValue", "increment", "maximum", "minimum", "appendMissingElements", "removeAllFromArray"]),
                             set: $util.oneOfSetter($oneOfFields)
                         });
-    
+
                         /**
                          * Creates a FieldTransform message from a plain object. Also converts values to their respective internal types.
                          * @function fromObject
@@ -14258,7 +14274,7 @@
                             }
                             return message;
                         };
-    
+
                         /**
                          * Creates a plain object from a FieldTransform message. Also converts values to other types if specified.
                          * @function toObject
@@ -14308,7 +14324,7 @@
                             }
                             return object;
                         };
-    
+
                         /**
                          * Converts this FieldTransform to JSON.
                          * @function toJSON
@@ -14319,7 +14335,7 @@
                         FieldTransform.prototype.toJSON = function toJSON() {
                             return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                         };
-    
+
                         /**
                          * ServerValue enum.
                          * @name google.firestore.v1.DocumentTransform.FieldTransform.ServerValue
@@ -14333,15 +14349,15 @@
                             values[valuesById[1] = "REQUEST_TIME"] = "REQUEST_TIME";
                             return values;
                         })();
-    
+
                         return FieldTransform;
                     })();
-    
+
                     return DocumentTransform;
                 })();
-    
+
                 v1.WriteResult = (function() {
-    
+
                     /**
                      * Properties of a WriteResult.
                      * @memberof google.firestore.v1
@@ -14349,7 +14365,7 @@
                      * @property {google.protobuf.ITimestamp|null} [updateTime] WriteResult updateTime
                      * @property {Array.<google.firestore.v1.IValue>|null} [transformResults] WriteResult transformResults
                      */
-    
+
                     /**
                      * Constructs a new WriteResult.
                      * @memberof google.firestore.v1
@@ -14365,7 +14381,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * WriteResult updateTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} updateTime
@@ -14373,7 +14389,7 @@
                      * @instance
                      */
                     WriteResult.prototype.updateTime = null;
-    
+
                     /**
                      * WriteResult transformResults.
                      * @member {Array.<google.firestore.v1.IValue>} transformResults
@@ -14381,7 +14397,7 @@
                      * @instance
                      */
                     WriteResult.prototype.transformResults = $util.emptyArray;
-    
+
                     /**
                      * Creates a WriteResult message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -14411,7 +14427,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a WriteResult message. Also converts values to other types if specified.
                      * @function toObject
@@ -14438,7 +14454,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this WriteResult to JSON.
                      * @function toJSON
@@ -14449,12 +14465,12 @@
                     WriteResult.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return WriteResult;
                 })();
-    
+
                 v1.DocumentChange = (function() {
-    
+
                     /**
                      * Properties of a DocumentChange.
                      * @memberof google.firestore.v1
@@ -14463,7 +14479,7 @@
                      * @property {Array.<number>|null} [targetIds] DocumentChange targetIds
                      * @property {Array.<number>|null} [removedTargetIds] DocumentChange removedTargetIds
                      */
-    
+
                     /**
                      * Constructs a new DocumentChange.
                      * @memberof google.firestore.v1
@@ -14480,7 +14496,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * DocumentChange document.
                      * @member {google.firestore.v1.IDocument|null|undefined} document
@@ -14488,7 +14504,7 @@
                      * @instance
                      */
                     DocumentChange.prototype.document = null;
-    
+
                     /**
                      * DocumentChange targetIds.
                      * @member {Array.<number>} targetIds
@@ -14496,7 +14512,7 @@
                      * @instance
                      */
                     DocumentChange.prototype.targetIds = $util.emptyArray;
-    
+
                     /**
                      * DocumentChange removedTargetIds.
                      * @member {Array.<number>} removedTargetIds
@@ -14504,7 +14520,7 @@
                      * @instance
                      */
                     DocumentChange.prototype.removedTargetIds = $util.emptyArray;
-    
+
                     /**
                      * Creates a DocumentChange message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -14538,7 +14554,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a DocumentChange message. Also converts values to other types if specified.
                      * @function toObject
@@ -14572,7 +14588,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this DocumentChange to JSON.
                      * @function toJSON
@@ -14583,12 +14599,12 @@
                     DocumentChange.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return DocumentChange;
                 })();
-    
+
                 v1.DocumentDelete = (function() {
-    
+
                     /**
                      * Properties of a DocumentDelete.
                      * @memberof google.firestore.v1
@@ -14597,7 +14613,7 @@
                      * @property {Array.<number>|null} [removedTargetIds] DocumentDelete removedTargetIds
                      * @property {google.protobuf.ITimestamp|null} [readTime] DocumentDelete readTime
                      */
-    
+
                     /**
                      * Constructs a new DocumentDelete.
                      * @memberof google.firestore.v1
@@ -14613,7 +14629,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * DocumentDelete document.
                      * @member {string} document
@@ -14621,7 +14637,7 @@
                      * @instance
                      */
                     DocumentDelete.prototype.document = "";
-    
+
                     /**
                      * DocumentDelete removedTargetIds.
                      * @member {Array.<number>} removedTargetIds
@@ -14629,7 +14645,7 @@
                      * @instance
                      */
                     DocumentDelete.prototype.removedTargetIds = $util.emptyArray;
-    
+
                     /**
                      * DocumentDelete readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -14637,7 +14653,7 @@
                      * @instance
                      */
                     DocumentDelete.prototype.readTime = null;
-    
+
                     /**
                      * Creates a DocumentDelete message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -14666,7 +14682,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a DocumentDelete message. Also converts values to other types if specified.
                      * @function toObject
@@ -14697,7 +14713,7 @@
                         }
                         return object;
                     };
-    
+
                     /**
                      * Converts this DocumentDelete to JSON.
                      * @function toJSON
@@ -14708,12 +14724,12 @@
                     DocumentDelete.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return DocumentDelete;
                 })();
-    
+
                 v1.DocumentRemove = (function() {
-    
+
                     /**
                      * Properties of a DocumentRemove.
                      * @memberof google.firestore.v1
@@ -14722,7 +14738,7 @@
                      * @property {Array.<number>|null} [removedTargetIds] DocumentRemove removedTargetIds
                      * @property {google.protobuf.ITimestamp|null} [readTime] DocumentRemove readTime
                      */
-    
+
                     /**
                      * Constructs a new DocumentRemove.
                      * @memberof google.firestore.v1
@@ -14738,7 +14754,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * DocumentRemove document.
                      * @member {string} document
@@ -14746,7 +14762,7 @@
                      * @instance
                      */
                     DocumentRemove.prototype.document = "";
-    
+
                     /**
                      * DocumentRemove removedTargetIds.
                      * @member {Array.<number>} removedTargetIds
@@ -14754,7 +14770,7 @@
                      * @instance
                      */
                     DocumentRemove.prototype.removedTargetIds = $util.emptyArray;
-    
+
                     /**
                      * DocumentRemove readTime.
                      * @member {google.protobuf.ITimestamp|null|undefined} readTime
@@ -14762,7 +14778,7 @@
                      * @instance
                      */
                     DocumentRemove.prototype.readTime = null;
-    
+
                     /**
                      * Creates a DocumentRemove message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -14791,7 +14807,7 @@
                         }
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from a DocumentRemove message. Also converts values to other types if specified.
                      * @function toObject
@@ -14822,7 +14838,7 @@
                             object.readTime = $root.google.protobuf.Timestamp.toObject(message.readTime, options);
                         return object;
                     };
-    
+
                     /**
                      * Converts this DocumentRemove to JSON.
                      * @function toJSON
@@ -14833,12 +14849,12 @@
                     DocumentRemove.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return DocumentRemove;
                 })();
-    
+
                 v1.ExistenceFilter = (function() {
-    
+
                     /**
                      * Properties of an ExistenceFilter.
                      * @memberof google.firestore.v1
@@ -14846,7 +14862,7 @@
                      * @property {number|null} [targetId] ExistenceFilter targetId
                      * @property {number|null} [count] ExistenceFilter count
                      */
-    
+
                     /**
                      * Constructs a new ExistenceFilter.
                      * @memberof google.firestore.v1
@@ -14861,7 +14877,7 @@
                                 if (properties[keys[i]] != null)
                                     this[keys[i]] = properties[keys[i]];
                     }
-    
+
                     /**
                      * ExistenceFilter targetId.
                      * @member {number} targetId
@@ -14869,7 +14885,7 @@
                      * @instance
                      */
                     ExistenceFilter.prototype.targetId = 0;
-    
+
                     /**
                      * ExistenceFilter count.
                      * @member {number} count
@@ -14877,7 +14893,7 @@
                      * @instance
                      */
                     ExistenceFilter.prototype.count = 0;
-    
+
                     /**
                      * Creates an ExistenceFilter message from a plain object. Also converts values to their respective internal types.
                      * @function fromObject
@@ -14896,7 +14912,7 @@
                             message.count = object.count | 0;
                         return message;
                     };
-    
+
                     /**
                      * Creates a plain object from an ExistenceFilter message. Also converts values to other types if specified.
                      * @function toObject
@@ -14920,7 +14936,7 @@
                             object.count = message.count;
                         return object;
                     };
-    
+
                     /**
                      * Converts this ExistenceFilter to JSON.
                      * @function toJSON
@@ -14931,34 +14947,34 @@
                     ExistenceFilter.prototype.toJSON = function toJSON() {
                         return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                     };
-    
+
                     return ExistenceFilter;
                 })();
-    
+
                 return v1;
             })();
-    
+
             return firestore;
         })();
-    
+
         google.api = (function() {
-    
+
             /**
              * Namespace api.
              * @memberof google
              * @namespace
              */
             var api = {};
-    
+
             api.Http = (function() {
-    
+
                 /**
                  * Properties of a Http.
                  * @memberof google.api
                  * @interface IHttp
                  * @property {Array.<google.api.IHttpRule>|null} [rules] Http rules
                  */
-    
+
                 /**
                  * Constructs a new Http.
                  * @memberof google.api
@@ -14974,7 +14990,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Http rules.
                  * @member {Array.<google.api.IHttpRule>} rules
@@ -14982,7 +14998,7 @@
                  * @instance
                  */
                 Http.prototype.rules = $util.emptyArray;
-    
+
                 /**
                  * Creates a Http message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -15007,7 +15023,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a Http message. Also converts values to other types if specified.
                  * @function toObject
@@ -15030,7 +15046,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this Http to JSON.
                  * @function toJSON
@@ -15041,12 +15057,12 @@
                 Http.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Http;
             })();
-    
+
             api.HttpRule = (function() {
-    
+
                 /**
                  * Properties of a HttpRule.
                  * @memberof google.api
@@ -15061,7 +15077,7 @@
                  * @property {string|null} [body] HttpRule body
                  * @property {Array.<google.api.IHttpRule>|null} [additionalBindings] HttpRule additionalBindings
                  */
-    
+
                 /**
                  * Constructs a new HttpRule.
                  * @memberof google.api
@@ -15077,7 +15093,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * HttpRule get.
                  * @member {string|null|undefined} get
@@ -15085,7 +15101,7 @@
                  * @instance
                  */
                 HttpRule.prototype.get = null;
-    
+
                 /**
                  * HttpRule put.
                  * @member {string|null|undefined} put
@@ -15093,7 +15109,7 @@
                  * @instance
                  */
                 HttpRule.prototype.put = null;
-    
+
                 /**
                  * HttpRule post.
                  * @member {string|null|undefined} post
@@ -15101,7 +15117,7 @@
                  * @instance
                  */
                 HttpRule.prototype.post = null;
-    
+
                 /**
                  * HttpRule delete.
                  * @member {string|null|undefined} delete
@@ -15109,7 +15125,7 @@
                  * @instance
                  */
                 HttpRule.prototype["delete"] = null;
-    
+
                 /**
                  * HttpRule patch.
                  * @member {string|null|undefined} patch
@@ -15117,7 +15133,7 @@
                  * @instance
                  */
                 HttpRule.prototype.patch = null;
-    
+
                 /**
                  * HttpRule custom.
                  * @member {google.api.ICustomHttpPattern|null|undefined} custom
@@ -15125,7 +15141,7 @@
                  * @instance
                  */
                 HttpRule.prototype.custom = null;
-    
+
                 /**
                  * HttpRule selector.
                  * @member {string} selector
@@ -15133,7 +15149,7 @@
                  * @instance
                  */
                 HttpRule.prototype.selector = "";
-    
+
                 /**
                  * HttpRule body.
                  * @member {string} body
@@ -15141,7 +15157,7 @@
                  * @instance
                  */
                 HttpRule.prototype.body = "";
-    
+
                 /**
                  * HttpRule additionalBindings.
                  * @member {Array.<google.api.IHttpRule>} additionalBindings
@@ -15149,10 +15165,10 @@
                  * @instance
                  */
                 HttpRule.prototype.additionalBindings = $util.emptyArray;
-    
+
                 // OneOf field names bound to virtual getters and setters
                 var $oneOfFields;
-    
+
                 /**
                  * HttpRule pattern.
                  * @member {"get"|"put"|"post"|"delete"|"patch"|"custom"|undefined} pattern
@@ -15163,7 +15179,7 @@
                     get: $util.oneOfGetter($oneOfFields = ["get", "put", "post", "delete", "patch", "custom"]),
                     set: $util.oneOfSetter($oneOfFields)
                 });
-    
+
                 /**
                  * Creates a HttpRule message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -15207,7 +15223,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a HttpRule message. Also converts values to other types if specified.
                  * @function toObject
@@ -15268,7 +15284,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this HttpRule to JSON.
                  * @function toJSON
@@ -15279,12 +15295,12 @@
                 HttpRule.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return HttpRule;
             })();
-    
+
             api.CustomHttpPattern = (function() {
-    
+
                 /**
                  * Properties of a CustomHttpPattern.
                  * @memberof google.api
@@ -15292,7 +15308,7 @@
                  * @property {string|null} [kind] CustomHttpPattern kind
                  * @property {string|null} [path] CustomHttpPattern path
                  */
-    
+
                 /**
                  * Constructs a new CustomHttpPattern.
                  * @memberof google.api
@@ -15307,7 +15323,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * CustomHttpPattern kind.
                  * @member {string} kind
@@ -15315,7 +15331,7 @@
                  * @instance
                  */
                 CustomHttpPattern.prototype.kind = "";
-    
+
                 /**
                  * CustomHttpPattern path.
                  * @member {string} path
@@ -15323,7 +15339,7 @@
                  * @instance
                  */
                 CustomHttpPattern.prototype.path = "";
-    
+
                 /**
                  * Creates a CustomHttpPattern message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -15342,7 +15358,7 @@
                         message.path = String(object.path);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a CustomHttpPattern message. Also converts values to other types if specified.
                  * @function toObject
@@ -15366,7 +15382,7 @@
                         object.path = message.path;
                     return object;
                 };
-    
+
                 /**
                  * Converts this CustomHttpPattern to JSON.
                  * @function toJSON
@@ -15377,10 +15393,10 @@
                 CustomHttpPattern.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return CustomHttpPattern;
             })();
-    
+
             /**
              * FieldBehavior enum.
              * @name google.api.FieldBehavior
@@ -15404,9 +15420,9 @@
                 values[valuesById[6] = "UNORDERED_LIST"] = "UNORDERED_LIST";
                 return values;
             })();
-    
+
             api.ResourceDescriptor = (function() {
-    
+
                 /**
                  * Properties of a ResourceDescriptor.
                  * @memberof google.api
@@ -15419,7 +15435,7 @@
                  * @property {string|null} [singular] ResourceDescriptor singular
                  * @property {Array.<google.api.ResourceDescriptor.Style>|null} [style] ResourceDescriptor style
                  */
-    
+
                 /**
                  * Constructs a new ResourceDescriptor.
                  * @memberof google.api
@@ -15436,7 +15452,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * ResourceDescriptor type.
                  * @member {string} type
@@ -15444,7 +15460,7 @@
                  * @instance
                  */
                 ResourceDescriptor.prototype.type = "";
-    
+
                 /**
                  * ResourceDescriptor pattern.
                  * @member {Array.<string>} pattern
@@ -15452,7 +15468,7 @@
                  * @instance
                  */
                 ResourceDescriptor.prototype.pattern = $util.emptyArray;
-    
+
                 /**
                  * ResourceDescriptor nameField.
                  * @member {string} nameField
@@ -15460,7 +15476,7 @@
                  * @instance
                  */
                 ResourceDescriptor.prototype.nameField = "";
-    
+
                 /**
                  * ResourceDescriptor history.
                  * @member {google.api.ResourceDescriptor.History} history
@@ -15468,7 +15484,7 @@
                  * @instance
                  */
                 ResourceDescriptor.prototype.history = 0;
-    
+
                 /**
                  * ResourceDescriptor plural.
                  * @member {string} plural
@@ -15476,7 +15492,7 @@
                  * @instance
                  */
                 ResourceDescriptor.prototype.plural = "";
-    
+
                 /**
                  * ResourceDescriptor singular.
                  * @member {string} singular
@@ -15484,7 +15500,7 @@
                  * @instance
                  */
                 ResourceDescriptor.prototype.singular = "";
-    
+
                 /**
                  * ResourceDescriptor style.
                  * @member {Array.<google.api.ResourceDescriptor.Style>} style
@@ -15492,7 +15508,7 @@
                  * @instance
                  */
                 ResourceDescriptor.prototype.style = $util.emptyArray;
-    
+
                 /**
                  * Creates a ResourceDescriptor message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -15553,7 +15569,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a ResourceDescriptor message. Also converts values to other types if specified.
                  * @function toObject
@@ -15600,7 +15616,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this ResourceDescriptor to JSON.
                  * @function toJSON
@@ -15611,7 +15627,7 @@
                 ResourceDescriptor.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 /**
                  * History enum.
                  * @name google.api.ResourceDescriptor.History
@@ -15627,7 +15643,7 @@
                     values[valuesById[2] = "FUTURE_MULTI_PATTERN"] = "FUTURE_MULTI_PATTERN";
                     return values;
                 })();
-    
+
                 /**
                  * Style enum.
                  * @name google.api.ResourceDescriptor.Style
@@ -15641,12 +15657,12 @@
                     values[valuesById[1] = "DECLARATIVE_FRIENDLY"] = "DECLARATIVE_FRIENDLY";
                     return values;
                 })();
-    
+
                 return ResourceDescriptor;
             })();
-    
+
             api.ResourceReference = (function() {
-    
+
                 /**
                  * Properties of a ResourceReference.
                  * @memberof google.api
@@ -15654,7 +15670,7 @@
                  * @property {string|null} [type] ResourceReference type
                  * @property {string|null} [childType] ResourceReference childType
                  */
-    
+
                 /**
                  * Constructs a new ResourceReference.
                  * @memberof google.api
@@ -15669,7 +15685,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * ResourceReference type.
                  * @member {string} type
@@ -15677,7 +15693,7 @@
                  * @instance
                  */
                 ResourceReference.prototype.type = "";
-    
+
                 /**
                  * ResourceReference childType.
                  * @member {string} childType
@@ -15685,7 +15701,7 @@
                  * @instance
                  */
                 ResourceReference.prototype.childType = "";
-    
+
                 /**
                  * Creates a ResourceReference message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -15704,7 +15720,7 @@
                         message.childType = String(object.childType);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a ResourceReference message. Also converts values to other types if specified.
                  * @function toObject
@@ -15728,7 +15744,7 @@
                         object.childType = message.childType;
                     return object;
                 };
-    
+
                 /**
                  * Converts this ResourceReference to JSON.
                  * @function toJSON
@@ -15739,24 +15755,24 @@
                 ResourceReference.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return ResourceReference;
             })();
-    
+
             return api;
         })();
-    
+
         google.type = (function() {
-    
+
             /**
              * Namespace type.
              * @memberof google
              * @namespace
              */
             var type = {};
-    
+
             type.LatLng = (function() {
-    
+
                 /**
                  * Properties of a LatLng.
                  * @memberof google.type
@@ -15764,7 +15780,7 @@
                  * @property {number|null} [latitude] LatLng latitude
                  * @property {number|null} [longitude] LatLng longitude
                  */
-    
+
                 /**
                  * Constructs a new LatLng.
                  * @memberof google.type
@@ -15779,7 +15795,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * LatLng latitude.
                  * @member {number} latitude
@@ -15787,7 +15803,7 @@
                  * @instance
                  */
                 LatLng.prototype.latitude = 0;
-    
+
                 /**
                  * LatLng longitude.
                  * @member {number} longitude
@@ -15795,7 +15811,7 @@
                  * @instance
                  */
                 LatLng.prototype.longitude = 0;
-    
+
                 /**
                  * Creates a LatLng message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -15814,7 +15830,7 @@
                         message.longitude = Number(object.longitude);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a LatLng message. Also converts values to other types if specified.
                  * @function toObject
@@ -15838,7 +15854,7 @@
                         object.longitude = options.json && !isFinite(message.longitude) ? String(message.longitude) : message.longitude;
                     return object;
                 };
-    
+
                 /**
                  * Converts this LatLng to JSON.
                  * @function toJSON
@@ -15849,24 +15865,24 @@
                 LatLng.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return LatLng;
             })();
-    
+
             return type;
         })();
-    
+
         google.rpc = (function() {
-    
+
             /**
              * Namespace rpc.
              * @memberof google
              * @namespace
              */
             var rpc = {};
-    
+
             rpc.Status = (function() {
-    
+
                 /**
                  * Properties of a Status.
                  * @memberof google.rpc
@@ -15875,7 +15891,7 @@
                  * @property {string|null} [message] Status message
                  * @property {Array.<google.protobuf.IAny>|null} [details] Status details
                  */
-    
+
                 /**
                  * Constructs a new Status.
                  * @memberof google.rpc
@@ -15891,7 +15907,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Status code.
                  * @member {number} code
@@ -15899,7 +15915,7 @@
                  * @instance
                  */
                 Status.prototype.code = 0;
-    
+
                 /**
                  * Status message.
                  * @member {string} message
@@ -15907,7 +15923,7 @@
                  * @instance
                  */
                 Status.prototype.message = "";
-    
+
                 /**
                  * Status details.
                  * @member {Array.<google.protobuf.IAny>} details
@@ -15915,7 +15931,7 @@
                  * @instance
                  */
                 Status.prototype.details = $util.emptyArray;
-    
+
                 /**
                  * Creates a Status message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -15944,7 +15960,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a Status message. Also converts values to other types if specified.
                  * @function toObject
@@ -15975,7 +15991,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this Status to JSON.
                  * @function toJSON
@@ -15986,24 +16002,24 @@
                 Status.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Status;
             })();
-    
+
             return rpc;
         })();
-    
+
         google.longrunning = (function() {
-    
+
             /**
              * Namespace longrunning.
              * @memberof google
              * @namespace
              */
             var longrunning = {};
-    
+
             longrunning.Operations = (function() {
-    
+
                 /**
                  * Constructs a new Operations service.
                  * @memberof google.longrunning
@@ -16017,9 +16033,9 @@
                 function Operations(rpcImpl, requestDelimited, responseDelimited) {
                     $protobuf.rpc.Service.call(this, rpcImpl, requestDelimited, responseDelimited);
                 }
-    
+
                 (Operations.prototype = Object.create($protobuf.rpc.Service.prototype)).constructor = Operations;
-    
+
                 /**
                  * Callback as used by {@link google.longrunning.Operations#listOperations}.
                  * @memberof google.longrunning.Operations
@@ -16028,7 +16044,7 @@
                  * @param {Error|null} error Error, if any
                  * @param {google.longrunning.ListOperationsResponse} [response] ListOperationsResponse
                  */
-    
+
                 /**
                  * Calls ListOperations.
                  * @function listOperations
@@ -16042,7 +16058,7 @@
                 Object.defineProperty(Operations.prototype.listOperations = function listOperations(request, callback) {
                     return this.rpcCall(listOperations, $root.google.longrunning.ListOperationsRequest, $root.google.longrunning.ListOperationsResponse, request, callback);
                 }, "name", { value: "ListOperations" });
-    
+
                 /**
                  * Calls ListOperations.
                  * @function listOperations
@@ -16052,7 +16068,7 @@
                  * @returns {Promise<google.longrunning.ListOperationsResponse>} Promise
                  * @variation 2
                  */
-    
+
                 /**
                  * Callback as used by {@link google.longrunning.Operations#getOperation}.
                  * @memberof google.longrunning.Operations
@@ -16061,7 +16077,7 @@
                  * @param {Error|null} error Error, if any
                  * @param {google.longrunning.Operation} [response] Operation
                  */
-    
+
                 /**
                  * Calls GetOperation.
                  * @function getOperation
@@ -16075,7 +16091,7 @@
                 Object.defineProperty(Operations.prototype.getOperation = function getOperation(request, callback) {
                     return this.rpcCall(getOperation, $root.google.longrunning.GetOperationRequest, $root.google.longrunning.Operation, request, callback);
                 }, "name", { value: "GetOperation" });
-    
+
                 /**
                  * Calls GetOperation.
                  * @function getOperation
@@ -16085,7 +16101,7 @@
                  * @returns {Promise<google.longrunning.Operation>} Promise
                  * @variation 2
                  */
-    
+
                 /**
                  * Callback as used by {@link google.longrunning.Operations#deleteOperation}.
                  * @memberof google.longrunning.Operations
@@ -16094,7 +16110,7 @@
                  * @param {Error|null} error Error, if any
                  * @param {google.protobuf.Empty} [response] Empty
                  */
-    
+
                 /**
                  * Calls DeleteOperation.
                  * @function deleteOperation
@@ -16108,7 +16124,7 @@
                 Object.defineProperty(Operations.prototype.deleteOperation = function deleteOperation(request, callback) {
                     return this.rpcCall(deleteOperation, $root.google.longrunning.DeleteOperationRequest, $root.google.protobuf.Empty, request, callback);
                 }, "name", { value: "DeleteOperation" });
-    
+
                 /**
                  * Calls DeleteOperation.
                  * @function deleteOperation
@@ -16118,7 +16134,7 @@
                  * @returns {Promise<google.protobuf.Empty>} Promise
                  * @variation 2
                  */
-    
+
                 /**
                  * Callback as used by {@link google.longrunning.Operations#cancelOperation}.
                  * @memberof google.longrunning.Operations
@@ -16127,7 +16143,7 @@
                  * @param {Error|null} error Error, if any
                  * @param {google.protobuf.Empty} [response] Empty
                  */
-    
+
                 /**
                  * Calls CancelOperation.
                  * @function cancelOperation
@@ -16141,7 +16157,7 @@
                 Object.defineProperty(Operations.prototype.cancelOperation = function cancelOperation(request, callback) {
                     return this.rpcCall(cancelOperation, $root.google.longrunning.CancelOperationRequest, $root.google.protobuf.Empty, request, callback);
                 }, "name", { value: "CancelOperation" });
-    
+
                 /**
                  * Calls CancelOperation.
                  * @function cancelOperation
@@ -16151,7 +16167,7 @@
                  * @returns {Promise<google.protobuf.Empty>} Promise
                  * @variation 2
                  */
-    
+
                 /**
                  * Callback as used by {@link google.longrunning.Operations#waitOperation}.
                  * @memberof google.longrunning.Operations
@@ -16160,7 +16176,7 @@
                  * @param {Error|null} error Error, if any
                  * @param {google.longrunning.Operation} [response] Operation
                  */
-    
+
                 /**
                  * Calls WaitOperation.
                  * @function waitOperation
@@ -16174,7 +16190,7 @@
                 Object.defineProperty(Operations.prototype.waitOperation = function waitOperation(request, callback) {
                     return this.rpcCall(waitOperation, $root.google.longrunning.WaitOperationRequest, $root.google.longrunning.Operation, request, callback);
                 }, "name", { value: "WaitOperation" });
-    
+
                 /**
                  * Calls WaitOperation.
                  * @function waitOperation
@@ -16184,12 +16200,12 @@
                  * @returns {Promise<google.longrunning.Operation>} Promise
                  * @variation 2
                  */
-    
+
                 return Operations;
             })();
-    
+
             longrunning.Operation = (function() {
-    
+
                 /**
                  * Properties of an Operation.
                  * @memberof google.longrunning
@@ -16200,7 +16216,7 @@
                  * @property {google.rpc.IStatus|null} [error] Operation error
                  * @property {google.protobuf.IAny|null} [response] Operation response
                  */
-    
+
                 /**
                  * Constructs a new Operation.
                  * @memberof google.longrunning
@@ -16215,7 +16231,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * Operation name.
                  * @member {string} name
@@ -16223,7 +16239,7 @@
                  * @instance
                  */
                 Operation.prototype.name = "";
-    
+
                 /**
                  * Operation metadata.
                  * @member {google.protobuf.IAny|null|undefined} metadata
@@ -16231,7 +16247,7 @@
                  * @instance
                  */
                 Operation.prototype.metadata = null;
-    
+
                 /**
                  * Operation done.
                  * @member {boolean} done
@@ -16239,7 +16255,7 @@
                  * @instance
                  */
                 Operation.prototype.done = false;
-    
+
                 /**
                  * Operation error.
                  * @member {google.rpc.IStatus|null|undefined} error
@@ -16247,7 +16263,7 @@
                  * @instance
                  */
                 Operation.prototype.error = null;
-    
+
                 /**
                  * Operation response.
                  * @member {google.protobuf.IAny|null|undefined} response
@@ -16255,10 +16271,10 @@
                  * @instance
                  */
                 Operation.prototype.response = null;
-    
+
                 // OneOf field names bound to virtual getters and setters
                 var $oneOfFields;
-    
+
                 /**
                  * Operation result.
                  * @member {"error"|"response"|undefined} result
@@ -16269,7 +16285,7 @@
                     get: $util.oneOfGetter($oneOfFields = ["error", "response"]),
                     set: $util.oneOfSetter($oneOfFields)
                 });
-    
+
                 /**
                  * Creates an Operation message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -16303,7 +16319,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an Operation message. Also converts values to other types if specified.
                  * @function toObject
@@ -16340,7 +16356,7 @@
                     }
                     return object;
                 };
-    
+
                 /**
                  * Converts this Operation to JSON.
                  * @function toJSON
@@ -16351,19 +16367,19 @@
                 Operation.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return Operation;
             })();
-    
+
             longrunning.GetOperationRequest = (function() {
-    
+
                 /**
                  * Properties of a GetOperationRequest.
                  * @memberof google.longrunning
                  * @interface IGetOperationRequest
                  * @property {string|null} [name] GetOperationRequest name
                  */
-    
+
                 /**
                  * Constructs a new GetOperationRequest.
                  * @memberof google.longrunning
@@ -16378,7 +16394,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * GetOperationRequest name.
                  * @member {string} name
@@ -16386,7 +16402,7 @@
                  * @instance
                  */
                 GetOperationRequest.prototype.name = "";
-    
+
                 /**
                  * Creates a GetOperationRequest message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -16403,7 +16419,7 @@
                         message.name = String(object.name);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a GetOperationRequest message. Also converts values to other types if specified.
                  * @function toObject
@@ -16423,7 +16439,7 @@
                         object.name = message.name;
                     return object;
                 };
-    
+
                 /**
                  * Converts this GetOperationRequest to JSON.
                  * @function toJSON
@@ -16434,12 +16450,12 @@
                 GetOperationRequest.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return GetOperationRequest;
             })();
-    
+
             longrunning.ListOperationsRequest = (function() {
-    
+
                 /**
                  * Properties of a ListOperationsRequest.
                  * @memberof google.longrunning
@@ -16449,7 +16465,7 @@
                  * @property {number|null} [pageSize] ListOperationsRequest pageSize
                  * @property {string|null} [pageToken] ListOperationsRequest pageToken
                  */
-    
+
                 /**
                  * Constructs a new ListOperationsRequest.
                  * @memberof google.longrunning
@@ -16464,7 +16480,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * ListOperationsRequest name.
                  * @member {string} name
@@ -16472,7 +16488,7 @@
                  * @instance
                  */
                 ListOperationsRequest.prototype.name = "";
-    
+
                 /**
                  * ListOperationsRequest filter.
                  * @member {string} filter
@@ -16480,7 +16496,7 @@
                  * @instance
                  */
                 ListOperationsRequest.prototype.filter = "";
-    
+
                 /**
                  * ListOperationsRequest pageSize.
                  * @member {number} pageSize
@@ -16488,7 +16504,7 @@
                  * @instance
                  */
                 ListOperationsRequest.prototype.pageSize = 0;
-    
+
                 /**
                  * ListOperationsRequest pageToken.
                  * @member {string} pageToken
@@ -16496,7 +16512,7 @@
                  * @instance
                  */
                 ListOperationsRequest.prototype.pageToken = "";
-    
+
                 /**
                  * Creates a ListOperationsRequest message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -16519,7 +16535,7 @@
                         message.pageToken = String(object.pageToken);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a ListOperationsRequest message. Also converts values to other types if specified.
                  * @function toObject
@@ -16549,7 +16565,7 @@
                         object.name = message.name;
                     return object;
                 };
-    
+
                 /**
                  * Converts this ListOperationsRequest to JSON.
                  * @function toJSON
@@ -16560,12 +16576,12 @@
                 ListOperationsRequest.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return ListOperationsRequest;
             })();
-    
+
             longrunning.ListOperationsResponse = (function() {
-    
+
                 /**
                  * Properties of a ListOperationsResponse.
                  * @memberof google.longrunning
@@ -16573,7 +16589,7 @@
                  * @property {Array.<google.longrunning.IOperation>|null} [operations] ListOperationsResponse operations
                  * @property {string|null} [nextPageToken] ListOperationsResponse nextPageToken
                  */
-    
+
                 /**
                  * Constructs a new ListOperationsResponse.
                  * @memberof google.longrunning
@@ -16589,7 +16605,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * ListOperationsResponse operations.
                  * @member {Array.<google.longrunning.IOperation>} operations
@@ -16597,7 +16613,7 @@
                  * @instance
                  */
                 ListOperationsResponse.prototype.operations = $util.emptyArray;
-    
+
                 /**
                  * ListOperationsResponse nextPageToken.
                  * @member {string} nextPageToken
@@ -16605,7 +16621,7 @@
                  * @instance
                  */
                 ListOperationsResponse.prototype.nextPageToken = "";
-    
+
                 /**
                  * Creates a ListOperationsResponse message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -16632,7 +16648,7 @@
                         message.nextPageToken = String(object.nextPageToken);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a ListOperationsResponse message. Also converts values to other types if specified.
                  * @function toObject
@@ -16659,7 +16675,7 @@
                         object.nextPageToken = message.nextPageToken;
                     return object;
                 };
-    
+
                 /**
                  * Converts this ListOperationsResponse to JSON.
                  * @function toJSON
@@ -16670,19 +16686,19 @@
                 ListOperationsResponse.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return ListOperationsResponse;
             })();
-    
+
             longrunning.CancelOperationRequest = (function() {
-    
+
                 /**
                  * Properties of a CancelOperationRequest.
                  * @memberof google.longrunning
                  * @interface ICancelOperationRequest
                  * @property {string|null} [name] CancelOperationRequest name
                  */
-    
+
                 /**
                  * Constructs a new CancelOperationRequest.
                  * @memberof google.longrunning
@@ -16697,7 +16713,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * CancelOperationRequest name.
                  * @member {string} name
@@ -16705,7 +16721,7 @@
                  * @instance
                  */
                 CancelOperationRequest.prototype.name = "";
-    
+
                 /**
                  * Creates a CancelOperationRequest message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -16722,7 +16738,7 @@
                         message.name = String(object.name);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a CancelOperationRequest message. Also converts values to other types if specified.
                  * @function toObject
@@ -16742,7 +16758,7 @@
                         object.name = message.name;
                     return object;
                 };
-    
+
                 /**
                  * Converts this CancelOperationRequest to JSON.
                  * @function toJSON
@@ -16753,19 +16769,19 @@
                 CancelOperationRequest.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return CancelOperationRequest;
             })();
-    
+
             longrunning.DeleteOperationRequest = (function() {
-    
+
                 /**
                  * Properties of a DeleteOperationRequest.
                  * @memberof google.longrunning
                  * @interface IDeleteOperationRequest
                  * @property {string|null} [name] DeleteOperationRequest name
                  */
-    
+
                 /**
                  * Constructs a new DeleteOperationRequest.
                  * @memberof google.longrunning
@@ -16780,7 +16796,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * DeleteOperationRequest name.
                  * @member {string} name
@@ -16788,7 +16804,7 @@
                  * @instance
                  */
                 DeleteOperationRequest.prototype.name = "";
-    
+
                 /**
                  * Creates a DeleteOperationRequest message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -16805,7 +16821,7 @@
                         message.name = String(object.name);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a DeleteOperationRequest message. Also converts values to other types if specified.
                  * @function toObject
@@ -16825,7 +16841,7 @@
                         object.name = message.name;
                     return object;
                 };
-    
+
                 /**
                  * Converts this DeleteOperationRequest to JSON.
                  * @function toJSON
@@ -16836,12 +16852,12 @@
                 DeleteOperationRequest.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return DeleteOperationRequest;
             })();
-    
+
             longrunning.WaitOperationRequest = (function() {
-    
+
                 /**
                  * Properties of a WaitOperationRequest.
                  * @memberof google.longrunning
@@ -16849,7 +16865,7 @@
                  * @property {string|null} [name] WaitOperationRequest name
                  * @property {google.protobuf.IDuration|null} [timeout] WaitOperationRequest timeout
                  */
-    
+
                 /**
                  * Constructs a new WaitOperationRequest.
                  * @memberof google.longrunning
@@ -16864,7 +16880,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * WaitOperationRequest name.
                  * @member {string} name
@@ -16872,7 +16888,7 @@
                  * @instance
                  */
                 WaitOperationRequest.prototype.name = "";
-    
+
                 /**
                  * WaitOperationRequest timeout.
                  * @member {google.protobuf.IDuration|null|undefined} timeout
@@ -16880,7 +16896,7 @@
                  * @instance
                  */
                 WaitOperationRequest.prototype.timeout = null;
-    
+
                 /**
                  * Creates a WaitOperationRequest message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -16902,7 +16918,7 @@
                     }
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from a WaitOperationRequest message. Also converts values to other types if specified.
                  * @function toObject
@@ -16926,7 +16942,7 @@
                         object.timeout = $root.google.protobuf.Duration.toObject(message.timeout, options);
                     return object;
                 };
-    
+
                 /**
                  * Converts this WaitOperationRequest to JSON.
                  * @function toJSON
@@ -16937,12 +16953,12 @@
                 WaitOperationRequest.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return WaitOperationRequest;
             })();
-    
+
             longrunning.OperationInfo = (function() {
-    
+
                 /**
                  * Properties of an OperationInfo.
                  * @memberof google.longrunning
@@ -16950,7 +16966,7 @@
                  * @property {string|null} [responseType] OperationInfo responseType
                  * @property {string|null} [metadataType] OperationInfo metadataType
                  */
-    
+
                 /**
                  * Constructs a new OperationInfo.
                  * @memberof google.longrunning
@@ -16965,7 +16981,7 @@
                             if (properties[keys[i]] != null)
                                 this[keys[i]] = properties[keys[i]];
                 }
-    
+
                 /**
                  * OperationInfo responseType.
                  * @member {string} responseType
@@ -16973,7 +16989,7 @@
                  * @instance
                  */
                 OperationInfo.prototype.responseType = "";
-    
+
                 /**
                  * OperationInfo metadataType.
                  * @member {string} metadataType
@@ -16981,7 +16997,7 @@
                  * @instance
                  */
                 OperationInfo.prototype.metadataType = "";
-    
+
                 /**
                  * Creates an OperationInfo message from a plain object. Also converts values to their respective internal types.
                  * @function fromObject
@@ -17000,7 +17016,7 @@
                         message.metadataType = String(object.metadataType);
                     return message;
                 };
-    
+
                 /**
                  * Creates a plain object from an OperationInfo message. Also converts values to other types if specified.
                  * @function toObject
@@ -17024,7 +17040,7 @@
                         object.metadataType = message.metadataType;
                     return object;
                 };
-    
+
                 /**
                  * Converts this OperationInfo to JSON.
                  * @function toJSON
@@ -17035,13 +17051,13 @@
                 OperationInfo.prototype.toJSON = function toJSON() {
                     return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
                 };
-    
+
                 return OperationInfo;
             })();
-    
+
             return longrunning;
         })();
-    
+
         return google;
     })();
 

--- a/dev/protos/google/firestore/v1/write.proto
+++ b/dev/protos/google/firestore/v1/write.proto
@@ -41,6 +41,11 @@ message Write {
     // `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
     string delete = 2;
 
+    // The name of a document on which to verify the `current_document`
+    // precondition.
+    // This only requires read access to the document.
+    string verify = 5;
+
     // Applies a transformation to a document.
     DocumentTransform transform = 6;
   }

--- a/dev/protos/protos.json
+++ b/dev/protos/protos.json
@@ -2133,6 +2133,7 @@
                       "oneof": [
                         "update",
                         "delete",
+                        "verify",
                         "transform"
                       ]
                     }
@@ -2145,6 +2146,10 @@
                     "delete": {
                       "type": "string",
                       "id": 2
+                    },
+                    "verify": {
+                      "type": "string",
+                      "id": 5
                     },
                     "transform": {
                       "type": "DocumentTransform",

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -959,10 +959,9 @@ export class Firestore implements firestore.Firestore {
    * transaction.
    * @param {boolean=} optimisticLocking Whether to use optimistic locking.
    * By default, transactions lock documents pessimistically, which increases
-   * the chance that transactions succeed but blocks other clients from
-   * modifying the documents read during the transaction. When
-   * `optimisticLocking` is enabled, writes are not blocked. When other clients
-   * modify a document, the transaction is instead retried. Optimistic
+   * the chance that transactions succeed but blocks other clients`
+   * modifications. With `optimisticLocking`, writes are not blocked. When other
+   * clients modify a document, the transaction is instead retried. Optimistic
    * transactions do not support queries.
    * @param {number=} maxAttempts The maximum number of attempts for this
    * transaction. Defaults to five.

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -32,7 +32,7 @@ import {
   QuerySnapshot,
   validateDocumentReference,
 } from './reference';
-import {getRetryCodes, isObject, isPlainObject} from './util';
+import {isObject, isPlainObject} from './util';
 import {
   invalidArgumentMessage,
   RequiredArgumentOptions,
@@ -435,7 +435,7 @@ export class Transaction implements firestore.Transaction {
             }
           }
 
-          // For any remaining locks add verify preconditions.
+          // Add verify preconditions for any remaining locks.
           for (const [path, precondition] of locks) {
             commitRequest.writes.push({
               verify: path,

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -568,16 +568,17 @@ export class WriteBatch implements firestore.WriteBatch {
    *
    * @private
    * @param commitOptions Options to use for this commit.
-   * @param commitOptions.transactionId The transaction ID of this commit.
    * @param commitOptions.requestTag A unique client-assigned identifier for
    * this request.
+   * @param commitOptions.preprocessor A function that can be used to mutate
+   * the request before the commit.
    * @returns  A Promise that resolves when this batch completes.
    */
   async _commit<Req extends api.ICommitRequest, Resp>(commitOptions?: {
-    transactionId?: Uint8Array;
     requestTag?: string;
     retryCodes?: number[];
     methodName?: FirestoreUnaryMethod;
+    preproccessor?: (request: api.ICommitRequest) => api.ICommitRequest;
   }): Promise<Resp> {
     // Note: We don't call `verifyNotCommitted()` to allow for retries.
     this._committed = true;
@@ -587,13 +588,13 @@ export class WriteBatch implements firestore.WriteBatch {
 
     // Note that the request may not always be of type ICommitRequest. This is
     // just here to ensure type safety.
-    const request: api.ICommitRequest = {
+    let request: api.ICommitRequest = {
       database: this._firestore.formattedName,
       writes: this._ops.map(op => op.op()),
     };
 
-    if (commitOptions?.transactionId) {
-      request.transaction = commitOptions.transactionId;
+    if (commitOptions?.preproccessor) {
+      request = commitOptions?.preproccessor(request);
     }
 
     logger(

--- a/dev/test/transaction.ts
+++ b/dev/test/transaction.ts
@@ -1086,7 +1086,7 @@ describe('successful transactions (with optimistic locking)', () => {
     };
 
     return runTransaction(
-      /* transactionOptions= */ {optimisticLocking: true},
+      {optimisticLocking: true},
       (transaction, docRef) => {
         return transaction.get(docRef).then(doc => {
           expect(doc.id).to.equal('documentId');
@@ -1107,7 +1107,7 @@ describe('successful transactions (with optimistic locking)', () => {
     };
 
     return runTransaction(
-      /* transactionOptions= */ {optimisticLocking: true},
+      {optimisticLocking: true},
       (transaction, docRef) => {
         return transaction.get(docRef).then(doc => {
           expect(doc.exists).to.equal(false);
@@ -1134,7 +1134,7 @@ describe('successful transactions (with optimistic locking)', () => {
     };
 
     return runTransaction(
-      /* transactionOptions= */ {optimisticLocking: true},
+      {optimisticLocking: true},
       (transaction, docRef) => {
         return transaction.get(docRef).then(() => {
           transaction.set(docRef, {});
@@ -1183,7 +1183,7 @@ describe('successful transactions (with optimistic locking)', () => {
     };
 
     return runTransaction(
-      /* transactionOptions= */ {optimisticLocking: true},
+      {optimisticLocking: true},
       (transaction, docRef) => {
         return transaction.get(docRef).then(() => {
           transaction.update(
@@ -1213,7 +1213,7 @@ describe('failed transactions (with optimistic locking)', () => {
     };
 
     return runTransaction(
-      /* transactionOptions= */ {optimisticLocking: true},
+      {optimisticLocking: true},
       (transaction, docRef) => {
         return transaction.get(docRef);
       },
@@ -1231,7 +1231,7 @@ describe('failed transactions (with optimistic locking)', () => {
   it('rejects queries', () => {
     return expect(
       runTransaction(
-        /* transactionOptions= */ {optimisticLocking: true},
+        {optimisticLocking: true},
         (transaction, docRef) => {
           return transaction.get(docRef.parent);
         },

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -191,6 +191,17 @@ declare namespace FirebaseFirestore {
     /** Set to false or omit to indicate a read-write transaction. */
     readOnly?: false;
     /**
+     * Whether to use optimistic locking. By default, transactions lock
+     * documents pessimistically, which increases the chance that transactions
+     * succeed but blocks other clients from modifying the documents read during
+     * the transaction. When `optimisticLocking` is enabled, writes are not
+     * blocked. When other clients modify a document, the transaction is instead
+     * retried.
+     *
+     * Optimistic transactions do not support queries.
+     */
+    optimisticLocking?: boolean;
+    /**
      * The maximum number of attempts for this transaction. Defaults to five.
      */
     maxAttempts?: number;
@@ -336,10 +347,16 @@ declare namespace FirebaseFirestore {
      * Transactions can be performed as read-only or read-write transactions. By
      * default, transactions are executed in read-write mode.
      *
-     * A read-write transaction obtains a pessimistic lock on all documents that
-     * are read during the transaction. These locks block other transactions,
-     * batched writes, and other non-transactional writes from changing that
-     * document. Any writes in a read-write transactions are committed once
+     * By default, read-write transactions obtain a pessimistic locks on all
+     * documents that are read during the transaction. These locks block other
+     * transactions, batched writes, and other non-transactional writes from
+     * changing that document. If you enable optimistic locking, other clients
+     * can continue to modify these documents. The transaction will be retried
+     * if a concurrent write affects the data read during the transaction.
+     *
+     * A transaction can modify up to 500 documents. If you enable optimistic
+     * locking, any document read during the transaction also counts against
+     * this limit. Any writes in a read-write transactions are committed once
      * 'updateFunction' resolves, which also releases all locks.
      *
      * If a read-write transaction fails with contention, the transaction is

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -193,10 +193,9 @@ declare namespace FirebaseFirestore {
     /**
      * Whether to use optimistic locking. By default, transactions lock
      * documents pessimistically, which increases the chance that transactions
-     * succeed but blocks other clients from modifying the documents read during
-     * the transaction. When `optimisticLocking` is enabled, writes are not
-     * blocked. When other clients modify a document, the transaction is instead
-     * retried.
+     * succeed but blocks other clients` modifications. With
+     * `optimisticLocking`, writes are not blocked. When other clients modify a
+     * document, the transaction is instead retried.
      *
      * Optimistic transactions do not support queries.
      */


### PR DESCRIPTION
This PR adds support for optimistic transactions. A `verify` write is added to the commit for all documents read during an optimistic transaction.
 
This PR relies on an backend feature that is not yet public. We need to figure out what our strategy here will be.

The first commit just re-arranges tests. It is probably best to only review the second commit.

Fixes https://github.com/googleapis/google-cloud-node/issues/7489