### PR TITLE
fix(cloud-rad): move comments for TSDoc

### DIFF
--- a/dev/src/bundle.ts
+++ b/dev/src/bundle.ts
@@ -42,8 +42,6 @@ export class BundleBuilder {
 
   constructor(readonly bundleId: string) {}
 
-  add(documentSnapshot: DocumentSnapshot): BundleBuilder;
-  add(queryName: string, querySnapshot: QuerySnapshot): BundleBuilder;
   /**
    * Adds a Firestore document snapshot or query snapshot to the bundle.
    * Both the documents data and the query read time will be included in the bundle.
@@ -64,6 +62,8 @@ export class BundleBuilder {
    * // Save `bundleBuffer` to CDN or stream it to clients.
    * ```
    */
+  add(documentSnapshot: DocumentSnapshot): BundleBuilder;
+  add(queryName: string, querySnapshot: QuerySnapshot): BundleBuilder;
   add(
     documentOrName: DocumentSnapshot | string,
     querySnapshot?: QuerySnapshot

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -413,8 +413,6 @@ export class DocumentReference<T = firestore.DocumentData>
       .then(([writeResult]) => writeResult);
   }
 
-  set(data: Partial<T>, options: firestore.SetOptions): Promise<WriteResult>;
-  set(data: T): Promise<WriteResult>;
   /**
    * Writes to the document referred to by this DocumentReference. If the
    * document does not yet exist, it will be created. If you pass
@@ -440,6 +438,8 @@ export class DocumentReference<T = firestore.DocumentData>
    * });
    * ```
    */
+  set(data: Partial<T>, options: firestore.SetOptions): Promise<WriteResult>;
+  set(data: T): Promise<WriteResult>;
   set(
     data: T | Partial<T>,
     options?: firestore.SetOptions
@@ -2631,8 +2631,6 @@ export class CollectionReference<T = firestore.DocumentData>
     });
   }
 
-  doc(): DocumentReference<T>;
-  doc(documentPath: string): DocumentReference<T>;
   /**
    * Gets a [DocumentReference]{@link DocumentReference} instance that
    * refers to the document at the specified path. If no path is specified, an
@@ -2652,6 +2650,8 @@ export class CollectionReference<T = firestore.DocumentData>
    * console.log(`Reference with auto-id: ${documentRefWithAutoId.path}`);
    * ```
    */
+  doc(): DocumentReference<T>;
+  doc(documentPath: string): DocumentReference<T>;
   doc(documentPath?: string): DocumentReference<T> {
     if (arguments.length === 0) {
       documentPath = autoId();


### PR DESCRIPTION
As we move our ref docs to cloud.google.com, we rely on TSDoc rather JSDoc.

TSDoc expects comments before the first overloaded function, we
currently have those on the last function. Those comments don't make
it into the d.ts files. We need to move comments to the first
overloaded function rather than the last one.

Internally b/190631834

Script used: https://github.com/fhinkel/cloud-rad-script/blob/main/moveComments.js
