### PR TITLE
fix: emulator support for system tests

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -527,6 +527,13 @@ export class Firestore implements firestore.Firestore {
    * to `true`, these properties are skipped and not written to Firestore. If
    * set `false` or omitted, the SDK throws an exception when it encounters
    * properties of type `undefined`.
+   * @param {boolean=} settings.preferRest Whether to force the use of HTTP/1.1 REST
+   * transport until a method that requires gRPC is called. When a method requires gRPC,
+   * this Firestore client will load dependent gRPC libraries and then use gRPC transport
+   * for communication from that point forward. Currently the only operation
+   * that requires gRPC is creating a snapshot listener with the method
+   * `DocumentReference<T>.onSnapshot()`, `CollectionReference<T>.onSnapshot()`, or
+   * `Query<T>.onSnapshot()`.
    */
   constructor(settings?: firestore.Settings) {
     const libraryHeader = {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "docs": "jsdoc -c .jsdoc.js",
     "system-test:rest": "USE_REST_FALLBACK=YES mocha build/system-test --timeout 600000",
     "system-test:grpc": "mocha build/system-test --timeout 600000",
+    "system-test:rest:emulator": "USE_REST_FALLBACK=YES FIRESTORE_EMULATOR_HOST=localhost:8080 mocha build/system-test --timeout 600000",
+    "system-test:grpc:emulator": "FIRESTORE_EMULATOR_HOST=localhost:8080 mocha build/system-test --timeout 600000",
     "system-test": "npm run system-test:grpc && npm run system-test:rest",
     "presystem-test": "npm run compile",
     "samples-test": "npm link && cd samples/ && npm link ../ && npm test && cd ../",


### PR DESCRIPTION
fix: emulator support for system tests. Run system tests against the emulator using: `yarn system-test:grpc:emulator` or `yarn system-test:rest:emulator`

BEGIN_COMMIT_OVERRIDE
fix: emulator support for system tests. Run system tests against the emulator using: `yarn system-test:grpc:emulator` or `yarn system-test:rest:emulator`
END_COMMIT_OVERRIDE