### PR TITLE
fix: Don't allow serialization of firestore settings

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -652,6 +652,7 @@ export class Firestore implements firestore.Firestore {
     }
 
     this._settings = settings;
+    this._settings.toJson = function(){ return undefined; }
     this._serializer = new Serializer(this);
   }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -652,7 +652,9 @@ export class Firestore implements firestore.Firestore {
     }
 
     this._settings = settings;
-    this._settings.toJson = function(){ return undefined; }
+    this._settings.toJson = function () {
+      return undefined;
+    };
     this._serializer = new Serializer(this);
   }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -653,7 +653,11 @@ export class Firestore implements firestore.Firestore {
 
     this._settings = settings;
     this._settings.toJson = function () {
-      return undefined;
+      const temp = Object.assign({}, this);
+      if (temp.credentials) {
+        temp.credentials = {private_key: '***', client_email: '***'};
+      }
+      return temp;
     };
     this._serializer = new Serializer(this);
   }


### PR DESCRIPTION
When logging any firestore object like WriteBatch,Transaction,etc the settings object also gets logged / exposed
This can be seen by running JSON.stringify on any firestore object even a document reference
Many developers log firestore objects to help them debug testing/prod issues, this leaking of entire firestore key via this._settings is a bad practice as per me
We can also use Object.defineProperty to make it non-enumerable or any other technique that you like

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
