### PR TITLE
fix: Remove temporary header encoding workaround

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -593,21 +593,6 @@ export class Firestore implements firestore.Firestore {
           }
         }
 
-        // TODO (multi-db) Revert this override of gax.routingHeader.fromParams
-        // after a permanent fix is applied. See b/292075646
-        // This override of the routingHeader.fromParams does not
-        // encode forward slash characters. This is a temporary fix for b/291780066
-        gax.routingHeader.fromParams = params => {
-          return stringify(params, undefined, undefined, {
-            encodeURIComponent: (val: string) => {
-              return val
-                .split('/')
-                .map(component => encodeURIComponent(component))
-                .join('/');
-            },
-          });
-        };
-
         if (this._settings.ssl === false) {
           const grpcModule = this._settings.grpc ?? require('google-gax').grpc;
           const sslCreds = grpcModule.credentials.createInsecure();

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -84,7 +84,6 @@ import {
   RECURSIVE_DELETE_MIN_PENDING_OPS,
   RecursiveDelete,
 } from './recursive-delete';
-import {stringify} from 'querystring';
 
 export {
   CollectionReference,


### PR DESCRIPTION
Remove temporary workaround to header encoding issue b/291780066.

The workaround appears to cause trouble for some customers.
https://github.com/googleapis/nodejs-firestore/issues/1929
