### PR TITLE
fix: Remove @internal annotation from snapshot_

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -896,7 +896,6 @@ export class Firestore implements firestore.Firestore {
    * 'Proto3 JSON' and 'Protobuf JS' encoded data.
    *
    * @private
-   * @internal
    * @param documentOrName The Firestore 'Document' proto or the resource name
    * of a missing document.
    * @param readTime A 'Timestamp' proto indicating the time this document was


### PR DESCRIPTION
This commit removes the @internal annotation from snapshot_,
and fixes https://github.com/firebase/firebase-functions-test/issues/87.

`snapshot_` is currently referenced [here](https://github.com/firebase/firebase-functions-test/blob/master/src/providers/firestore.ts#L99).

[More context here](
https://github.com/firebase/firebase-functions-test/issues/87)

I'm happy to work through better alternatives too.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [?] Appropriate docs were updated (if necessary)

Fixes https://github.com/firebase/firebase-functions-test/issues/79  🦕
