### PR TITLE
fix: Update the depth validation used when writing documents

### DIFF
--- a/dev/src/serializer.ts
+++ b/dev/src/serializer.ts
@@ -312,7 +312,7 @@ export function validateUserInput(
   level?: number,
   inArray?: boolean
 ): void {
-  if (path && path.size > MAX_DEPTH) {
+  if (path && path.size - 1 > MAX_DEPTH) {
     throw new Error(
       `${invalidArgumentMessage(
         arg,

--- a/dev/test/serializer.ts
+++ b/dev/test/serializer.ts
@@ -60,7 +60,8 @@ describe('validateUserInput', () => {
                                           uiData: {
                                             // depth 19
                                             choicesFactors: {
-                                              rarely: 1, // depth 20
+                                              // depth 20
+                                              rarely: 1,
                                             },
                                           },
                                         },
@@ -135,7 +136,8 @@ describe('validateUserInput', () => {
                                             choicesFactors: {
                                               // depth 20
                                               rarely: {
-                                                cat: true, // depth 21
+                                                // depth 21
+                                                cat: true,
                                               },
                                             },
                                           },
@@ -166,7 +168,7 @@ describe('validateUserInput', () => {
         allowUndefined: false,
       })
     ).to.throw(
-      'Value for argument "nestedObject" is not a valid Firestore Object. Input object is deeper than 20 levels or contains a cycle.'
+      /Input object is deeper than 20 levels/i
     );
   });
 
@@ -207,7 +209,6 @@ describe('validateUserInput', () => {
 
   it('validates the depth of nested objects and arrays - 21', () => {
     // This nested object is 21 levels deep
-    // This nested object is 20 levels deep
     const nestedObject = {
       a: {
         b: {
@@ -243,7 +244,7 @@ describe('validateUserInput', () => {
         allowUndefined: false,
       })
     ).to.throw(
-      'Value for argument "nestedObject" is not a valid Firestore Object. Input object is deeper than 20 levels or contains a cycle.'
+        /Input object is deeper than 20 levels/i
     );
   });
 });

--- a/dev/test/serializer.ts
+++ b/dev/test/serializer.ts
@@ -1,0 +1,249 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {it} from 'mocha';
+import {expect} from 'chai';
+import {validateUserInput} from '../src/serializer';
+
+describe('validateUserInput', () => {
+  it('validates the depth of nested objects and arrays - 20', () => {
+    // This nested object is 20 levels deep
+    const nestedObject = {
+      // depth 0
+      links: [
+        // depth 1
+        {
+          // depth 2
+          child: {
+            // depth 3
+            links: [
+              // depth 4
+              {
+                // depth 5
+                child: {
+                  // depth 6
+                  links: [
+                    // depth 7
+                    {
+                      // depth 8
+                      child: {
+                        // depth 9
+                        links: [
+                          // depth 10
+                          {
+                            // depth 11
+                            child: {
+                              // depth 12
+                              links: [
+                                // depth 13
+                                {
+                                  // depth 14
+                                  child: {
+                                    // depth 15
+                                    links: [
+                                      // depth 16
+                                      {
+                                        // depth 17
+                                        child: {
+                                          // depth 18
+                                          uiData: {
+                                            // depth 19
+                                            choicesFactors: {
+                                              rarely: 1, // depth 20
+                                            },
+                                          },
+                                        },
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    validateUserInput('nestedObject', nestedObject, 'Firestore Object', {
+      allowDeletes: 'none',
+      allowTransforms: false,
+      allowUndefined: false,
+    });
+  });
+
+  it('validates the depth of nested objects and arrays - 21', () => {
+    // This nested object is 21 levels deep
+    const nestedObject = {
+      // depth 0
+      links: [
+        // depth 1
+        {
+          // depth 2
+          child: {
+            // depth 3
+            links: [
+              // depth 4
+              {
+                // depth 5
+                child: {
+                  // depth 6
+                  links: [
+                    // depth 7
+                    {
+                      // depth 8
+                      child: {
+                        // depth 9
+                        links: [
+                          // depth 10
+                          {
+                            // depth 11
+                            child: {
+                              // depth 12
+                              links: [
+                                // depth 13
+                                {
+                                  // depth 14
+                                  child: {
+                                    // depth 15
+                                    links: [
+                                      // depth 16
+                                      {
+                                        // depth 17
+                                        child: {
+                                          // depth 18
+                                          uiData: {
+                                            // depth 19
+                                            choicesFactors: {
+                                              // depth 20
+                                              rarely: {
+                                                cat: true, // depth 21
+                                              },
+                                            },
+                                          },
+                                        },
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(() =>
+      validateUserInput('nestedObject', nestedObject, 'Firestore Object', {
+        allowDeletes: 'none',
+        allowTransforms: false,
+        allowUndefined: false,
+      })
+    ).to.throw(
+      'Value for argument "nestedObject" is not a valid Firestore Object. Input object is deeper than 20 levels or contains a cycle.'
+    );
+  });
+
+  it('validates the depth of nested objects - 20', () => {
+    // This nested object is 20 levels deep
+    const nestedObject = {
+      a: {
+        b: {
+          c: {
+            d: {
+              e: {
+                f: {
+                  g: {
+                    h: {
+                      i: {
+                        j: {
+                          k: {
+                            l: {m: {n: {o: {p: {q: {r: {s: {t: {u: 1}}}}}}}}},
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    validateUserInput('nestedObject', nestedObject, 'Firestore Object', {
+      allowDeletes: 'none',
+      allowTransforms: false,
+      allowUndefined: false,
+    });
+  });
+
+  it('validates the depth of nested objects and arrays - 21', () => {
+    // This nested object is 21 levels deep
+    // This nested object is 20 levels deep
+    const nestedObject = {
+      a: {
+        b: {
+          c: {
+            d: {
+              e: {
+                f: {
+                  g: {
+                    h: {
+                      i: {
+                        j: {
+                          k: {
+                            l: {
+                              m: {n: {o: {p: {q: {r: {s: {t: {u: {v: 1}}}}}}}}},
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      validateUserInput('nestedObject', nestedObject, 'Firestore Object', {
+        allowDeletes: 'none',
+        allowTransforms: false,
+        allowUndefined: false,
+      })
+    ).to.throw(
+      'Value for argument "nestedObject" is not a valid Firestore Object. Input object is deeper than 20 levels or contains a cycle.'
+    );
+  });
+});

--- a/dev/test/serializer.ts
+++ b/dev/test/serializer.ts
@@ -167,9 +167,7 @@ describe('validateUserInput', () => {
         allowTransforms: false,
         allowUndefined: false,
       })
-    ).to.throw(
-      /Input object is deeper than 20 levels/i
-    );
+    ).to.throw(/Input object is deeper than 20 levels/i);
   });
 
   it('validates the depth of nested objects - 20', () => {
@@ -243,8 +241,6 @@ describe('validateUserInput', () => {
         allowTransforms: false,
         allowUndefined: false,
       })
-    ).to.throw(
-        /Input object is deeper than 20 levels/i
-    );
+    ).to.throw(/Input object is deeper than 20 levels/i);
   });
 });


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Update the depth validation used when writing documents, so that it matches the validation of the Firestore backend.
END_COMMIT_OVERRIDE