### PR TITLE
chore: Make compile with NodeJS v20.5.0

### DIFF
--- a/dev/src/backoff.ts
+++ b/dev/src/backoff.ts
@@ -97,7 +97,7 @@ export function setTimeoutHandler(
     // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66176/files#diff-e838d0ace9cd5f6516bacfbd3ad00d02cd37bd60f9993ce6223f52d889a1fdbaR122-R126
     //
     // Adding `[Symbol.dispose](): void;` cannot be done on older versions of
-    // NodeJS. So we simply cast to `NodeJS.Timout`.
+    // NodeJS. So we simply cast to `NodeJS.Timeout`.
     return timeout;
   };
 }

--- a/dev/src/backoff.ts
+++ b/dev/src/backoff.ts
@@ -272,7 +272,7 @@ export class ExponentialBackoff {
         'ExponentialBackoff.backoffAndWait',
         null,
         `Backing off for ${delayWithJitterMs} ms ` +
-        `(base delay: ${this.currentBaseMs} ms)`
+          `(base delay: ${this.currentBaseMs} ms)`
       );
     }
 

--- a/dev/src/backoff.ts
+++ b/dev/src/backoff.ts
@@ -92,7 +92,12 @@ export function setTimeoutHandler(
       [Symbol.toPrimitive]: () => {
         throw new Error('For tests only. Not Implemented');
       },
-    };
+    } as unknown as NodeJS.Timeout;
+    // `NodeJS.Timeout` type signature change:
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66176/files#diff-e838d0ace9cd5f6516bacfbd3ad00d02cd37bd60f9993ce6223f52d889a1fdbaR122-R126
+    //
+    // Adding `[Symbol.dispose](): void;` cannot be done on older versions of
+    // NodeJS. So we simply cast to `NodeJS.Timout`.
     return timeout;
   };
 }
@@ -267,7 +272,7 @@ export class ExponentialBackoff {
         'ExponentialBackoff.backoffAndWait',
         null,
         `Backing off for ${delayWithJitterMs} ms ` +
-          `(base delay: ${this.currentBaseMs} ms)`
+        `(base delay: ${this.currentBaseMs} ms)`
       );
     }
 


### PR DESCRIPTION
An external change to CI appears to run code on NodeJS v20.5.0.

Unfortunately, this breaks our hacky override of Timeout. So as a quick fix, I made it even hackier. Since we only use this for tests, this should be fine.