### PR TITLE
fix: Add tests for multiple inequality support

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1804,6 +1804,11 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
     );
   }
 
+  /**
+   * Returns the sorted array of unique inequality filter fields used in this query.
+   *
+   * @return An array of inequality filter fields sorted lexicographically by FieldPath.
+   */
   private getInequalityFilterFields(): FieldPath[] {
     let FieldPathSet = new Set<FieldPath>();
 
@@ -1815,7 +1820,6 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
       }
     }
 
-    // Sort the inequality fields lexicographically.
     return [...FieldPathSet].sort((a, b) => a.compareTo(b));
   }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -710,9 +710,6 @@ abstract class FilterInternal {
   /** Returns a list of all filters that are contained within this filter */
   abstract getFilters(): FilterInternal[];
 
-  /** Returns the field of the first filter that's an inequality, or null if none. */
-  abstract getFirstInequalityField(): FieldPath | null;
-
   /** Returns the proto representation of this filter */
   abstract toProto(): Filter;
 
@@ -733,13 +730,6 @@ class CompositeFilterInternal extends FilterInternal {
 
   public getFilters(): FilterInternal[] {
     return this.filters;
-  }
-
-  public getFirstInequalityField(): FieldPath | null {
-    return (
-      this.getFlattenedFilters().find(filter => filter.isInequalityFilter())
-        ?.field ?? null
-    );
   }
 
   public isConjunction(): boolean {
@@ -805,14 +795,6 @@ class FieldFilterInternal extends FilterInternal {
 
   public getFilters(): FilterInternal[] {
     return [this];
-  }
-
-  getFirstInequalityField(): FieldPath | null {
-    if (this.isInequalityFilter()) {
-      return this.field;
-    } else {
-      return null;
-    }
   }
 
   /**

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1805,22 +1805,22 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
   }
 
   /**
-   * Returns the sorted array of unique inequality filter fields used in this query.
+   * Returns the sorted array of inequality filter fields used in this query.
    *
    * @return An array of inequality filter fields sorted lexicographically by FieldPath.
    */
   private getInequalityFilterFields(): FieldPath[] {
-    let FieldPathSet = new Set<FieldPath>();
+    const inequalityFields: FieldPath[] = [];
 
     for (const filter of this._queryOptions.filters) {
       for (const subFilter of filter.getFlattenedFilters()) {
         if (subFilter.isInequalityFilter()) {
-          FieldPathSet = FieldPathSet.add(subFilter.field);
+          inequalityFields.push(subFilter.field);
         }
       }
     }
 
-    return [...FieldPathSet].sort((a, b) => a.compareTo(b));
+    return inequalityFields.sort((a, b) => a.compareTo(b));
   }
 
   /**
@@ -1872,6 +1872,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
         !field.isEqual(FieldPath.documentId())
       ) {
         fieldOrders.push(new FieldOrder(field, lastDirection));
+        fieldsNormalized.add(field.toString());
       }
     }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1834,8 +1834,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
     }
 
     // Sort the inequality fields lexicographically.
-    const sortedFieldPath = [...FieldPathSet].sort((a, b) => a.compareTo(b));
-    return sortedFieldPath;
+    return [...FieldPathSet].sort((a, b) => a.compareTo(b));
   }
 
   /**
@@ -1863,7 +1862,9 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
     }
 
     const fieldOrders = this._queryOptions.fieldOrders.slice();
-    const fieldsNormalized = new Set([...fieldOrders.map(item => item.field)]);
+    const fieldsNormalized = new Set([
+      ...fieldOrders.map(item => item.field.toString()),
+    ]);
 
     /** The order of the implicit ordering always matches the last explicit order by. */
     const lastDirection =
@@ -1881,14 +1882,14 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
     const inequalityFields = this.getInequalityFilterFields();
     for (const field of inequalityFields) {
       if (
-        !fieldsNormalized.has(field) &&
+        !fieldsNormalized.has(field.toString()) &&
         !field.isEqual(FieldPath.documentId())
       ) {
         fieldOrders.push(new FieldOrder(field, lastDirection));
       }
     }
 
-    if (!fieldsNormalized.has(FieldPath.documentId())) {
+    if (!fieldsNormalized.has(FieldPath.documentId().toString())) {
       fieldOrders.push(new FieldOrder(FieldPath.documentId(), lastDirection));
     }
 

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1871,6 +1871,7 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
       }
     }
 
+    // Add the document key field to the last if it is not explicitly ordered.
     if (!fieldsNormalized.has(FieldPath.documentId().toString())) {
       fieldOrders.push(new FieldOrder(FieldPath.documentId(), lastDirection));
     }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -826,6 +826,7 @@ class FieldFilterInternal extends FilterInternal {
       case 'LESS_THAN':
       case 'LESS_THAN_OR_EQUAL':
       case 'NOT_EQUAL':
+      case 'NOT_IN':
         return true;
       default:
         return false;

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2864,7 +2864,7 @@ describe('Query class', () => {
         doc5: {key: 'bb', sort: 1, v: 1},
       });
 
-      let results = await collection
+      const results = await collection
         .where('key', '>', 'a')
         .where('sort', '>=', 1)
         .orderBy('v')

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2905,7 +2905,7 @@ describe('Query class', () => {
         doc4: {key: 'b', sort: 2},
         doc5: {key: 'bb', sort: 1},
       });
-      let docSnap = await collection.doc('doc2').get();
+      const docSnap = await collection.doc('doc2').get();
 
       let results = await collection
         .where('sort', '>=', 1)

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2557,63 +2557,63 @@ describe('Query class', () => {
       });
 
       // Multiple inequality fields
-      let res = await collection
+      let results = await collection
         .where('key', '!=', 'a')
         .where('sort', '<=', 2)
         .where('v', '>', 2)
         .get();
-      expectDocs(res, 'doc3');
+      expectDocs(results, 'doc3');
 
       // Duplicate inequality fields
-      res = await collection
+      results = await collection
         .where('key', '!=', 'a')
         .where('sort', '<=', 2)
         .where('sort', '>', 1)
         .get();
-      expectDocs(res, 'doc4');
+      expectDocs(results, 'doc4');
 
       // With multiple IN
-      res = await collection
+      results = await collection
         .where('key', '>=', 'a')
         .where('sort', '<=', 2)
         .where('v', 'in', [2, 3, 4])
         .where('sort', 'in', [2, 3])
         .get();
-      expectDocs(res, 'doc4');
+      expectDocs(results, 'doc4');
 
       // With NOT-IN
-      res = await collection
+      results = await collection
         .where('key', '>=', 'a')
         .where('sort', '<=', 2)
         .where('v', 'not-in', [2, 4, 5])
         .get();
-      expectDocs(res, 'doc1', 'doc3');
+      expectDocs(results, 'doc1', 'doc3');
 
       // With orderby
-      res = await collection
+      results = await collection
         .where('key', '>=', 'a')
         .where('sort', '<=', 2)
         .orderBy('v', 'desc')
         .get();
-      expectDocs(res, 'doc3', 'doc4', 'doc1');
+      expectDocs(results, 'doc3', 'doc4', 'doc1');
 
       // With limit
-      res = await collection
+      results = await collection
         .where('key', '>=', 'a')
         .where('sort', '<=', 2)
         .orderBy('v', 'desc')
         .limit(2)
         .get();
-      expectDocs(res, 'doc3', 'doc4');
+      expectDocs(results, 'doc3', 'doc4');
 
       // With limitToLast
-      res = await collection
+      results = await collection
         .where('key', '>=', 'a')
         .where('sort', '<=', 2)
         .orderBy('v', 'desc')
         .limitToLast(2)
         .get();
-      expectDocs(res, 'doc4', 'doc1');
+      expectDocs(results, 'doc4', 'doc1');
     });
 
     it('can use on special values', async () => {
@@ -2626,18 +2626,18 @@ describe('Query class', () => {
         doc6: {key: 'f', sort: 1, v: 1},
       });
 
-      let res = await collection
+      let results = await collection
         .where('key', '!=', 'a')
         .where('sort', '<=', 2)
         .get();
-      expectDocs(res, 'doc5', 'doc6');
+      expectDocs(results, 'doc5', 'doc6');
 
-      res = await collection
+      results = await collection
         .where('key', '!=', 'a')
         .where('sort', '<=', 2)
         .where('v', '<=', 1)
         .get();
-      expectDocs(res, 'doc6');
+      expectDocs(results, 'doc6');
     });
 
     it('can use with array membership', async () => {
@@ -2651,19 +2651,19 @@ describe('Query class', () => {
         doc7: {key: 'g', sort: 4, v: [null]},
       });
 
-      let res = await collection
+      let results = await collection
         .where('key', '!=', 'a')
         .where('sort', '>=', 1)
         .where('v', 'array-contains', 0)
         .get();
-      expectDocs(res, 'doc2');
+      expectDocs(results, 'doc2');
 
-      res = await collection
+      results = await collection
         .where('key', '!=', 'a')
         .where('sort', '>=', 1)
         .where('v', 'array-contains-any', [0, 1])
         .get();
-      expectDocs(res, 'doc2', 'doc4');
+      expectDocs(results, 'doc2', 'doc4');
     });
 
     it('can use with nested field', async () => {
@@ -2688,21 +2688,21 @@ describe('Query class', () => {
         doc4: testData(300),
       });
 
-      let res = await collection
+      let results = await collection
         .where('metadata.createdAt', '<=', 500)
         .where('metadata.createdAt', '>', 100)
         .where('name', '!=', 'room 200')
         .orderBy('name')
         .get();
-      expectDocs(res, 'doc4', 'doc1');
+      expectDocs(results, 'doc4', 'doc1');
 
-      res = await collection
+      results = await collection
         .where('field', '>=', 'field 100')
         .where(new FieldPath('field.dot'), '!=', 300)
         .where('field\\slash', '<', 400)
         .orderBy('name', 'desc')
         .get();
-      expectDocs(res, 'doc2', 'doc3');
+      expectDocs(results, 'doc2', 'doc3');
     });
 
     it('can use with nested composite filters', async () => {
@@ -2715,7 +2715,7 @@ describe('Query class', () => {
         doc6: {key: 'b', sort: 0, v: 0},
       });
 
-      let res = await collection
+      let results = await collection
         .where(
           Filter.or(
             Filter.and(
@@ -2730,9 +2730,9 @@ describe('Query class', () => {
         )
         .get();
       // Implicitly ordered by: 'key' asc, 'sort' asc, 'v' asc, __name__ asc
-      expectDocs(res, 'doc1', 'doc6', 'doc5', 'doc4');
+      expectDocs(results, 'doc1', 'doc6', 'doc5', 'doc4');
 
-      res = await collection
+      results = await collection
         .where(
           Filter.or(
             Filter.and(
@@ -2749,9 +2749,9 @@ describe('Query class', () => {
         .orderBy('key')
         .get();
       // Ordered by: 'sort' desc, 'key' asc, 'v' asc, __name__ asc
-      expectDocs(res, 'doc5', 'doc4', 'doc1', 'doc6');
+      expectDocs(results, 'doc5', 'doc4', 'doc1', 'doc6');
 
-      res = await collection
+      results = await collection
         .where(
           Filter.and(
             Filter.or(
@@ -2778,7 +2778,7 @@ describe('Query class', () => {
         )
         .get();
       // Implicitly ordered by: 'key' asc, 'sort' asc, 'v' asc, __name__ asc
-      expectDocs(res, 'doc1', 'doc2');
+      expectDocs(results, 'doc1', 'doc2');
     });
 
     it('inequality fields will be implicitly ordered lexicographically by the server', async () => {
@@ -2791,22 +2791,22 @@ describe('Query class', () => {
         doc6: {key: 'b', sort: 0, v: 0},
       });
 
-      let res = await collection
+      let results = await collection
         .where('key', '!=', 'a')
         .where('sort', '>', 1)
         .where('v', 'in', [1, 2, 3, 4])
         .get();
       // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
-      expectDocs(res, 'doc2', 'doc4', 'doc5', 'doc3');
+      expectDocs(results, 'doc2', 'doc4', 'doc5', 'doc3');
 
-      res = await collection
+      results = await collection
         .where('sort', '>', 1)
         .where('key', '!=', 'a')
         .where('v', 'in', [1, 2, 3, 4])
         .get();
       // Changing filters order will not effect implicit order.
       // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
-      expectDocs(res, 'doc2', 'doc4', 'doc5', 'doc3');
+      expectDocs(results, 'doc2', 'doc4', 'doc5', 'doc3');
     });
 
     it('can use multiple explicit order by field', async () => {
@@ -2819,40 +2819,59 @@ describe('Query class', () => {
         doc6: {key: 'c', sort: 0, v: 2},
       });
 
-      let res = await collection
+      let results = await collection
         .where('key', '>', 'a')
         .where('sort', '>=', 1)
         .orderBy('v')
         .get();
       // Ordered by: 'v' asc, 'key' asc, 'sort' asc, __name__ asc
-      expectDocs(res, 'doc2', 'doc4', 'doc3', 'doc5');
+      expectDocs(results, 'doc2', 'doc4', 'doc3', 'doc5');
 
-      res = await collection
+      results = await collection
         .where('key', '>', 'a')
         .where('sort', '>=', 1)
         .orderBy('v')
         .orderBy('sort')
         .get();
       // Ordered by: 'v asc, 'sort' asc, 'key' asc,  __name__ asc
-      expectDocs(res, 'doc2', 'doc5', 'doc4', 'doc3');
+      expectDocs(results, 'doc2', 'doc5', 'doc4', 'doc3');
 
-      res = await collection
+      results = await collection
         .where('key', '>', 'a')
         .where('sort', '>=', 1)
         .orderBy('v', 'desc')
         .get();
       // Implicit order by matches the direction of last explicit order by.
       // Ordered by: 'v' desc, 'key' desc, 'sort' desc, __name__ desc
-      expectDocs(res, 'doc5', 'doc3', 'doc4', 'doc2');
+      expectDocs(results, 'doc5', 'doc3', 'doc4', 'doc2');
 
-      res = await collection
+      results = await collection
         .where('key', '>', 'a')
         .where('sort', '>=', 1)
         .orderBy('v', 'desc')
         .orderBy('sort')
         .get();
       // Ordered by: 'v desc, 'sort' asc, 'key' asc,  __name__ asc
-      expectDocs(res, 'doc5', 'doc4', 'doc3', 'doc2');
+      expectDocs(results, 'doc5', 'doc4', 'doc3', 'doc2');
+    });
+
+    it('can use in aggregate query', async () => {
+      const collection = await testCollectionWithDocs({
+        doc1: {key: 'a', sort: 5, v: 0},
+        doc2: {key: 'aa', sort: 4, v: 0},
+        doc3: {key: 'b', sort: 3, v: 1},
+        doc4: {key: 'b', sort: 2, v: 1},
+        doc5: {key: 'bb', sort: 1, v: 1},
+      });
+
+      let results = await collection
+        .where('key', '>', 'a')
+        .where('sort', '>=', 1)
+        .orderBy('v')
+        .count()
+        .get();
+      expect(results.data().count).to.be.equal(4);
+      //TODO(MIEQ): Add sum and average when they are public.
     });
 
     it('can use document ID im multiple inequality query', async () => {
@@ -2864,32 +2883,32 @@ describe('Query class', () => {
         doc5: {key: 'bb', sort: 1},
       });
 
-      let res = await collection
+      let results = await collection
         .where('sort', '>=', 1)
         .where('key', '!=', 'a')
         .where(FieldPath.documentId(), '<', 'doc5')
         .get();
       // Document Key in inequality field will implicitly ordered to the last.
       // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
-      expectDocs(res, 'doc2', 'doc4', 'doc3');
+      expectDocs(results, 'doc2', 'doc4', 'doc3');
 
-      res = await collection
+      results = await collection
         .where(FieldPath.documentId(), '<', 'doc5')
         .where('sort', '>=', 1)
         .where('key', '!=', 'a')
         .get();
       // Changing filters order will not effect implicit order.
       // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
-      expectDocs(res, 'doc2', 'doc4', 'doc3');
+      expectDocs(results, 'doc2', 'doc4', 'doc3');
 
-      res = await collection
+      results = await collection
         .where(FieldPath.documentId(), '<', 'doc5')
         .where('sort', '>=', 1)
         .where('key', '!=', 'a')
         .orderBy('sort', 'desc')
         .get();
       // Ordered by: 'sort' desc,'key' desc,  __name__ desc
-      expectDocs(res, 'doc2', 'doc3', 'doc4');
+      expectDocs(results, 'doc2', 'doc3', 'doc4');
     });
 
     it('Cursors with DocumentSnapshot implicitly adds inequality fields', async () => {
@@ -2902,13 +2921,13 @@ describe('Query class', () => {
       });
 
       const docSnap = await collection.doc('doc4').get();
-      const res = await collection
+      const results = await collection
         .where('key', '!=', 'a')
         .where('sort', '>', 1)
         .startAt(docSnap)
         .get();
       // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
-      expectDocs(res, 'doc4', 'doc3');
+      expectDocs(results, 'doc4', 'doc3');
     });
   });
 });

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2697,9 +2697,9 @@ describe('Query class', () => {
         .where('name', '!=', 'room 200')
         .orderBy('name');
       let docSnap = await collection.doc('doc4').get();
-      let query_sdk_normalized = query.startAt(docSnap);
+      let queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc4', 'doc1');
-      expectDocs(await query_sdk_normalized.get(), 'doc4', 'doc1');
+      expectDocs(await queryWithCursor.get(), 'doc4', 'doc1');
 
       // ordered by: name desc, field desc, field.dot desc, field\\slash desc, __name__ desc
       query = collection
@@ -2708,9 +2708,9 @@ describe('Query class', () => {
         .where('field\\slash', '<', 400)
         .orderBy('name', 'desc');
       docSnap = await collection.doc('doc2').get();
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc3');
-      expectDocs(await query_sdk_normalized.get(), 'doc2', 'doc3');
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc3');
     });
 
     it('can use with nested composite filters', async () => {
@@ -2734,15 +2734,9 @@ describe('Query class', () => {
         )
       );
       let docSnap = await collection.doc('doc1').get();
-      let query_sdk_normalized = query.startAt(docSnap);
+      let queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc1', 'doc6', 'doc5', 'doc4');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc1',
-        'doc6',
-        'doc5',
-        'doc4'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc1', 'doc6', 'doc5', 'doc4');
 
       // Ordered by: 'sort' desc, 'key' asc, 'v' asc, __name__ asc
       query = collection
@@ -2761,15 +2755,9 @@ describe('Query class', () => {
         .orderBy('sort', 'desc')
         .orderBy('key');
       docSnap = await collection.doc('doc5').get();
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc5', 'doc4', 'doc1', 'doc6');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc5',
-        'doc4',
-        'doc1',
-        'doc6'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc5', 'doc4', 'doc1', 'doc6');
 
       // Implicitly ordered by: 'key' asc, 'sort' asc, 'v' asc, __name__ asc
       query = collection.where(
@@ -2794,9 +2782,9 @@ describe('Query class', () => {
         )
       );
       docSnap = await collection.doc('doc1').get();
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc1', 'doc2');
-      expectDocs(await query_sdk_normalized.get(), 'doc1', 'doc2');
+      expectDocs(await queryWithCursor.get(), 'doc1', 'doc2');
     });
 
     it('inequality fields will be implicitly ordered lexicographically by the server', async () => {
@@ -2816,15 +2804,9 @@ describe('Query class', () => {
         .where('key', '!=', 'a')
         .where('sort', '>', 1)
         .where('v', 'in', [1, 2, 3, 4]);
-      let query_sdk_normalized = query.startAt(docSnap);
+      let queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc4', 'doc5', 'doc3');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc2',
-        'doc4',
-        'doc5',
-        'doc3'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc4', 'doc5', 'doc3');
 
       // Changing filters order will not effect implicit order.
       // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
@@ -2832,15 +2814,9 @@ describe('Query class', () => {
         .where('sort', '>', 1)
         .where('key', '!=', 'a')
         .where('v', 'in', [1, 2, 3, 4]);
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc4', 'doc5', 'doc3');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc2',
-        'doc4',
-        'doc5',
-        'doc3'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc4', 'doc5', 'doc3');
     });
 
     it('can use multiple explicit order by field', async () => {
@@ -2860,15 +2836,9 @@ describe('Query class', () => {
         .where('key', '>', 'a')
         .where('sort', '>=', 1)
         .orderBy('v');
-      let query_sdk_normalized = query.startAt(docSnap);
+      let queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc4', 'doc3', 'doc5');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc2',
-        'doc4',
-        'doc3',
-        'doc5'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc4', 'doc3', 'doc5');
 
       // Ordered by: 'v asc, 'sort' asc, 'key' asc,  __name__ asc
       query = collection
@@ -2876,15 +2846,9 @@ describe('Query class', () => {
         .where('sort', '>=', 1)
         .orderBy('v')
         .orderBy('sort');
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc5', 'doc4', 'doc3');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc2',
-        'doc5',
-        'doc4',
-        'doc3'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc5', 'doc4', 'doc3');
 
       docSnap = await collection.doc('doc5').get();
 
@@ -2894,15 +2858,9 @@ describe('Query class', () => {
         .where('key', '>', 'a')
         .where('sort', '>=', 1)
         .orderBy('v', 'desc');
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc5', 'doc3', 'doc4', 'doc2');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc5',
-        'doc3',
-        'doc4',
-        'doc2'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc5', 'doc3', 'doc4', 'doc2');
 
       // Ordered by: 'v desc, 'sort' asc, 'key' asc,  __name__ asc
       query = collection
@@ -2910,15 +2868,9 @@ describe('Query class', () => {
         .where('sort', '>=', 1)
         .orderBy('v', 'desc')
         .orderBy('sort');
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc5', 'doc4', 'doc3', 'doc2');
-      expectDocs(
-        await query_sdk_normalized.get(),
-        'doc5',
-        'doc4',
-        'doc3',
-        'doc2'
-      );
+      expectDocs(await queryWithCursor.get(), 'doc5', 'doc4', 'doc3', 'doc2');
     });
 
     it('can use in aggregate query', async () => {
@@ -2957,9 +2909,9 @@ describe('Query class', () => {
         .where('sort', '>=', 1)
         .where('key', '!=', 'a')
         .where(FieldPath.documentId(), '<', 'doc5');
-      let query_sdk_normalized = query.startAt(docSnap);
+      let queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc4', 'doc3');
-      expectDocs(await query_sdk_normalized.get(), 'doc2', 'doc4', 'doc3');
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc4', 'doc3');
 
       // Changing filters order will not effect implicit order.
       // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
@@ -2967,9 +2919,9 @@ describe('Query class', () => {
         .where(FieldPath.documentId(), '<', 'doc5')
         .where('sort', '>=', 1)
         .where('key', '!=', 'a');
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc4', 'doc3');
-      expectDocs(await query_sdk_normalized.get(), 'doc2', 'doc4', 'doc3');
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc4', 'doc3');
 
       // Ordered by: 'sort' desc,'key' desc,  __name__ desc
       query = collection
@@ -2977,9 +2929,9 @@ describe('Query class', () => {
         .where('sort', '>=', 1)
         .where('key', '!=', 'a')
         .orderBy('sort', 'desc');
-      query_sdk_normalized = query.startAt(docSnap);
+      queryWithCursor = query.startAt(docSnap);
       expectDocs(await query.get(), 'doc2', 'doc3', 'doc4');
-      expectDocs(await query_sdk_normalized.get(), 'doc2', 'doc3', 'doc4');
+      expectDocs(await queryWithCursor.get(), 'doc2', 'doc3', 'doc4');
     });
   });
 });

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2897,8 +2897,7 @@ describe('Query class', () => {
         doc2: {key: 'aa', sort: 4, v: 4},
         doc3: {key: 'b', sort: 3, v: 3},
         doc4: {key: 'b', sort: 2, v: 2},
-        doc5: {key: 'b', sort: 2, v: 1},
-        doc6: {key: 'b', sort: 0, v: 0},
+        doc5: {key: 'b', sort: 0, v: 1},
       });
 
       const docSnap = await collection.doc('doc4').get();
@@ -2907,7 +2906,8 @@ describe('Query class', () => {
         .where('sort', '>', 1)
         .startAt(docSnap)
         .get();
-      expectDocs(res, 'doc4', 'doc5', 'doc3');
+      // Implicitly ordered by: 'key' asc, 'sort' asc, __name__ asc
+      expectDocs(res, 'doc4', 'doc3');
     });
   });
 });

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2667,6 +2667,7 @@ describe('Query class', () => {
     });
 
     it('can use with nested field', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const testData = (n?: number): any => {
         n = n || 1;
         return {
@@ -2901,7 +2902,7 @@ describe('Query class', () => {
       });
 
       const docSnap = await collection.doc('doc4').get();
-      let res = await collection
+      const res = await collection
         .where('key', '!=', 'a')
         .where('sort', '>', 1)
         .startAt(docSnap)

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -2703,6 +2703,17 @@ describe('Query class', () => {
         .orderBy('name', 'desc')
         .get();
       expectDocs(results, 'doc2', 'doc3');
+
+      // Cursor will add implicit order by fields in the same order as server does.
+      const docSnap = await collection.doc('doc2').get();
+      results = await collection
+        .where('field', '>=', 'field 100')
+        .where(new FieldPath('field.dot'), '!=', 300)
+        .where('field\\slash', '<', 400)
+        .orderBy('name', 'desc')
+        .startAfter(docSnap)
+        .get();
+      expectDocs(results, 'doc3');
     });
 
     it('can use with nested composite filters', async () => {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -2440,6 +2440,570 @@ describe('startAt() interface', () => {
     });
   });
 
+  describe('inequality fields are implicitly ordered lexicographically', () => {
+    it('upper and lower case characters', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              'A',
+              'ASCENDING',
+              'a',
+              'ASCENDING',
+              'aa',
+              'ASCENDING',
+              'b',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(true, 'A', 'a', 'aa', 'b', {
+              referenceValue:
+                `projects/${PROJECT_ID}/databases/(default)/` +
+                'documents/collectionId/doc',
+            }),
+            fieldFiltersQuery(
+              'a',
+              'LESS_THAN',
+              'value',
+              'a',
+              'GREATER_THAN_OR_EQUAL',
+              'value',
+              'aa',
+              'GREATER_THAN',
+              'value',
+              'b',
+              'GREATER_THAN',
+              'value',
+              'A',
+              'GREATER_THAN',
+              'value'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {
+          a: 'a',
+          aa: 'aa',
+          b: 'b',
+          A: 'A',
+        }).then(doc => {
+          const query = firestore
+            .collection('collectionId')
+            .where('a', '<', 'value')
+            .where('a', '>=', 'value')
+            .where('aa', '>', 'value')
+            .where('b', '>', 'value')
+            .where('A', '>', 'value')
+            .startAt(doc);
+          return query.get();
+        });
+      });
+    });
+
+    it('characters and numbers', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              '`1`',
+              'ASCENDING',
+              '`19`',
+              'ASCENDING',
+              '`2`',
+              'ASCENDING',
+              'a',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(true, '1', '19', '2', 'a', {
+              referenceValue:
+                `projects/${PROJECT_ID}/databases/(default)/` +
+                'documents/collectionId/doc',
+            }),
+            fieldFiltersQuery(
+              'a',
+              'LESS_THAN',
+              'value',
+              '`1`',
+              'GREATER_THAN',
+              'value',
+              '`19`',
+              'GREATER_THAN',
+              'value',
+              '`2`',
+              'GREATER_THAN',
+              'value'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {
+          a: 'a',
+          1: '1',
+          19: '19',
+          2: '2',
+        }).then(doc => {
+          const query = firestore
+            .collection('collectionId')
+            .where('a', '<', 'value')
+            .where('1', '>', 'value')
+            .where('19', '>', 'value')
+            .where('2', '>', 'value')
+            .startAt(doc);
+          return query.get();
+        });
+      });
+    });
+
+    it('nested fields', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              'a',
+              'ASCENDING',
+              'a.a',
+              'ASCENDING',
+              'aa',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(
+              true,
+              {
+                mapValue: {
+                  fields: {
+                    a: {
+                      stringValue: 'a.a',
+                    },
+                  },
+                },
+              },
+              'a.a',
+              'aa',
+              {
+                referenceValue:
+                  `projects/${PROJECT_ID}/databases/(default)/` +
+                  'documents/collectionId/doc',
+              }
+            ),
+            fieldFiltersQuery(
+              'a',
+              'LESS_THAN',
+              'value',
+              'a.a',
+              'GREATER_THAN',
+              'value',
+              'aa',
+              'GREATER_THAN',
+              'value'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {a: {a: 'a.a'}, aa: 'aa'}).then(
+          doc => {
+            const query = firestore
+              .collection('collectionId')
+              .where('a', '<', 'value')
+              .where('a.a', '>', 'value')
+              .where('aa', '>', 'value')
+              .startAt(doc);
+            return query.get();
+          }
+        );
+      });
+    });
+
+    it('special characters', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              '_a',
+              'ASCENDING',
+              'a',
+              'ASCENDING',
+              'a.a',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(
+              true,
+              '_a',
+              {
+                mapValue: {
+                  fields: {
+                    a: {
+                      stringValue: 'a.a',
+                    },
+                  },
+                },
+              },
+              'a.a',
+              {
+                referenceValue:
+                  `projects/${PROJECT_ID}/databases/(default)/` +
+                  'documents/collectionId/doc',
+              }
+            ),
+            fieldFiltersQuery(
+              'a',
+              'LESS_THAN',
+              'a',
+              '_a',
+              'GREATER_THAN',
+              '_a',
+              'a.a',
+              'GREATER_THAN',
+              'a.a'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {a: {a: 'a.a'}, _a: '_a'}).then(
+          doc => {
+            const query = firestore
+              .collection('collectionId')
+              .where('a', '<', 'a')
+              .where('_a', '>', '_a')
+              .where('a.a', '>', 'a.a')
+              .startAt(doc);
+            return query.get();
+          }
+        );
+      });
+    });
+
+    it('field name with dot', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              'a',
+              'ASCENDING',
+              'a.z',
+              'ASCENDING',
+              '`a.a`',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(
+              true,
+              {
+                mapValue: {
+                  fields: {
+                    z: {
+                      stringValue: 'a.z',
+                    },
+                  },
+                },
+              },
+              'a.z',
+              'a.a',
+              {
+                referenceValue:
+                  `projects/${PROJECT_ID}/databases/(default)/` +
+                  'documents/collectionId/doc',
+              }
+            ),
+            fieldFiltersQuery(
+              'a',
+              'LESS_THAN',
+              'value',
+              '`a.a`',
+              'GREATER_THAN',
+              'value',
+              'a.z',
+              'GREATER_THAN',
+              'value'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {a: {z: 'a.z'}, 'a.a': 'a.a'}).then(
+          doc => {
+            const query = firestore
+              .collection('collectionId')
+              .where('a', '<', 'value')
+              .where(new FieldPath('a.a'), '>', 'value') // field name with dot
+              .where('a.z', '>', 'value') // nested field
+              .startAt(doc);
+            return query.get();
+          }
+        );
+      });
+    });
+
+    it('composite filter', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              'a',
+              'ASCENDING',
+              'b',
+              'ASCENDING',
+              'c',
+              'ASCENDING',
+              'd',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(true, 'a', 'b', 'c', 'd', {
+              referenceValue:
+                `projects/${PROJECT_ID}/databases/(default)/` +
+                'documents/collectionId/doc',
+            }),
+            where(
+              compositeFilter(
+                'AND',
+                fieldFilter('a', 'LESS_THAN', 'value'),
+
+                compositeFilter(
+                  'AND',
+                  compositeFilter(
+                    'OR',
+                    fieldFilter('b', 'GREATER_THAN_OR_EQUAL', 'value'),
+                    fieldFilter('c', 'LESS_THAN_OR_EQUAL', 'value')
+                  ),
+                  compositeFilter(
+                    'OR',
+                    fieldFilter('d', 'GREATER_THAN', 'value'),
+                    fieldFilter('e', 'EQUAL', 'value')
+                  )
+                )
+              )
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {
+          a: 'a',
+          b: 'b',
+          c: 'c',
+          d: 'd',
+          e: 'e',
+        }).then(doc => {
+          const query = firestore
+            .collection('collectionId')
+            .where('a', '<', 'value')
+            .where(
+              Filter.and(
+                Filter.or(
+                  Filter.where('b', '>=', 'value'),
+                  Filter.where('c', '<=', 'value')
+                ),
+                Filter.or(
+                  Filter.where('d', '>', 'value'),
+                  Filter.where('e', '==', 'value')
+                )
+              )
+            )
+            .startAt(doc);
+          return query.get();
+        });
+      });
+    });
+
+    it('explicit orderby', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              'z',
+              'ASCENDING',
+              'a',
+              'ASCENDING',
+              'b',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(true, 'z', 'a', 'b', {
+              referenceValue:
+                `projects/${PROJECT_ID}/databases/(default)/` +
+                'documents/collectionId/doc',
+            }),
+            fieldFiltersQuery(
+              'b',
+              'LESS_THAN',
+              'value',
+              'a',
+              'GREATER_THAN',
+              'value',
+              'z',
+              'GREATER_THAN',
+              'value'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {
+          a: 'a',
+          b: 'b',
+          z: 'z',
+        }).then(doc => {
+          const query = firestore
+            .collection('collectionId')
+            .where('b', '<', 'value')
+            .where('a', '>', 'value')
+            .where('z', '>', 'value')
+            .orderBy('z')
+            .startAt(doc);
+          return query.get();
+        });
+      });
+    });
+
+    it('explicit order by direction', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              'z',
+              'DESCENDING',
+              'a',
+              'DESCENDING',
+              'b',
+              'DESCENDING',
+              '__name__',
+              'DESCENDING'
+            ),
+            startAt(true, 'z', 'a', 'b', {
+              referenceValue:
+                `projects/${PROJECT_ID}/databases/(default)/` +
+                'documents/collectionId/doc',
+            }),
+            fieldFiltersQuery(
+              'b',
+              'LESS_THAN',
+              'value',
+              'a',
+              'GREATER_THAN',
+              'value'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {
+          a: 'a',
+          b: 'b',
+          z: 'z',
+        }).then(doc => {
+          const query = firestore
+            .collection('collectionId')
+            .where('b', '<', 'value')
+            .where('a', '>', 'value')
+            .orderBy('z', 'desc')
+            .startAt(doc);
+          return query.get();
+        });
+      });
+    });
+
+    it('last explicit order by direction', () => {
+      const overrides: ApiOverride = {
+        runQuery: request => {
+          queryEquals(
+            request,
+            orderBy(
+              'z',
+              'DESCENDING',
+              'c',
+              'ASCENDING',
+              'a',
+              'ASCENDING',
+              'b',
+              'ASCENDING',
+              '__name__',
+              'ASCENDING'
+            ),
+            startAt(true, 'z', 'c', 'a', 'b', {
+              referenceValue:
+                `projects/${PROJECT_ID}/databases/(default)/` +
+                'documents/collectionId/doc',
+            }),
+            fieldFiltersQuery(
+              'b',
+              'LESS_THAN',
+              'value',
+              'a',
+              'GREATER_THAN',
+              'value'
+            )
+          );
+          return stream();
+        },
+      };
+
+      return createInstance(overrides).then(firestoreInstance => {
+        firestore = firestoreInstance;
+        return snapshot('collectionId/doc', {
+          a: 'a',
+          b: 'b',
+          c: 'c',
+          z: 'z',
+        }).then(doc => {
+          const query = firestore
+            .collection('collectionId')
+            .where('b', '<', 'value')
+            .where('a', '>', 'value')
+            .orderBy('z', 'desc')
+            .orderBy('c')
+            .startAt(doc);
+          return query.get();
+        });
+      });
+    });
+  });
+
   it('validates field exists in document snapshot', () => {
     const query = firestore.collection('collectionId').orderBy('foo', 'desc');
 

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -2440,7 +2440,7 @@ describe('startAt() interface', () => {
     });
   });
 
-  describe('inequality fields are implicitly ordered lexicographically', () => {
+  describe('inequality fields are implicitly ordered lexicographically for cursors', () => {
     it('upper and lower case characters', () => {
       const overrides: ApiOverride = {
         runQuery: request => {


### PR DESCRIPTION
Port integration tests from web SDK to make sure client and server sdks behaviours are consistent.
Update the `createImplicitOrderBy` function for queries with cursor. 

Updated the isInequality check to be consistent with mobile&web sdks:
https://github.com/firebase/firebase-js-sdk/blob/320e58cc57d0fc485548611c5975dd3df69f8d18/packages/firestore/src/core/filter.ts#L177
https://github.com/firebase/firebase-ios-sdk/blob/2eccf796524777ce8fae5b82c3e4b0d9875bb9af/Firestore/core/src/core/field_filter.cc#L146
https://github.com/firebase/firebase-android-sdk/blob/b7a34fb108f1d619f5cc98677582e585c239048a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FieldFilter.java#L145