### PR TITLE
fix: Pin Typescript to prevent new type checking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "sinon": "^13.0.0",
     "through2": "^4.0.0",
     "ts-node": "^10.0.0",
-    "typescript": "^4.6.4"
+    "typescript": "~4.7.4"
   }
 }


### PR DESCRIPTION
We are experiencing type checking errors with new version 4.8.2 of typescript. So we are pinning to previous version 4.7.4.

See example of errors below:


dev/src/bulk-writer.ts:583:26 - error TS2345: Argument of type 'DocumentReference<T>' is not assignable to parameter of type 'DocumentReference<unknown>'.
  The types returned by 'parent.where(...).get()' are incompatible between these types.
    Type 'Promise<QuerySnapshot<T>>' is not assignable to type 'Promise<QuerySnapshot<unknown>>'.
      Type 'QuerySnapshot<T>' is not assignable to type 'QuerySnapshot<unknown>'.
        Types of property 'docs' are incompatible.
          Type 'QueryDocumentSnapshot<T>[]' is not assignable to type 'QueryDocumentSnapshot<unknown>[]'.
            Type 'QueryDocumentSnapshot<T>' is not assignable to type 'QueryDocumentSnapshot<unknown>'.
              Types of property 'isEqual' are incompatible.
                Type '(other: DocumentSnapshot<T>) => boolean' is not assignable to type '(other: DocumentSnapshot<unknown>) => boolean'.
                  Types of parameters 'other' and 'other' are incompatible.
                    Type 'DocumentSnapshot<unknown>' is not assignable to type 'DocumentSnapshot<T>'.
                      The types returned by 'ref.parent.where(...).get()' are incompatible between these types.
                        Type 'Promise<QuerySnapshot<unknown>>' is not assignable to type 'Promise<QuerySnapshot<T>>'.
                          Type 'QuerySnapshot<unknown>' is not assignable to type 'QuerySnapshot<T>'.
                            Types of property 'docs' are incompatible.
                              Type 'QueryDocumentSnapshot<unknown>[]' is not assignable to type 'QueryDocumentSnapshot<T>[]'.
                                Type 'QueryDocumentSnapshot<unknown>' is not assignable to type 'QueryDocumentSnapshot<T>'.
                                  The types returned by 'data()' are incompatible between these types.
                                    Type 'unknown' is not assignable to type 'T'.
                                      'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.

583     return this._enqueue(documentRef, 'create', bulkCommitBatch =>
                             ~~~~~~~~~~~

dev/src/bulk-writer.ts:623:26 - error TS2345: Argument of type 'DocumentReference<T>' is not assignable to parameter of type 'DocumentReference<unknown>'.
  The types returned by 'parent.where(...).get()' are incompatible between these types.
    Type 'Promise<QuerySnapshot<T>>' is not assignable to type 'Promise<QuerySnapshot<unknown>>'.
      Type 'QuerySnapshot<T>' is not assignable to type 'QuerySnapshot<unknown>'.
        Types of property 'docs' are incompatible.
          Type 'QueryDocumentSnapshot<T>[]' is not assignable to type 'QueryDocumentSnapshot<unknown>[]'.
            Type 'QueryDocumentSnapshot<T>' is not assignable to type 'QueryDocumentSnapshot<unknown>'.
              Types of property 'isEqual' are incompatible.
                Type '(other: DocumentSnapshot<T>) => boolean' is not assignable to type '(other: DocumentSnapshot<unknown>) => boolean'.
                  Types of parameters 'other' and 'other' are incompatible.
                    Type 'DocumentSnapshot<unknown>' is not assignable to type 'DocumentSnapshot<T>'.
                      The types returned by 'ref.parent.where(...).get()' are incompatible between these types.
                        Type 'Promise<QuerySnapshot<unknown>>' is not assignable to type 'Promise<QuerySnapshot<T>>'.
                          Type 'QuerySnapshot<unknown>' is not assignable to type 'QuerySnapshot<T>'.
                            Types of property 'docs' are incompatible.
                              Type 'QueryDocumentSnapshot<unknown>[]' is not assignable to type 'QueryDocumentSnapshot<T>[]'.
                                Type 'QueryDocumentSnapshot<unknown>' is not assignable to type 'QueryDocumentSnapshot<T>'.
                                  The types returned by 'data()' are incompatible between these types.
                                    Type 'unknown' is not assignable to type 'T'.
                                      'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.

623     return this._enqueue(documentRef, 'delete', bulkCommitBatch =>
                             ~~~~~~~~~~~

dev/src/bulk-writer.ts:683:26 - error TS2345: Argument of type 'DocumentReference<T>' is not assignable to parameter of type 'DocumentReference<unknown>'.
  The types returned by 'parent.where(...).get()' are incompatible between these types.
    Type 'Promise<QuerySnapshot<T>>' is not assignable to type 'Promise<QuerySnapshot<unknown>>'.
      Type 'QuerySnapshot<T>' is not assignable to type 'QuerySnapshot<unknown>'.
        Types of property 'docs' are incompatible.
          Type 'QueryDocumentSnapshot<T>[]' is not assignable to type 'QueryDocumentSnapshot<unknown>[]'.
            Type 'QueryDocumentSnapshot<T>' is not assignable to type 'QueryDocumentSnapshot<unknown>'.
              Types of property 'isEqual' are incompatible.
                Type '(other: DocumentSnapshot<T>) => boolean' is not assignable to type '(other: DocumentSnapshot<unknown>) => boolean'.
                  Types of parameters 'other' and 'other' are incompatible.
                    Type 'DocumentSnapshot<unknown>' is not assignable to type 'DocumentSnapshot<T>'.
                      The types returned by 'ref.parent.where(...).get()' are incompatible between these types.
                        Type 'Promise<QuerySnapshot<unknown>>' is not assignable to type 'Promise<QuerySnapshot<T>>'.
                          Type 'QuerySnapshot<unknown>' is not assignable to type 'QuerySnapshot<T>'.
                            Types of property 'docs' are incompatible.
                              Type 'QueryDocumentSnapshot<unknown>[]' is not assignable to type 'QueryDocumentSnapshot<T>[]'.
                                Type 'QueryDocumentSnapshot<unknown>' is not assignable to type 'QueryDocumentSnapshot<T>'.
                                  The types returned by 'data()' are incompatible between these types.
                                    Type 'unknown' is not assignable to type 'T'.
                                      'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.

683     return this._enqueue(documentRef, 'set', bulkCommitBatch => {
                             ~~~~~~~~~~~

dev/src/bulk-writer.ts:747:26 - error TS2345: Argument of type 'DocumentReference<T>' is not assignable to parameter of type 'DocumentReference<unknown>'.
  The types returned by 'parent.where(...).get()' are incompatible between these types.
    Type 'Promise<QuerySnapshot<T>>' is not assignable to type 'Promise<QuerySnapshot<unknown>>'.
      Type 'QuerySnapshot<T>' is not assignable to type 'QuerySnapshot<unknown>'.
        Types of property 'docs' are incompatible.
          Type 'QueryDocumentSnapshot<T>[]' is not assignable to type 'QueryDocumentSnapshot<unknown>[]'.
            Type 'QueryDocumentSnapshot<T>' is not assignable to type 'QueryDocumentSnapshot<unknown>'.
              Types of property 'isEqual' are incompatible.
                Type '(other: DocumentSnapshot<T>) => boolean' is not assignable to type '(other: DocumentSnapshot<unknown>) => boolean'.
                  Types of parameters 'other' and 'other' are incompatible.
                    Type 'DocumentSnapshot<unknown>' is not assignable to type 'DocumentSnapshot<T>'.
                      The types returned by 'ref.parent.where(...).get()' are incompatible between these types.
                        Type 'Promise<QuerySnapshot<unknown>>' is not assignable to type 'Promise<QuerySnapshot<T>>'.
                          Type 'QuerySnapshot<unknown>' is not assignable to type 'QuerySnapshot<T>'.
                            Types of property 'docs' are incompatible.
                              Type 'QueryDocumentSnapshot<unknown>[]' is not assignable to type 'QueryDocumentSnapshot<T>[]'.
                                Type 'QueryDocumentSnapshot<unknown>' is not assignable to type 'QueryDocumentSnapshot<T>'.
                                  The types returned by 'data()' are incompatible between these types.
                                    Type 'unknown' is not assignable to type 'T'.
                                      'T' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.

747     return this._enqueue(documentRef, 'update', bulkCommitBatch =>
                             ~~~~~~~~~~~

dev/src/write-batch.ts:198:7 - error TS2345: Argument of type 'WithFieldValue<T>' is not assignable to parameter of type 'WithFieldValue<DocumentData>'.
  Type 'T' is not assignable to type 'WithFieldValue<DocumentData>'.
    Type 'T' is not assignable to type '{ [x: string]: any; }'.

198       data as firestore.WithFieldValue<T>
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  dev/src/write-batch.ts:192:10
    192   create<T>(
                 ~
    This type parameter might need an `extends { [x: string]: any; }` constraint.
  dev/src/write-batch.ts:192:10
    192   create<T>(
                 ~
    This type parameter might need an `extends firestore.WithFieldValue<firestore.DocumentData>` constraint.

dev/src/write-batch.ts:339:50 - error TS2345: Argument of type 'T' is not assignable to parameter of type 'WithFieldValue<DocumentData>'.
  Type 'T' is not assignable to type '{ [x: string]: any; }'.

339       firestoreData = ref._converter.toFirestore(data as T);
                                                     ~~~~~~~~~

  dev/src/write-batch.ts:323:7
    323   set<T>(
              ~
    This type parameter might need an `extends { [x: string]: any; }` constraint.
  dev/src/write-batch.ts:323:7
    323   set<T>(
              ~
    This type parameter might need an `extends firestore.WithFieldValue<firestore.DocumentData>` constraint.

dev/src/write-batch.ts:490:24 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(o: { [s: string]: unknown; } | ArrayLike<unknown>): [string, unknown][]', gave the following error.
    Argument of type 'UpdateData<T>' is not assignable to parameter of type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
      Type 'T | (T extends {} ? { [K in keyof T]?: FieldValue | UpdateData<T[K]> | undefined; } & UnionToIntersection<{ [K in keyof T & string]: ChildUpdateFields<K, T[K]>; }[keyof T & string]> : Partial<...>)' is not assignable to type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
        Type 'Primitive & T' is not assignable to type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
          Type 'undefined & T' is not assignable to type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
            Type 'undefined & T' is not assignable to type 'ArrayLike<unknown>'.
              Type 'UpdateData<T>' is not assignable to type 'ArrayLike<unknown>'.
                Type 'T | (T extends {} ? { [K in keyof T]?: FieldValue | UpdateData<T[K]> | undefined; } & UnionToIntersection<{ [K in keyof T & string]: ChildUpdateFields<K, T[K]>; }[keyof T & string]> : Partial<...>)' is not assignable to type 'ArrayLike<unknown>'.
                  Type 'Primitive & T' is not assignable to type 'ArrayLike<unknown>'.
                    Type 'undefined & T' is not assignable to type 'ArrayLike<unknown>'.
  Overload 2 of 2, '(o: {}): [string, any][]', gave the following error.
    Argument of type 'UpdateData<T>' is not assignable to parameter of type '{}'.
      Type 'T | (T extends {} ? { [K in keyof T]?: FieldValue | UpdateData<T[K]> | undefined; } & UnionToIntersection<{ [K in keyof T & string]: ChildUpdateFields<K, T[K]>; }[keyof T & string]> : Partial<...>)' is not assignable to type '{}'.
        Type 'Primitive & T' is not assignable to type '{}'.
          Type 'undefined & T' is not assignable to type '{}'.

490         Object.entries(dataOrField as firestore.UpdateData<T>).forEach(
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~



Found 7 errors in 2 files.
