### PR TITLE
feat: allow UnhandledPromiseRejection errors in BulkWriter if no error handler is specified

### DIFF
--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -424,8 +424,10 @@ describe('BulkWriter', () => {
     ]);
 
     const doc = firestore.doc('collectionId/doc');
-    bulkWriter.onWriteError(() => false);
     bulkWriter.set(doc, {foo: 'bar'});
+    // Set the error handler after calling set() to ensure that the check is
+    // performed when the promise resolves.
+    bulkWriter.onWriteError(() => false);
     return bulkWriter.close();
   });
 

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -40,6 +40,7 @@ import {
   DEFAULT_MAXIMUM_OPS_PER_SECOND_LIMIT,
   RETRY_MAX_BATCH_SIZE,
 } from '../src/bulk-writer';
+import {Deferred} from '../src/util';
 import {
   ApiOverride,
   create,
@@ -54,7 +55,6 @@ import {
   verifyInstance,
 } from './util/helpers';
 import api = proto.google.firestore.v1;
-import {Deferred} from '../src/util';
 
 // Change the argument to 'console.log' to enable debug output.
 setLogFunction(null);


### PR DESCRIPTION
BulkWriter should throw an error if an operation promise is rejected without a custom error handler. Otherwise, failures are silently swallowed without any indication to the end-developer. If an error handler is specified with `onWriteError()`, BulkWriter assumes that the developer is handling the error and will swallow failed promises so that the developer does not have to add a dangling `catch()` statement for every promise.