### PR TITLE
fix: Make transaction rollback best effort.

### DIFF
--- a/dev/src/transaction.ts
+++ b/dev/src/transaction.ts
@@ -481,7 +481,20 @@ export class Transaction implements firestore.Transaction {
       transaction: this._transactionId,
     };
 
-    return this._firestore.request('rollback', request, this._requestTag);
+    const promise: Promise<void> = this._firestore.request(
+      'rollback',
+      request,
+      this._requestTag
+    );
+
+    return promise.catch(reason => {
+      logger(
+        'Firestore.runTransaction',
+        this._requestTag,
+        'Best effort to rollback failed with error:',
+        reason
+      );
+    });
   }
 
   /**

--- a/dev/test/transaction.ts
+++ b/dev/test/transaction.ts
@@ -574,7 +574,6 @@ describe('failed transactions', () => {
           begin({transactionId: 'foo1'}),
           commit('foo1', /* writes=*/ undefined, serverError),
           rollback('foo1', serverError),
-          rollback('foo1'),
           backoff(),
           begin({
             transactionId: 'foo2',


### PR DESCRIPTION
Internal tracking: b/316023452

A rollback is meant to be best effort. If the transaction has already expired, it is possible for the rollback to fail due to transaction no longer existing in Firestore. The retry logic will use attempts to rollback, and in the case where transaction no longer exists, all attempts to be exhausted attempted to rollback transaction.

This PR makes the rollback best effort, simply logging any rollback error and continuing.