### PR TITLE
feat: allow type T in WithFieldValue<T>

### DIFF
--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -31,21 +31,25 @@ declare namespace FirebaseFirestore {
    * Similar to Typescript's `Partial<T>`, but allows nested fields to be
    * omitted and FieldValues to be passed in as property values.
    */
-  export type PartialWithFieldValue<T> = T extends Primitive
-    ? T
-    : T extends {}
-    ? {[K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue}
-    : Partial<T>;
+  export type PartialWithFieldValue<T> =
+    | Partial<T>
+    | (T extends Primitive
+        ? T
+        : T extends {}
+        ? {[K in keyof T]?: PartialWithFieldValue<T[K]> | FieldValue}
+        : never);
 
   /**
    * Allows FieldValues to be passed in as a property value while maintaining
    * type safety.
    */
-  export type WithFieldValue<T> = T extends Primitive
-    ? T
-    : T extends {}
-    ? {[K in keyof T]: WithFieldValue<T[K]> | FieldValue}
-    : Partial<T>;
+  export type WithFieldValue<T> =
+    | T
+    | (T extends Primitive
+        ? T
+        : T extends {}
+        ? {[K in keyof T]: WithFieldValue<T[K]> | FieldValue}
+        : never);
 
   /**
    * Update data (for use with [update]{@link DocumentReference#update})


### PR DESCRIPTION
Expanded `Firestore.WithFieldValue<T>` to include `T`. This allows developers to delegate `WithFieldValue<T>` inside wrappers of type `T` to avoid exposing Firebase types beyond Firebase-specific logic.

Porting from web: [1](https://github.com/firebase/firebase-js-sdk/pull/5675),[2](https://github.com/firebase/firebase-js-sdk/pull/5698)