### PR TITLE
fix: save negative zero as doubleValue

### DIFF
--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -118,7 +118,7 @@ export class Serializer {
     }
 
     if (typeof val === 'number') {
-      const isNegativeZero = value === 0 && 1 / value === -Infinity;
+      const isNegativeZero = val === 0 && 1 / val === -Infinity;
       if (isNegativeZero) {
         return {
           doubleValue: -0,

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -118,7 +118,12 @@ export class Serializer {
     }
 
     if (typeof val === 'number') {
-      if (Number.isSafeInteger(val)) {
+      const isNegativeZero = value === 0 && 1 / value === -Infinity;
+      if (isNegativeZero) {
+        return {
+          doubleValue: -0,
+        };
+      } else if (Number.isSafeInteger(val)) {
         return {
           integerValue: val as number,
         };

--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -118,12 +118,8 @@ export class Serializer {
     }
 
     if (typeof val === 'number') {
-      const isNegativeZero = val === 0 && 1 / val === -Infinity;
-      if (isNegativeZero) {
-        return {
-          doubleValue: -0,
-        };
-      } else if (Number.isSafeInteger(val)) {
+      const isNegativeZero = val === 0 && 1 / val === 1 / -0;
+      if (Number.isSafeInteger(val) && !isNegativeZero) {
         return {
           integerValue: val as number,
         };

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -224,6 +224,29 @@ describe('serialize document', () => {
     });
   });
 
+  it('serializes negative zero into double', () => {
+    const overrides: ApiOverride = {
+      commit: request => {
+        requestEquals(
+          request,
+          set({
+            document: document('documentId', 'negativeZero', {
+              doubleValue: -0,
+            }),
+          })
+        );
+        return response(writeResult(1));
+      },
+    };
+
+    return createInstance(overrides).then(firestore => {
+      return firestore.doc('collectionId/documentId').set({
+        // Set to -0, which should be stored as a double.
+        negativeZero: -0,
+      });
+    });
+  });
+
   it('serializes date before 1970', () => {
     const overrides: ApiOverride = {
       commit: request => {


### PR DESCRIPTION
# Why?

Javascript only has a number type while firestore differentiates between int64 and double. Both the Web SDK and the nodejs SDK identify integers to store them appropriately. However, the algorithms between the Web SDK and the nodejs SDK differ in one particular case: the negative zero double value.

Relevant lines of code from the JS SDK:
https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/remote/number_serializer.ts#L56
https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/util/types.ts#L44

This PR aligns the nodejs SDK behavior with the one in the Web SDK.

# Template

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] ~~Appropriate docs were updated (if necessary)~~

Fixes #1638 🦕