### PR TITLE
docs: Improve documentation for `DocumentReference.create`.

### DIFF
--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -371,7 +371,7 @@ export class DocumentReference<
    *
    * @param {DocumentData} data An object that contains the fields and data to
    * serialize as the document.
-   * @throws {Error} If the provided input is not a valid Firestore document.
+   * @throws {Error} If the provided input is not a valid Firestore document or if the document already exists.
    * @returns {Promise.<WriteResult>} A Promise that resolves with the
    * write time of this create.
    *

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -1273,7 +1273,7 @@ declare namespace FirebaseFirestore {
      * provided object values. The write fails if the document already exists
      *
      * @param data The object data to serialize as the document.
-     * @throws Error If the provided input is not a valid Firestore document.
+     * @throws {Error} If the provided input is not a valid Firestore document or if the document already exists.
      * @return A Promise resolved with the write time of this create.
      */
     create(data: WithFieldValue<AppModelType>): Promise<WriteResult>;


### PR DESCRIPTION
fixes #1921 