### PR TITLE
Firestore: Remove obsolete special case from tests when verifying "missing index" error message in non-default DB

### DIFF
--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3194,16 +3194,9 @@ describe('count queries', () => {
     () => {
       const query = randomCol.where('key1', '==', 42).where('key2', '<', 42);
       const countQuery = query.count();
-      const databaseId = query.firestore._settings.databaseId ?? '(default)';
-      // TODO(b/316359394) Remove this check for the default databases once
-      //  cl/582465034 is rolled out to production.
-      if (databaseId === '(default)') {
-        return expect(countQuery.get()).to.be.eventually.rejectedWith(
-          /index.*https:\/\/console\.firebase\.google\.com/
-        );
-      } else {
-        return expect(countQuery.get()).to.be.eventually.rejectedWith(/index/);
-      }
+      return expect(countQuery.get()).to.be.eventually.rejectedWith(
+        /index.*https:\/\/console\.firebase\.google\.com/
+      );
     }
   );
 });
@@ -3571,18 +3564,9 @@ describe('Aggregation queries', () => {
         sum: AggregateField.sum('pages'),
         average: AggregateField.average('pages'),
       });
-      const databaseId = query.firestore._settings.databaseId ?? '(default)';
-      // TODO(b/316359394) Remove this check for the default databases once
-      //  cl/582465034 is rolled out to production.
-      if (databaseId === '(default)') {
-        return expect(aggregateQuery.get()).to.be.eventually.rejectedWith(
-          /index.*https:\/\/console\.firebase\.google\.com/
-        );
-      } else {
-        return expect(aggregateQuery.get()).to.be.eventually.rejectedWith(
-          /index/
-        );
-      }
+      return expect(aggregateQuery.get()).to.be.eventually.rejectedWith(
+        /index.*https:\/\/console\.firebase\.google\.com/
+      );
     }
   );
 


### PR DESCRIPTION
This PR removes a special case from the integration tests (https://github.com/googleapis/nodejs-firestore/pull/1960) that verifies the "missing index" error message returned from the server. Previously, a non-default database would result in a different, less descriptive error message; however, the backend was updated to use the same, descriptive error message for both default and non-default databases. The tests, therefore, should have to the special case removed to increase the coverage of the tests.

Googlers see b/316359394 for more information.