### PR TITLE
docs: expose ReadWriteTransactionOptions and ReadOnlyTransactionOptions

### DIFF
--- a/dev/src/bulk-writer.ts
+++ b/dev/src/bulk-writer.ts
@@ -327,7 +327,7 @@ class BufferedOperation {
  * @class BulkWriterError
  */
 export class BulkWriterError extends Error {
-  /** @hideconstructor */
+  /** @private */
   constructor(
     /** The status code of the error. */
     readonly code: GrpcStatus,
@@ -495,7 +495,7 @@ export class BulkWriter {
     );
   };
 
-  /** @hideconstructor */
+  /** @private */
   constructor(
     private readonly firestore: Firestore,
     options?: firestore.BulkWriterOptions

--- a/dev/src/collection-group.ts
+++ b/dev/src/collection-group.ts
@@ -39,7 +39,7 @@ export class CollectionGroup<T = firestore.DocumentData>
   extends Query<T>
   implements firestore.CollectionGroup<T>
 {
-  /** @hideconstructor */
+  /** @private */
   constructor(
     firestore: Firestore,
     collectionId: string,

--- a/dev/src/document-change.ts
+++ b/dev/src/document-change.ts
@@ -35,7 +35,7 @@ export class DocumentChange<T = firestore.DocumentData>
   private readonly _newIndex: number;
 
   /**
-   * @hideconstructor
+   * @private
    *
    * @param {string} type 'added' | 'removed' | 'modified'.
    * @param {QueryDocumentSnapshot} document The document.

--- a/dev/src/document.ts
+++ b/dev/src/document.ts
@@ -108,7 +108,7 @@ export class DocumentSnapshot<T = firestore.DocumentData>
   private _updateTime: Timestamp | undefined;
 
   /**
-   * @hideconstructor
+   * @private
    *
    * @param ref The reference to the document.
    * @param _fieldsProto The fields of the Firestore `Document` Protobuf backing
@@ -122,6 +122,7 @@ export class DocumentSnapshot<T = firestore.DocumentData>
    */
   constructor(
     ref: DocumentReference<T>,
+    /** @private */
     readonly _fieldsProto?: ApiMapValue,
     readTime?: Timestamp,
     createTime?: Timestamp,
@@ -649,7 +650,7 @@ export class DocumentMask {
   /**
    * @private
    * @internal
-   * @hideconstructor
+   * @private
    *
    * @param fieldPaths The field paths in this mask.
    */
@@ -928,7 +929,7 @@ export class DocumentTransform<T = firestore.DocumentData> {
   /**
    * @private
    * @internal
-   * @hideconstructor
+   * @private
    *
    * @param ref The DocumentReference for this transform.
    * @param transforms A Map of FieldPaths to FieldTransforms.
@@ -1067,7 +1068,7 @@ export class Precondition {
   /**
    * @private
    * @internal
-   * @hideconstructor
+   * @private
    *
    * @param options.exists - Whether the referenced document should exist in
    * Firestore,

--- a/dev/src/field-value.ts
+++ b/dev/src/field-value.ts
@@ -37,9 +37,7 @@ import api = proto.google.firestore.v1;
  * @class FieldValue
  */
 export class FieldValue implements firestore.FieldValue {
-  /**
-   * @hideconstructor
-   */
+  /** @private */
   constructor() {}
 
   /**

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -132,13 +132,15 @@ setLibVersion(libVersion);
  */
 const CLOUD_RESOURCE_HEADER = 'google-cloud-resource-prefix';
 
-/*!
+/**
  * The maximum number of times to retry idempotent requests.
+ * @private
  */
 export const MAX_REQUEST_RETRIES = 5;
 
-/*!
+/**
  * The maximum number of times to attempt a transaction before failing.
+ * @private
  */
 export const DEFAULT_MAX_TRANSACTION_ATTEMPTS = 5;
 
@@ -330,8 +332,8 @@ const MAX_CONCURRENT_REQUESTS_PER_CLIENT = 100;
  *
  * @property {GrpcStatus} code The status code of the error.
  * @property {string} message The error message of the error.
- * @property {DocumentReference} documentRef The document reference the operation was
- * performed on.
+ * @property {DocumentReference} documentRef The document reference the
+ * operation was performed on.
  * @property {'create' | 'set' | 'update' | 'delete'} operationType The type
  * of operation performed.
  * @property {number} failedAttempts How many times this operation has been
@@ -861,21 +863,25 @@ export class Firestore implements firestore.Firestore {
     readTime?: google.protobuf.ITimestamp,
     encoding?: 'protobufJS'
   ): DocumentSnapshot;
+  /** @private */
   snapshot_(
     documentName: string,
     readTime: string,
     encoding: 'json'
   ): DocumentSnapshot;
+  /** @private */
   snapshot_(
     document: api.IDocument,
     readTime: google.protobuf.ITimestamp,
     encoding?: 'protobufJS'
   ): QueryDocumentSnapshot;
+  /** @private */
   snapshot_(
     document: {[k: string]: unknown},
     readTime: string,
     encoding: 'json'
   ): QueryDocumentSnapshot;
+  /** @private */
   snapshot_(
     documentOrName: api.IDocument | {[k: string]: unknown} | string,
     readTime?: google.protobuf.ITimestamp | string,
@@ -975,24 +981,22 @@ export class Firestore implements firestore.Firestore {
    * Options object for {@link Firestore#runTransaction} to configure a
    * read-only transaction.
    *
-   * @callback Firestore~ReadOnlyTransactionOptions
-   * @template T
    * @param {true} readOnly Set to true to indicate a read-only transaction.
    * @param {Timestamp=} readTime If specified, documents are read at the given
    * time. This may not be more than 60 seconds in the past from when the
    * request is processed by the server.
+   * @typedef {Object} Firestore~ReadOnlyTransactionOptions
    */
 
   /**
    * Options object for {@link Firestore#runTransaction} to configure a
    * read-write transaction.
    *
-   * @callback Firestore~ReadWriteTransactionOptions
-   * @template T
    * @param {false=} readOnly Set to false or omit to indicate a read-write
    * transaction.
    * @param {number=} maxAttempts The maximum number of attempts for this
-   * transaction. Defaults to five.
+   * transaction. Defaults to 5.
+   * @typedef {Object} Firestore~ReadWriteTransactionOptions
    */
 
   /**

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -77,7 +77,7 @@ abstract class Path<T> {
    *
    * @private
    * @internal
-   * @hideconstructor
+   * @private
    * @param segments Sequence of parts of a path.
    */
   constructor(protected readonly segments: string[]) {}

--- a/dev/src/query-partition.ts
+++ b/dev/src/query-partition.ts
@@ -39,7 +39,7 @@ export class QueryPartition<T = firestore.DocumentData>
   private _memoizedStartAt: unknown[] | undefined;
   private _memoizedEndBefore: unknown[] | undefined;
 
-  /** @hideconstructor */
+  /** @private */
   constructor(
     private readonly _firestore: Firestore,
     private readonly _collectionId: string,

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -128,15 +128,18 @@ export class DocumentReference<T = firestore.DocumentData>
   implements Serializable, firestore.DocumentReference<T>
 {
   /**
-   * @hideconstructor
+   * @private
    *
+   * @private
    * @param _firestore The Firestore Database client.
    * @param _path The Path of this reference.
    * @param _converter The converter to use when serializing data.
    */
   constructor(
     private readonly _firestore: Firestore,
+    /** @private */
     readonly _path: ResourcePath,
+    /** @private */
     readonly _converter = defaultConverter<T>()
   ) {}
 
@@ -805,7 +808,7 @@ export class QuerySnapshot<T = firestore.DocumentData>
   private _changes: (() => Array<DocumentChange<T>>) | null = null;
 
   /**
-   * @hideconstructor
+   * @private
    *
    * @param _query The originating query.
    * @param _readTime The time when this query snapshot was obtained.
@@ -1248,16 +1251,19 @@ export class QueryOptions<T> {
  */
 export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
   private readonly _serializer: Serializer;
+  /** @private */
   protected readonly _allowUndefined: boolean;
 
   /**
-   * @hideconstructor
+   * @private
    *
    * @param _firestore The Firestore Database client.
    * @param _queryOptions Options that define the query.
    */
   constructor(
+    /** @private */
     readonly _firestore: Firestore,
+    /** @private */
     protected readonly _queryOptions: QueryOptions<T>
   ) {
     this._serializer = new Serializer(_firestore);
@@ -2513,7 +2519,7 @@ export class CollectionReference<T = firestore.DocumentData>
   implements firestore.CollectionReference<T>
 {
   /**
-   * @hideconstructor
+   * @private
    *
    * @param firestore The Firestore Database client.
    * @param path The Path of this collection.

--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -66,7 +66,7 @@ export class Transaction implements firestore.Transaction {
   private _transactionId?: Uint8Array;
 
   /**
-   * @hideconstructor
+   * @private
    *
    * @param firestore The Firestore Database client.
    * @param requestTag A unique client-assigned identifier for the scope of

--- a/dev/src/watch.ts
+++ b/dev/src/watch.ts
@@ -212,7 +212,6 @@ abstract class Watch<T = firestore.DocumentData> {
   /**
    * @private
    * @internal
-   * @hideconstructor
    *
    * @param firestore The Firestore Database client.
    */

--- a/dev/src/write-batch.ts
+++ b/dev/src/write-batch.ts
@@ -57,7 +57,7 @@ import api = google.firestore.v1;
  */
 export class WriteResult implements firestore.WriteResult {
   /**
-   * @hideconstructor
+   * @private
    *
    * @param _writeTime The time of the corresponding document write.
    */
@@ -131,14 +131,13 @@ export class WriteBatch implements firestore.WriteBatch {
 
   /**
    * The number of writes in this batch.
+   * @private
    */
   get _opCount(): number {
     return this._ops.length;
   }
 
-  /**
-   * @hideconstructor
-   */
+  /** @private */
   constructor(firestore: Firestore) {
     this._firestore = firestore;
     this._serializer = new Serializer(firestore);

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -299,7 +299,7 @@ declare namespace FirebaseFirestore {
     /** Set to false or omit to indicate a read-write transaction. */
     readOnly?: false;
     /**
-     * The maximum number of attempts for this transaction. Defaults to five.
+     * The maximum number of attempts for this transaction. Defaults to 5.
      */
     maxAttempts?: number;
   }


### PR DESCRIPTION
This exposes ReadWriteTransactionOptions and ReadOnlyTransactionOptions in the public docs and hides some private members in the new docs pipeline.