### PR TITLE
fix: Add warning message when passing single DocumentReference in cursor without orderBy clause

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -1845,6 +1845,15 @@ export class Query<T = firestore.DocumentData> implements firestore.Query<T> {
       return this._queryOptions.fieldOrders;
     }
 
+    // TODO(b/296435819): Remove this warning message.
+    if (cursorValuesOrDocumentSnapshot[0] instanceof DocumentReference) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Warning: Passing DocumentReference into a cursor without orderBy clause is not an intended
+        behavior. Please use DocumentSnapshot or add an explicit orderBy on document key field.`
+      );
+    }
+
     const fieldOrders = this._queryOptions.fieldOrders.slice();
 
     // If no explicit ordering is specified, use the first inequality to


### PR DESCRIPTION
port from https://github.com/googleapis/java-firestore/pull/1397