### PR TITLE
fix: update retry policy to not retry streams that have not made progress receiving documents

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1637,7 +1637,7 @@ export class Firestore implements firestore.Firestore {
       function streamReady(): void {
         if (!streamInitialized) {
           streamInitialized = true;
-          logger('Firestore._initializeStream', requestTag, 'Releasing stream');
+          logger('Firestore._initializeStream', requestTag, 'Stream ready');
           resolve(resultStream);
         }
       }

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2571,7 +2571,12 @@ export class Query<
   }
 
   _hasRetryTimedOut(methodName: string, startTime: number): boolean {
-    return Date.now() - startTime >= getTotalTimeout(methodName);
+    const totalTimeout = getTotalTimeout(methodName);
+    if (totalTimeout === 0) {
+      return false;
+    }
+
+    return Date.now() - startTime >= totalTimeout;
   }
 
   /**

--- a/dev/src/reference.ts
+++ b/dev/src/reference.ts
@@ -2637,6 +2637,9 @@ export class Query<
 
         let streamActive: Deferred<boolean>;
         do {
+          // Set lastReceivedDocument to null before each retry attempt to ensure the retry makes progress
+          lastReceivedDocument = null;
+
           streamActive = new Deferred<boolean>();
           backendStream = await this._firestore.requestStream(
             'runQuery',

--- a/dev/src/util.ts
+++ b/dev/src/util.ts
@@ -179,6 +179,21 @@ export function getRetryCodes(methodName: string): number[] {
 }
 
 /**
+ * Gets the total timeout in milliseconds from the retry settings in
+ * the service config for the given RPC. If the total timeout is not
+ * set, then `0` is returned.
+ *
+ * @private
+ * @internal
+ */
+export function getTotalTimeout(methodName: string): number {
+  return (
+    getServiceConfig(methodName)?.retry?.backoffSettings?.totalTimeoutMillis ??
+    0
+  );
+}
+
+/**
  * Returns the backoff setting from the service configuration.
  * @private
  * @internal


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: update retry policy to not retry streams that have not made progress receiving documents
END_COMMIT_OVERRIDE