### PR TITLE
docs: Write javadocs for COUNT API

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -56,7 +56,6 @@ import {
 import {DocumentWatch, QueryWatch} from './watch';
 import {validateDocumentData, WriteBatch, WriteResult} from './write-batch';
 import api = protos.google.firestore.v1;
-import {Primitive} from '@google-cloud/firestore';
 
 /**
  * The direction of a `Query.orderBy()` clause is specified as 'desc' or 'asc'
@@ -3314,7 +3313,7 @@ function isArrayEqual<T extends {isEqual: (t: T) => boolean}>(
  * @param right Array of primitives.
  * @return True if arrays are equal.
  */
-function isPrimitiveArrayEqual<T extends Primitive>(
+function isPrimitiveArrayEqual<T>(
   left: T[],
   right: T[]
 ): boolean {

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -3061,23 +3061,28 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
     if (this === other) {
       return true;
     }
-    if (other instanceof AggregateQuery) {
-      if (!this._query.isEqual(other._query)) {
-        return false;
-      }
-
-      const thisAggregates: [string, AggregateField<unknown>][] =
-        Object.entries(this._aggregates);
-      const otherAggregates = other._aggregates;
-
-      return (
-        thisAggregates.length === Object.keys(otherAggregates).length &&
-        thisAggregates.every(([alias, field]) =>
-          field.isEqual(otherAggregates[alias])
-        )
-      );
+    if (!(other instanceof AggregateQuery)) {
+      return false;
     }
-    return false;
+    if (!this._query.isEqual(other._query)) {
+      return false;
+    }
+
+    // Verify that this object has the same aggregation keys as `other`.
+    const thisAggregateKeys = Object.keys(this._aggregates).sort();
+    const otherAggregateKeys = Object.keys(other._aggregates).sort();
+    if (thisAggregateKeys.length != otherAggregateKeys.length) {
+      return false;
+    }
+    if (thisAggregateKeys.some((key, index) => key !== otherAggregateKeys[index])) {
+      return false;
+    }
+
+    // TODO: Also compare the `AggregateField` instances from `this._aggregates`
+    // to their counterparts in `other._aggregates` once `AggregateField` gains
+    // an `isEqual()` method, which will happen once we support more than one
+    // type of `AggregateField` (currently, we only support "count").
+    return true;
   }
 }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2873,8 +2873,6 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
   ) {}
 
   /** The query whose aggregations will be calculated by this object. */
-
-  /** The query that was executed to produce this result. */
   get query(): Query<unknown> {
     return this._query;
   }
@@ -3313,10 +3311,7 @@ function isArrayEqual<T extends {isEqual: (t: T) => boolean}>(
  * @param right Array of primitives.
  * @return True if arrays are equal.
  */
-function isPrimitiveArrayEqual<T>(
-  left: T[],
-  right: T[]
-): boolean {
+function isPrimitiveArrayEqual<T>(left: T[], right: T[]): boolean {
   if (left.length !== right.length) {
     return false;
   }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -3139,8 +3139,8 @@ export class AggregateQuerySnapshot<T extends firestore.AggregateSpec>
    * Compares this object with the given object for equality.
    *
    * Two `AggregateQuerySnapshot` instances are considered "equal" if they
-   * have the read time, the same data, and underlying queries that compare
-   * "equal" using `AggregateQuery.isEqual()`.
+   * have the same data and their underlying queries compare "equal" using
+   * `AggregateQuery.isEqual()`.
    *
    * @param other The object to compare to this object for equality.
    * @return `true` if this object is "equal" to the given object, as
@@ -3153,9 +3153,9 @@ export class AggregateQuerySnapshot<T extends firestore.AggregateSpec>
     if (!(other instanceof AggregateQuerySnapshot)) {
       return false;
     }
-    if (!this.readTime.isEqual(other.readTime)) {
-      return false;
-    }
+    // Since the read time is different on every read, we explicitly ignore all
+    // document metadata in this comparison, just like
+    // `DocumentSnapshot.isEqual()` does.
     if (!this.query.isEqual(other.query)) {
       return false;
     }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -3057,7 +3057,8 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
    *
    * This object is considered "equal" to the other object if and only if
    * `other` performs the same aggregations as this `AggregateQuery` and
-   * the underlying `Query` of `other` compares equal to that of this object.
+   * the underlying Query of `other` compares equal to that of this object
+   * using `Query.isEqual()`.
    *
    * @param other The object to compare to this object for equality.
    * @return `true` if this object is "equal" to the given object, as
@@ -3073,19 +3074,7 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
     if (!this.query.isEqual(other.query)) {
       return false;
     }
-
-    // Verify that this object has the same aggregation keys as `other`.
-    const thisAggregateKeys = Object.keys(this._aggregates).sort();
-    const otherAggregateKeys = Object.keys(other._aggregates).sort();
-    if (!isPrimitiveArrayEqual(thisAggregateKeys, otherAggregateKeys)) {
-      return false;
-    }
-
-    // TODO: Also compare the `AggregateField` instances from `this._aggregates`
-    // to their counterparts in `other._aggregates` once `AggregateField` gains
-    // an `isEqual()` method, which will happen once we support more than one
-    // type of `AggregateField` (currently, we only support "count").
-    return true;
+    return deepEqual(this._aggregates, other._aggregates);
   }
 }
 
@@ -3160,19 +3149,7 @@ export class AggregateQuerySnapshot<T extends firestore.AggregateSpec>
       return false;
     }
 
-    // Verify that this object has the same aggregation keys as `other`.
-    const thisAggregateKeys = Object.keys(this._data).sort();
-    const otherAggregateKeys = Object.keys(other._data).sort();
-    if (!isPrimitiveArrayEqual(thisAggregateKeys, otherAggregateKeys)) {
-      return false;
-    }
-
-    // Verify that this object has the same aggregation results as `other`.
-    if (!thisAggregateKeys.every(key => this._data[key] === other._data[key])) {
-      return false;
-    }
-
-    return true;
+    return deepEqual(this._data, other._data);
   }
 }
 
@@ -3300,29 +3277,6 @@ function isArrayEqual<T extends {isEqual: (t: T) => boolean}>(
 
   for (let i = 0; i < left.length; ++i) {
     if (!left[i].isEqual(right[i])) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/**
- * Verifies equality for an array of primitives using the `===` operator.
- *
- * @private
- * @internal
- * @param left Array of primitives.
- * @param right Array of primitives.
- * @return True if arrays are equal.
- */
-function isPrimitiveArrayEqual<T>(left: T[], right: T[]): boolean {
-  if (left.length !== right.length) {
-    return false;
-  }
-
-  for (let i = 0; i < left.length; ++i) {
-    if (left[i] !== right[i]) {
       return false;
     }
   }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1599,11 +1599,21 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
   }
 
   /**
-   * Returns an `AggregateQuery` that counts the number of documents in the
-   * result set.
+   * Returns a query that counts the documents in the result set of this
+   * query.
    *
-   * @return an `AggregateQuery` that counts the number of documents in the
-   * result set.
+   * The returned query, when executed, counts the documents in the result set
+   * of this query without actually downloading the documents.
+   *
+   * Using the returned query to count the documents is efficient because only
+   * the final count, not the documents' data, is downloaded. The returned
+   * query can even count the documents if the result set would be
+   * prohibitively large to download entirely (e.g. thousands of documents).
+   *
+   * @return a query that counts the documents in the result set of this
+   * query. The count can be retrieved from `snapshot.data().count`, where
+   * `snapshot` is the `AggregateQuerySnapshot` resulting from running the
+   * returned query.
    */
   count(): AggregateQuery<{count: firestore.AggregateField<number>}> {
     return this._aggregate({count: AggregateField.count()});
@@ -2859,10 +2869,6 @@ export class AggregateField<T> implements firestore.AggregateField<T> {
 
   static count(): AggregateField<number> {
     return new AggregateField<number>();
-  }
-
-  isEqual(other: firestore.AggregateField<T>): boolean {
-    return this === other || other instanceof AggregateField;
   }
 }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -56,7 +56,7 @@ import {
 import {DocumentWatch, QueryWatch} from './watch';
 import {validateDocumentData, WriteBatch, WriteResult} from './write-batch';
 import api = protos.google.firestore.v1;
-import {Primitive} from "@google-cloud/firestore";
+import {Primitive} from '@google-cloud/firestore';
 
 /**
  * The direction of a `Query.orderBy()` clause is specified as 'desc' or 'asc'
@@ -2853,10 +2853,6 @@ export class CollectionReference<T = firestore.DocumentData>
   }
 }
 
-export class AggregateField<T> implements firestore.AggregateField<T> {
-  private constructor() {}
-}
-
 /**
  * A query that calculates aggregations over an underlying query.
  */
@@ -2867,15 +2863,22 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
    * @private
    * @internal
    *
-   * @param _query The query whose aggregations will be calculated by this object.
+   * @param _query The query whose aggregations will be calculated by this
+   * object.
    * @param _aggregates The aggregations that will be performed by this query.
    */
-  constructor(_query: Query<any>, private readonly _aggregates: T) {
-    this.query = _query;
-  }
+  constructor(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private readonly _query: Query<any>,
+    private readonly _aggregates: T
+  ) {}
 
   /** The query whose aggregations will be calculated by this object. */
-  readonly query: Query<unknown>;
+
+  /** The query that was executed to produce this result. */
+  get query(): Query<unknown> {
+    return this._query;
+  }
 
   /**
    * Executes this query.
@@ -3000,9 +3003,10 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
    * Internal method to decode values within result.
    * @private
    */
-  private _decodeResult(
+  private decodeResult(
     proto: api.IAggregationResult
   ): firestore.AggregateSpecData<T> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = {};
     const fields = proto.aggregateFields;
     if (fields) {
@@ -3027,9 +3031,10 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
    * @internal
    * @returns Serialized JSON for the query.
    */
-  _toProto(transactionId?: Uint8Array): api.IRunAggregationQueryRequest {
+  toProto(transactionId?: Uint8Array): api.IRunAggregationQueryRequest {
     const queryProto = this.query.toProto();
-    //TODO(tomandersen) inspect _query to build request - this is just hard coded count right now.
+    //TODO(tomandersen) inspect _query to build request - this is just hard
+    // coded count right now.
     const runQueryRequest: api.IRunAggregationQueryRequest = {
       parent: queryProto.parent,
       structuredAggregationQuery: {
@@ -3103,19 +3108,20 @@ export class AggregateQuerySnapshot<T extends firestore.AggregateSpec>
    * query.
    */
   constructor(
-    _query: AggregateQuery<T>,
-    _readTime: Timestamp,
+    private readonly _query: AggregateQuery<T>,
+    private readonly _readTime: Timestamp,
     private readonly _data: firestore.AggregateSpecData<T>
-  ) {
-    this.query = _query;
-    this.readTime = _readTime;
-  }
+  ) {}
 
   /** The query that was executed to produce this result. */
-  readonly query: AggregateQuery<T>;
+  get query(): AggregateQuery<T> {
+    return this._query;
+  }
 
   /** The time this snapshot was read. */
-  readonly readTime: firestore.Timestamp;
+  get readTime(): Timestamp {
+    return this._readTime;
+  }
 
   /**
    * Returns the results of the aggregations performed over the underlying
@@ -3308,7 +3314,10 @@ function isArrayEqual<T extends {isEqual: (t: T) => boolean}>(
  * @param right Array of primitives.
  * @return True if arrays are equal.
  */
-function isPrimitiveArrayEqual<T extends Primitive>(left: T[], right: T[]): boolean {
+function isPrimitiveArrayEqual<T extends Primitive>(
+  left: T[],
+  right: T[]
+): boolean {
   if (left.length !== right.length) {
     return false;
   }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2922,7 +2922,7 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
    */
   _stream(transactionId?: Uint8Array): Readable {
     const tag = requestTag();
-    const firestore = this.query.firestore;
+    const firestore = this._query.firestore;
 
     const stream: Transform = new Transform({
       objectMode: true,
@@ -3007,7 +3007,7 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
     const data: any = {};
     const fields = proto.aggregateFields;
     if (fields) {
-      const serializer = this.query.firestore._serializer!;
+      const serializer = this._query.firestore._serializer!;
       for (const prop of Object.keys(fields)) {
         if (this._aggregates[prop] === undefined) {
           throw new Error(
@@ -3029,7 +3029,7 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
    * @returns Serialized JSON for the query.
    */
   toProto(transactionId?: Uint8Array): api.IRunAggregationQueryRequest {
-    const queryProto = this.query.toProto();
+    const queryProto = this._query.toProto();
     //TODO(tomandersen) inspect _query to build request - this is just hard
     // coded count right now.
     const runQueryRequest: api.IRunAggregationQueryRequest = {

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -3167,7 +3167,12 @@ export class AggregateQuerySnapshot<T extends firestore.AggregateSpec>
       return false;
     }
 
-    return thisAggregateKeys.every(key => this._data[key] === other._data[key]);
+    // Verify that this object has the same aggregation results as `other`.
+    if (!thisAggregateKeys.every(key => this._data[key] === other._data[key])) {
+      return false;
+    }
+
+    return true;
   }
 }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2873,7 +2873,7 @@ export class AggregateQuery<T extends firestore.AggregateSpec>
   ) {}
 
   /** The query whose aggregations will be calculated by this object. */
-  get query(): Query<unknown> {
+  get query(): firestore.Query<unknown> {
     return this._query;
   }
 
@@ -3100,12 +3100,12 @@ export class AggregateQuerySnapshot<T extends firestore.AggregateSpec>
   ) {}
 
   /** The query that was executed to produce this result. */
-  get query(): AggregateQuery<T> {
+  get query(): firestore.AggregateQuery<T> {
     return this._query;
   }
 
   /** The time this snapshot was read. */
-  get readTime(): Timestamp {
+  get readTime(): firestore.Timestamp {
     return this._readTime;
   }
 

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -21,7 +21,7 @@
 // Declare a global (ambient) namespace
 // (used when not using import statement, but just script include).
 declare namespace FirebaseFirestore {
-  // Alias for `any` but used where a Firestore field value would be provided.
+  /** Alias for `any` but used where a Firestore field value would be provided. */
   export type DocumentFieldValue = any;
 
   /**
@@ -2081,7 +2081,7 @@ declare namespace FirebaseFirestore {
 
   /**
    * A query that calculates aggregations over an underlying query.
-   * */
+   */
   export class AggregateQuery<T extends AggregateSpec> {
     private constructor();
 
@@ -2091,7 +2091,7 @@ declare namespace FirebaseFirestore {
     /**
      * Executes this query.
      *
-     * @return A {promise that will be resolved with the results of the query.
+     * @return A promise that will be resolved with the results of the query.
      */
     get(): Promise<AggregateQuerySnapshot<T>>;
 

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -2050,18 +2050,12 @@ declare namespace FirebaseFirestore {
    */
   export class AggregateField<T> {
     private constructor();
-
-    /**
-     * Returns an aggregation field that counts the documents in the result set
-     * of a query.
-     */
-    static count(): AggregateField<number>;
   }
 
   /**
    * The union of all `AggregateField` types that are supported by Firestore.
    */
-  export type AggregateFieldType = ReturnType<typeof AggregateField.count>;
+  export type AggregateFieldType = AggregateField<number>;
 
   /**
    * A type whose property values are all `AggregateField` objects.
@@ -2099,7 +2093,7 @@ declare namespace FirebaseFirestore {
      * Compares this object with the given object for equality.
      *
      * This object is considered "equal" to the other object if and only if
-     * `other` performs the same aggregations as this {@link AggregateQuery} and
+     * `other` performs the same aggregations as this `AggregateQuery` and
      * the underlying `Query` of `other` compares equal to that of this object.
      *
      * @param other The object to compare to this object for equality.

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -2133,8 +2133,8 @@ declare namespace FirebaseFirestore {
      * Compares this object with the given object for equality.
      *
      * Two `AggregateQuerySnapshot` instances are considered "equal" if they
-     * have the read time, the same data, and underlying queries that compare
-     * "equal" using `AggregateQuery.isEqual()`.
+     * have the same data and their underlying queries compare "equal" using
+     * `AggregateQuery.isEqual()`.
      *
      * @param other The object to compare to this object for equality.
      * @return `true` if this object is "equal" to the given object, as

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -2095,7 +2095,8 @@ declare namespace FirebaseFirestore {
      *
      * This object is considered "equal" to the other object if and only if
      * `other` performs the same aggregations as this `AggregateQuery` and
-     * the underlying `Query` of `other` compares equal to that of this object.
+     * the underlying Query of `other` compares equal to that of this object
+     * using `Query.isEqual()`.
      *
      * @param other The object to compare to this object for equality.
      * @return `true` if this object is "equal" to the given object, as

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -2048,6 +2048,7 @@ declare namespace FirebaseFirestore {
   /**
    * Represents an aggregation that can be performed by Firestore.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export class AggregateField<T> {
     private constructor();
   }

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -1707,9 +1707,21 @@ declare namespace FirebaseFirestore {
     ): () => void;
 
     /**
-     * Returns count `AggregateQuery` based on this `Query`.
+     * Returns a query that counts the documents in the result set of this
+     * query.
      *
-     * @return AggregateQuery that contains count aggregate.
+     * The returned query, when executed, counts the documents in the result set
+     * of this query without actually downloading the documents.
+     *
+     * Using the returned query to count the documents is efficient because only
+     * the final count, not the documents' data, is downloaded. The returned
+     * query can even count the documents if the result set would be
+     * prohibitively large to download entirely (e.g. thousands of documents).
+     *
+     * @return a query that counts the documents in the result set of this
+     * query. The count can be retrieved from `snapshot.data().count`, where
+     * `snapshot` is the `AggregateQuerySnapshot` resulting from running the
+     * returned query.
      */
     count(): AggregateQuery<{count: AggregateField<number>}>;
 
@@ -2034,94 +2046,104 @@ declare namespace FirebaseFirestore {
   }
 
   /**
-   * An `AggregateField`that captures input type T.
+   * Represents an aggregation that can be performed by Firestore.
    */
   export class AggregateField<T> {
     private constructor();
 
     /**
-     * Creates and returns an aggregation field that counts the documents in the result set.
-     * @returns An `AggregateField` object with number input type.
+     * Returns an aggregation field that counts the documents in the result set
+     * of a query.
      */
     static count(): AggregateField<number>;
-
-    /**
-     * Returns true if the aggregate function in this `AggregateField` is equal to the
-     * provided one.
-     *
-     * @param other The `AggregateField` to compare against.
-     * @return true if this `AggregateField` is equal to the provided one.
-     */
-    isEqual(other: AggregateField<T>): boolean;
   }
 
   /**
-   * The union of all `AggregateField` types that are returned from the factory
-   * functions.
+   * The union of all `AggregateField` types that are supported by Firestore.
    */
   export type AggregateFieldType = ReturnType<typeof AggregateField.count>;
 
   /**
-   * A type whose values are all `AggregateField` objects.
-   * This is used as an argument to the "getter" functions, and the snapshot will
-   * map the same names to the corresponding values.
+   * A type whose property values are all `AggregateField` objects.
    */
   export interface AggregateSpec {
     [field: string]: AggregateFieldType;
   }
 
   /**
-   * A type whose keys are taken from an `AggregateSpec` type, and whose values
-   * are the result of the aggregation performed by the corresponding
+   * A type whose keys are taken from an `AggregateSpec`, and whose values are
+   * the result of the aggregation performed by the corresponding
    * `AggregateField` from the input `AggregateSpec`.
    */
   export type AggregateSpecData<T extends AggregateSpec> = {
     [P in keyof T]: T[P] extends AggregateField<infer U> ? U : never;
   };
 
+  /**
+   * A query that calculates aggregations over an underlying query.
+   * */
   export class AggregateQuery<T extends AggregateSpec> {
     private constructor();
 
+    /** The query whose aggregations will be calculated by this object. */
     readonly query: Query<unknown>;
 
+    /**
+     * Executes this query.
+     *
+     * @return A {promise that will be resolved with the results of the query.
+     */
     get(): Promise<AggregateQuerySnapshot<T>>;
 
     /**
-     * Returns true if the query and aggregates in this `AggregateQuery` is equal to the
-     * provided one.
+     * Compares this object with the given object for equality.
      *
-     * @param other The `AggregateQuery` to compare against.
-     * @return true if this `AggregateQuery` is equal to the provided one.
+     * This object is considered "equal" to the other object if and only if
+     * `other` performs the same aggregations as this {@link AggregateQuery} and
+     * the underlying `Query` of `other` compares equal to that of this object.
+     *
+     * @param other The object to compare to this object for equality.
+     * @return `true` if this object is "equal" to the given object, as
+     * defined above, or `false` otherwise.
      */
     isEqual(other: AggregateQuery<T>): boolean;
   }
 
   /**
-   * An `AggregateQuerySnapshot` contains the results of running an aggregate query.
+   * The results of executing an aggregation query.
    */
   export class AggregateQuerySnapshot<T extends AggregateSpec> {
     private constructor();
 
+    /** The query that was executed to produce this result. */
     readonly query: AggregateQuery<T>;
 
+    /** The time this snapshot was read. */
     readonly readTime: Timestamp;
 
     /**
-     * The results of the requested aggregations. The keys of the returned object
-     * will be the same as those of the `AggregateSpec` object specified to the
-     * aggregation method, and the values will be the corresponding aggregation
-     * result.
+     * Returns the results of the aggregations performed over the underlying
+     * query.
      *
-     * @returns The aggregation statistics result of running a query.
+     * The keys of the returned object will be the same as those of the
+     * `AggregateSpec` object specified to the aggregation method, and the
+     * values will be the corresponding aggregation result.
+     *
+     * @returns The results of the aggregations performed over the underlying
+     * query.
      */
     data(): AggregateSpecData<T>;
 
     /**
-     * Returns true if the query, read time, and data in this `AggregateQuerySnapshot`
-     * is equal to the provided one.
+     * Compares this object with the given object for equality.
      *
-     * @param other The `AggregateQuerySnapshot` to compare against.
-     * @return true if this `AggregateQuerySnapshot` is equal to the provided one.
+     * Two `AggregateQuerySnapshot` instances are considered "equal" if they
+     * have the read time, the same data, and underlying queries that compare
+     * "equal" using `AggregateQuery.isEqual()`.
+     *
+     * @param other The object to compare to this object for equality.
+     * @return `true` if this object is "equal" to the given object, as
+     * defined above, or `false` otherwise.
      */
     isEqual(other: AggregateQuerySnapshot<T>): boolean;
   }


### PR DESCRIPTION
The wording is (mostly) copied from https://github.com/firebase/firebase-android-sdk/pull/4143, and also partially from https://github.com/firebase/firebase-js-sdk/pull/6632.

There were also some last-minute API and implementation changes:
1. `AggregateField.count()` and `AggregateField.isEqual()` were deleted, since they have no use case until other aggregations are supported (the same change was made in the firebase-js-sdk).
1. `Query._aggregate()` was removed, since it was so much simpler to just inline it into `Query.count()`.
1. Some lint warnings were suppressed with `eslint-disable-next-line` comments.
1. `AggregateQuery.isEqual()` and `AggregateQuerySnapshot.isEqual()` were tweaked to accommodate the deletion of `AggregateField.isEqual()`.
