### PR TITLE
Firestore: Add test that verifies aggregate query error message when missing index

### DIFF
--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3067,15 +3067,14 @@ describe('count queries', () => {
       const count5 = randomCol.offset(6).count();
       await runQueryAndExpectCount(count5, 1);
     });
+  }
 
-    it.only('count query error message is good if missing index', () => {
+  it('count query error message contains console link if missing index', () => {
     const query = randomCol.where('key1', '==', 42).where('key2', '<', 42);
-    expect(query.count().get()).to.be.eventually.rejectedWith(
+    return expect(query.count().get()).to.be.eventually.rejectedWith(
       /index.*https:\/\/console\.firebase\.google\.com/
     );
   });
-
-  }
 });
 
 describe('count queries using aggregate api', () => {

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3067,6 +3067,14 @@ describe('count queries', () => {
       const count5 = randomCol.offset(6).count();
       await runQueryAndExpectCount(count5, 1);
     });
+
+    it.only('count query error message is good if missing index', () => {
+    const query = randomCol.where('key1', '==', 42).where('key2', '<', 42);
+    expect(query.count().get()).to.be.eventually.rejectedWith(
+      /index.*https:\/\/console\.firebase\.google\.com/
+    );
+  });
+
   }
 });
 


### PR DESCRIPTION
This verifies that the descriptive error message that occurs when the server does not have the required index has the URL that customers can follow to create the index.

This is a port of the "getCountFromServer error message is good if missing index" integration test from https://github.com/firebase/firebase-js-sdk/blob/42bfb0b8243a6c36b66a0bbedf61436e70591062/packages/firestore/test/integration/api/aggregation.test.ts#L130-L155 and https://github.com/firebase/firebase-android-sdk/pull/4232.

Googlers see b/254063570 for details.