### PR TITLE
fix: make SetOptions a union type

### DIFF
--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -315,8 +315,8 @@ export class WriteBatch implements firestore.WriteBatch {
     options?: firestore.SetOptions
   ): WriteBatch {
     validateSetOptions('options', options, {optional: true});
-    const mergeLeaves = options && options.merge === true;
-    const mergePaths = options && options.mergeFields;
+    const mergeLeaves = options && 'merge' in options && options.merge;
+    const mergePaths = options && 'mergeFields' in options;
     const ref = validateDocumentReference('documentRef', documentRef);
     let firestoreData: firestore.DocumentData;
     if (mergeLeaves || mergePaths) {
@@ -763,27 +763,9 @@ export function validateSetOptions(
       );
     }
 
-    const setOptions = value as {[k: string]: unknown};
-
-    if ('merge' in setOptions && typeof setOptions.merge !== 'boolean') {
-      throw new Error(
-        `${invalidArgumentMessage(
-          arg,
-          'set() options argument'
-        )} "merge" is not a boolean.`
-      );
-    }
+    const setOptions = value as {mergeFields: Array<string | FieldPath>};
 
     if ('mergeFields' in setOptions) {
-      if (!Array.isArray(setOptions.mergeFields)) {
-        throw new Error(
-          `${invalidArgumentMessage(
-            arg,
-            'set() options argument'
-          )} "mergeFields" is not an array.`
-        );
-      }
-
       for (let i = 0; i < setOptions.mergeFields.length; ++i) {
         try {
           validateFieldPath(i, setOptions.mergeFields[i]);

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3113,7 +3113,7 @@ describe('Types test', () => {
         testObj: PartialWithFieldValue<TestObject>,
         options?: SetOptions
       ) {
-        if (options && (options.merge || options.mergeFields)) {
+        if (options) {
           expect(testObj).to.not.be.an.instanceOf(TestObject);
         } else {
           expect(testObj).to.be.an.instanceOf(TestObject);
@@ -3220,7 +3220,7 @@ describe('Types test', () => {
         testObj: PartialWithFieldValue<TestObject>,
         options?: SetOptions
       ) {
-        if (options && (options.merge || options.mergeFields)) {
+        if (options) {
           expect(testObj).to.not.be.an.instanceOf(TestObject);
         } else {
           expect(testObj).to.be.an.instanceOf(TestObject);

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -1309,47 +1309,6 @@ describe('set document', () => {
 
   it('validates merge option', () => {
     expect(() => {
-      firestore
-        .doc('collectionId/documentId')
-        .set({foo: 'bar'}, 'foo' as InvalidApiUsage);
-    }).to.throw(
-      'Value for argument "options" is not a valid set() options argument. Input is not an object.'
-    );
-
-    expect(() => {
-      firestore.doc('collectionId/documentId').set(
-        {foo: 'bar'},
-        {
-          merge: 42 as InvalidApiUsage,
-        }
-      );
-    }).to.throw(
-      'Value for argument "options" is not a valid set() options argument. "merge" is not a boolean.'
-    );
-
-    expect(() => {
-      firestore.doc('collectionId/documentId').set(
-        {foo: 'bar'},
-        {
-          mergeFields: 42 as InvalidApiUsage,
-        }
-      );
-    }).to.throw(
-      'Value for argument "options" is not a valid set() options argument. "mergeFields" is not an array.'
-    );
-
-    expect(() => {
-      firestore.doc('collectionId/documentId').set(
-        {foo: 'bar'},
-        {
-          mergeFields: [null as InvalidApiUsage],
-        }
-      );
-    }).to.throw(
-      'Value for argument "options" is not a valid set() options argument. "mergeFields" is not valid: Element at index 0 is not a valid field path. Paths can only be specified as strings or via a FieldPath object.'
-    );
-
-    expect(() => {
       firestore.doc('collectionId/documentId').set(
         {foo: 'bar'},
         {
@@ -1357,6 +1316,19 @@ describe('set document', () => {
         }
       );
     }).to.throw('Input data is missing for field "foobar".');
+
+    expect(() => {
+      firestore.doc('collectionId/documentId').set(
+        {foo: 'bar'},
+        {
+          mergeFields: ['foobar..'],
+        }
+      );
+    }).to.throw(
+      'Value for argument "options" is not a valid set() options argument. ' +
+        '"mergeFields" is not valid: Element at index 0 is not a valid ' +
+        'field path. Paths must not contain ".." in them.'
+    );
 
     expect(() => {
       firestore

--- a/dev/test/util/helpers.ts
+++ b/dev/test/util/helpers.ts
@@ -354,7 +354,7 @@ export const postConverterMerge = {
     post: PartialWithFieldValue<Post>,
     options?: SetOptions
   ): DocumentData {
-    if (options && (options.merge || options.mergeFields)) {
+    if (options) {
       expect(post).to.not.be.an.instanceOf(Post);
     } else {
       expect(post).to.be.an.instanceof(Post);

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -1065,25 +1065,22 @@ declare namespace FirebaseFirestore {
    * `DocumentReference`, `WriteBatch` and `Transaction`. These calls can be
    * configured to perform granular merges instead of overwriting the target
    * documents in their entirety.
+   *
+   * @param merge Changes the behavior of a set() call to only replace the
+   * values specified in its data argument. Fields omitted from the set() call
+   * remain untouched.
+   *
+   * @param mergeFields Changes the behavior of set() calls to only replace
+   * the specified field paths. Any field path that is not specified is ignored
+   * and remains untouched.
    */
-  export interface SetOptions {
-    /**
-     * Changes the behavior of a set() call to only replace the values specified
-     * in its data argument. Fields omitted from the set() call remain
-     * untouched.
-     */
-    readonly merge?: boolean;
-
-    /**
-     * Changes the behavior of set() calls to only replace the specified field
-     * paths. Any field path that is not specified is ignored and remains
-     * untouched.
-     *
-     * It is an error to pass a SetOptions object to a set() call that is
-     * missing a value for any of the fields specified here.
-     */
-    readonly mergeFields?: (string | FieldPath)[];
-  }
+  export type SetOptions =
+    | {
+        readonly merge?: boolean;
+      }
+    | {
+        readonly mergeFields?: Array<string | FieldPath>;
+      };
 
   /**
    * An options object that can be used to configure the behavior of `getAll()`


### PR DESCRIPTION
Making SetOptions match the web SDK.
- Remove some old validation logic
- Add test to check that validation is being run on individual field path strings.
- Kept the check against specifying `merge` and `mergeFields` in case there are JS users who somehow specify both (open to deleting that if you want)