### PR TITLE
fix: avoid destructuring undefined timestamps

### DIFF
--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -49,10 +49,7 @@ export function timestampFromJson(
   timestampValue?: string | google.protobuf.ITimestamp,
   argumentName?: string
 ): google.protobuf.ITimestamp | undefined {
-  let timestampProto: google.protobuf.ITimestamp = {
-      seconds: undefined,
-      nanos: undefined
-  };
+  let timestampProto: google.protobuf.ITimestamp = {};
 
   if (typeof timestampValue === 'string') {
     const date = new Date(timestampValue);

--- a/dev/src/convert.ts
+++ b/dev/src/convert.ts
@@ -49,7 +49,10 @@ export function timestampFromJson(
   timestampValue?: string | google.protobuf.ITimestamp,
   argumentName?: string
 ): google.protobuf.ITimestamp | undefined {
-  let timestampProto: google.protobuf.ITimestamp | undefined;
+  let timestampProto: google.protobuf.ITimestamp = {
+      seconds: undefined,
+      nanos: undefined
+  };
 
   if (typeof timestampValue === 'string') {
     const date = new Date(timestampValue);


### PR DESCRIPTION
In `https://github.com/googleapis/nodejs-firestore/blob/master/dev/src/index.ts#L911` we call from proto with a potential undefined instead of an object. This causes an error in `https://github.com/googleapis/nodejs-firestore/blob/master/dev/src/timestamp.ts#L122` where it tries to destructure an undefined value. This problem causes triggers to fail before entering user defined handler.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1574 🦕
