### PR TITLE
chore: upgrade typescript to v4.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "proxyquire": "^2.1.3",
     "sinon": "^11.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^4.1.5",
+    "typescript": "^4.4.3",
     "through2": "^4.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": [
       "es2016",
       "dom"
-    ]
+    ],
+    "useUnknownInCatchVariables": false,
   },
   "include": [
     "dev/src/*.d.ts",


### PR DESCRIPTION
Leaving the typescript at `^4.1.5` causes compiler errors when v4.4.2 is installed due to v.4.4's breaking change where errors in catch blocks default to `unknown` type ([documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#using-unknown-in-catch-variables)). This can cause `npm install` to fail if a 4.4.2 is the installed.

As a quick fix, I've added a compiler option to remove this functionality. There are several changes that would need to be made in order to remove the flag.