### PR TITLE
fix: Fix redaction of credentials in Firestore settings

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -745,7 +745,7 @@ export class Firestore implements firestore.Firestore {
     }
 
     this._settings = settings;
-    this._settings.toJson = function () {
+    this._settings.toJSON = function () {
       const temp = Object.assign({}, this);
       if (temp.credentials) {
         temp.credentials = {private_key: '***', client_email: '***'};

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -745,6 +745,13 @@ export class Firestore implements firestore.Firestore {
     }
 
     this._settings = settings;
+    this._settings.toJson = function () {
+      const temp = Object.assign({}, this);
+      if (temp.credentials) {
+        temp.credentials = {private_key: '***', client_email: '***'};
+      }
+      return temp;
+    };
     this._serializer = new Serializer(this);
   }
 

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -1374,7 +1374,7 @@ describe('getAll() method', () => {
 });
 
 describe('toJSON', () => {
-  it('Serializing settings hides credentials', () => {
+  it('Serializing Firestore settings redacts credentials', () => {
     const firestore = new Firestore.Firestore({
       projectId: 'myProjectId',
       credentials: {client_email: 'foo@bar', private_key: 'asdf1234'},

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -1372,3 +1372,38 @@ describe('getAll() method', () => {
     });
   });
 });
+
+describe('toJSON', () => {
+  it('Serializing settings hides credentials', () => {
+    const firestore = new Firestore.Firestore({
+      projectId: 'myProjectId',
+      credentials: {client_email: 'foo@bar', private_key: 'asdf1234'},
+    });
+
+    const serializedSettings = JSON.stringify(firestore._settings);
+
+    // Instead of validating the serialized string for redacted credentials,
+    // parse the settings and check the credential values.
+    const parsedSettings = JSON.parse(serializedSettings);
+    expect(parsedSettings.credentials.client_email).to.equal('***');
+    expect(parsedSettings.credentials.private_key).to.equal('***');
+  });
+
+  it('Serializing Firestore instance', () => {
+    const firestore = new Firestore.Firestore({
+      projectId: 'myProjectId',
+      credentials: {client_email: 'foo@bar', private_key: 'asdf1234'},
+    });
+
+    const serializedFirestore = JSON.stringify(firestore);
+
+    // Instead of validating the serialized string,
+    // parse the JSON back to an object and check the properties.
+    const expectedParsedFirestore = {
+      projectId: 'myProjectId',
+    };
+
+    const parsedFirestore = JSON.parse(serializedFirestore);
+    expect(parsedFirestore).to.deep.equal(expectedParsedFirestore);
+  });
+});


### PR DESCRIPTION
fix: Fix redaction of credentials in Firestore settings

Rollback removal of `toJSON` for Firestore settings and corrected the implementation. Added tests.
