### PR TITLE
fix: support union types and optional fields on UpdateData

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "proxyquire": "^2.1.3",
     "sinon": "^11.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^4.1.5",
+    "typescript": "^4.4.3",
     "through2": "^4.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": [
       "es2016",
       "dom"
-    ]
+    ],
+    "useUnknownInCatchVariables": false,
   },
   "include": [
     "dev/src/*.d.ts",

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -78,15 +78,28 @@ declare namespace FirebaseFirestore {
   export type NestedUpdateFields<T extends Record<string, unknown>> =
     UnionToIntersection<
       {
-        // Check that T[K] extends Record to only allow nesting for map values.
-        [K in keyof T & string]: T[K] extends Record<string, unknown>
-          ? // Recurse into the map and add the prefix in front of each key
-            // (e.g. Prefix 'bar.' to create: 'bar.baz' and 'bar.qux'.
-            AddPrefixToKeys<K, UpdateData<T[K]>>
-          : // TypedUpdateData is always a map of values.
-            never;
+        [K in keyof T & string]: ChildUpdateFields<K, T[K]>;
       }[keyof T & string] // Also include the generated prefix-string keys.
     >;
+
+  /**
+   * Helper for calculating the nested fields for a given type T1. This is needed
+   * to distribute union types such as `undefined | {...}` (happens for optional
+   * props) or `{a: A} | {b: B}`.
+   *
+   * In this use case, `V` is used to distribute the union types of `T[K]` on
+   * `Record`, since `T[K]` is evaluated as an expression and not distributed.
+   *
+   * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#distributive-conditional-types
+   */
+  export type ChildUpdateFields<K extends string, V> =
+    // Only allow nesting for map values
+    V extends Record<string, unknown>
+      ? // Recurse into the map and add the prefix in front of each key
+        // (e.g. Prefix 'bar.' to create: 'bar.baz' and 'bar.qux'.
+        AddPrefixToKeys<K, UpdateData<V>>
+      : // UpdateData is always a map of values.
+        never;
 
   /**
    * Returns a new map where every key is prefixed with the outer key appended


### PR DESCRIPTION
This PR goes on top of #1604. Will rename the feature branch from `bc/4.1` to something more appropriate after these are merged.