### PR TITLE
build: Running the license script for files in the types folder

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -229,6 +229,7 @@ s.copy(templates, excludes=[".eslintrc.json", ".kokoro/**/*", ".github/CODEOWNER
 shell.run(('rm', '-rf', 'dev/samples/generated'), hide_output = False)
 
 shell.run(('node', 'scripts/license.js', 'dev/protos'), hide_output = False)
+shell.run(('node', 'scripts/license.js', 'types'), hide_output = False)
 
 node.fix()  # fix formatting
 


### PR DESCRIPTION
Running the license script for files in the types/ folder. This ensures that the license header is included for any files written by owlbot in the types/ folder.