### PR TITLE
build: fix path-to-regexp to older version due to node 14 requirement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "protobufjs-cli": "^1.1.2",
     "proxyquire": "^2.1.3",
     "sinon": "^18.0.0",
+    "nise": "6.0.0",
+    "path-to-regexp": "6.2.2",
     "through2": "^4.0.0",
     "ts-node": "^10.0.0",
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "proxyquire": "^2.1.3",
     "sinon": "^18.0.0",
     "nise": "6.0.0",
-    "path-to-regexp": "6.2.2",
+    "path-to-regexp": "^6.0.0",
     "through2": "^4.0.0",
     "ts-node": "^10.0.0",
     "typescript": "^5.2.2"


### PR DESCRIPTION
Sinon depends on the [nise package](https://www.npmjs.com/package/nise). That package just published v6.0.1 which updated path-to-regexp from v6.2.1 to v8.1.0 with https://github.com/sinonjs/nise/pull/226. That should have been a major version bump, as this ended up introducing a breaking change that now it depends on Node >= 16, which is causing our CI to break.

This PR fixes path-to-regexp to ^6.2.1 like previously to make it work on Node >= 14

Similar to https://github.com/googleapis/nodejs-bigquery-storage/pull/475 and https://github.com/googleapis/nodejs-bigquery/pull/1403