### PR TITLE
fix: Remove incorrect,unreachable and unused code

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -745,13 +745,6 @@ export class Firestore implements firestore.Firestore {
     }
 
     this._settings = settings;
-    this._settings.toJSON = function () {
-      const temp = Object.assign({}, this);
-      if (temp.credentials) {
-        temp.credentials = {private_key: '***', client_email: '***'};
-      }
-      return temp;
-    };
     this._serializer = new Serializer(this);
   }
 

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -745,7 +745,7 @@ export class Firestore implements firestore.Firestore {
     }
 
     this._settings = settings;
-    this._settings.toJson = function () {
+    this._settings.toJSON = function () {
       const temp = Object.assign({}, this);
       if (temp.credentials) {
         temp.credentials = {private_key: '***', client_email: '***'};


### PR DESCRIPTION
The code I have removed is not used since the main **Firestore** class method has its own toJSON override, the spelling of toJSON method anyways is incorrect here, This will make the code cleaner.
This line instead takes care of the removed code now and is working in the latest version
https://github.com/googleapis/nodejs-firestore/blob/main/dev/src/index.ts#L1451

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

For Issue #1984

This PR was reverted in favor of correcting the redaction code for Firestore settings. It's still possible to serialize the settings on a Firestore instance, and it's also possible that the serialization of Firestore settings will be updated in the future to include the settings. The intent of this PR was good, but we're being cautious to handle the less common use case.
BEGIN_COMMIT_OVERRIDE
chore: This change was reverted before it was release in #1989.
END_COMMIT_OVERRIDE