### PR TITLE
chore: upgrade protobufjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "fast-deep-equal": "^3.1.1",
     "functional-red-black-tree": "^1.0.1",
     "google-gax": "^3.5.7",
-    "protobufjs": "^7.0.0"
+    "protobufjs": "^7.2.5"
   },
   "devDependencies": {
     "@types/assert": "^1.4.0",
@@ -87,7 +87,7 @@
     "length-prefixed-json-stream": "^1.0.1",
     "linkinator": "^5.0.0",
     "mocha": "^9.2.2",
-    "protobufjs-cli": "^1.0.0",
+    "protobufjs-cli": "^1.1.2",
     "proxyquire": "^2.1.3",
     "sinon": "^15.0.0",
     "through2": "^4.0.0",


### PR DESCRIPTION
Fixes #1888 

This PR upgrades the version of protobufjs to the latest version containing the fix for the critical vulnerability.
