### PR TITLE
build: Pin the protobuf library to v27. Unblocks the release and pinning prevents further breaking changes introduced in protobuf

### DIFF
--- a/dev/protos/update.sh
+++ b/dev/protos/update.sh
@@ -42,7 +42,9 @@ pushd "$WORK_DIR"
 
 # Clone necessary git repos.
 git clone --depth 1 https://github.com/googleapis/googleapis.git
-git clone --depth 1 https://github.com/google/protobuf.git
+# Protobuf may have breaking changes, so it will be pinned to a specific release.
+# TODO(version) nodejs-firestore should maintain the version number of protobuf manually
+git clone --single-branch --branch v27.0 --depth 1 https://github.com/google/protobuf.git
 
 # Copy necessary protos.
 mkdir -p "${PROTOS_DIR}/google/api"


### PR DESCRIPTION
Pin the protobuf library to v27. Unblocks the release and pinning prevents further breaking changes introduced in protobuf