### PR TITLE
fix: Set emulator credentials on rest fallback

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -597,6 +597,23 @@ export class Firestore implements firestore.Firestore {
           // also set the `protocol` option for GAX fallback to force http
           if (useFallback) {
             settings.protocol = 'http';
+
+            // If the emulator mode is enabled, we set emulator credentials
+            // to prevent the gRPC-fallback client from trying to obtain
+            // service account credentials from the environment.
+            if (process.env.FIRESTORE_EMULATOR_HOST) {
+              const emulatorCredentials = {
+                access_token: 'owner',
+              };
+              const emulatorClient =
+                // eslint-disable-next-line node/no-extraneous-require
+                new (require('google-auth-library').OAuth2Client)();
+              emulatorClient.setCredentials(emulatorCredentials);
+              const emulatorAuth = new (require('google-gax').GoogleAuth)({
+                authClient: emulatorClient,
+              });
+              settings.auth = emulatorAuth;
+            }
           }
 
           client = new module.exports.v1(settings, gax);

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -609,6 +609,8 @@ export class Firestore implements firestore.Firestore {
                 // eslint-disable-next-line node/no-extraneous-require
                 new (require('google-auth-library').OAuth2Client)();
               emulatorClient.setCredentials(emulatorCredentials);
+              emulatorClient.projectId =
+                settings.projectId ?? process.env.GCLOUD_PROJECT;
               const emulatorAuth = new (require('google-gax').GoogleAuth)({
                 authClient: emulatorClient,
               });


### PR DESCRIPTION
Setting Emulator credentials when REST fallback is enabled by setting `preferRest: true`.

I am not familiar with the codebase and looking for review from the experts :)
We already set emulator credentials on gRPC mode by setting custom headers at: https://github.com/googleapis/nodejs-firestore/blob/653a8e996b6e6be01825f030e81d0379b4318c8a/dev/src/index.ts#L1453 but for some reason this is not effective on REST fallback.

**Test coverage:**
Tried to add unit tests with `sinon.spy` on `modules.exports.v1` and `FirestoreClient`, but couldn't get it to work. Appreciate any thoughts on adding test coverage to this.

Fixes googleapis/gax-nodejs#1811 🦕
