### PR TITLE
fix: Use correct limit when retrying a limit query stream with a cursor

### DIFF
--- a/dev/src/reference/query-util.ts
+++ b/dev/src/reference/query-util.ts
@@ -338,8 +338,10 @@ export class QueryUtil<
                   // the query cursor. Note that we do not use backoff here. The
                   // call to `requestStream()` will backoff should the restart
                   // fail before delivering any results.
-                  let newQuery: Query<AppModelType, DbModelType> = query;
-                  if (this._queryOptions.limit) {
+                  let newQuery: Query<AppModelType, DbModelType>;
+                  if (!this._queryOptions.limit) {
+                    newQuery = query;
+                  } else {
                     const newLimit =
                       this._queryOptions.limit - numDocumentsReceived;
                     if (

--- a/dev/src/reference/query-util.ts
+++ b/dev/src/reference/query-util.ts
@@ -181,6 +181,7 @@ export class QueryUtil<
     const startTime = Date.now();
     const isExplain = explainOptions !== undefined;
 
+    let numDocumentsReceived = 0;
     let lastReceivedDocument: QueryDocumentSnapshot<
       AppModelType,
       DbModelType
@@ -239,6 +240,7 @@ export class QueryUtil<
           );
         }
 
+        ++numDocumentsReceived;
         callback(undefined, output);
 
         if (proto.done) {
@@ -317,6 +319,12 @@ export class QueryUtil<
                   stream.destroy(err);
                   streamActive.resolve(/* active= */ false);
                 } else if (lastReceivedDocument && retryWithCursor) {
+                  if (query instanceof VectorQuery) {
+                    throw new Error(
+                      'Unimplemented: Vector query does not support cursors yet.'
+                    );
+                  }
+
                   logger(
                     'Query._stream',
                     tag,
@@ -330,12 +338,28 @@ export class QueryUtil<
                   // the query cursor. Note that we do not use backoff here. The
                   // call to `requestStream()` will backoff should the restart
                   // fail before delivering any results.
+                  let newQuery: Query<AppModelType, DbModelType> = query;
+                  if (this._queryOptions.limit) {
+                    const newLimit =
+                      this._queryOptions.limit - numDocumentsReceived;
+                    if (
+                      this._queryOptions.limitType === undefined ||
+                      this._queryOptions.limitType === LimitType.First
+                    ) {
+                      newQuery = query.limit(newLimit);
+                    } else {
+                      newQuery = query.limitToLast(newLimit);
+                    }
+                  }
+
                   if (this._queryOptions.requireConsistency) {
-                    request = query
+                    request = newQuery
                       .startAfter(lastReceivedDocument)
                       .toProto(lastReceivedDocument.readTime);
                   } else {
-                    request = query.startAfter(lastReceivedDocument).toProto();
+                    request = newQuery
+                      .startAfter(lastReceivedDocument)
+                      .toProto();
                   }
 
                   // Set lastReceivedDocument to null before each retry attempt to ensure the retry makes progress

--- a/dev/test/recursive-delete.ts
+++ b/dev/test/recursive-delete.ts
@@ -226,7 +226,7 @@ describe('recursiveDelete() method:', () => {
                 'LESS_THAN',
                 endAt('root')
               ),
-              limit(RECURSIVE_DELETE_MAX_PENDING_OPS)
+              limit(RECURSIVE_DELETE_MAX_PENDING_OPS - 1)
             );
             return stream();
           }


### PR DESCRIPTION
When a query is streamed and the stream fails after receiving part of the result set, the client retries the stream with a cursor. If the original query has a limit, the retry logic should use a modified limit for the remainder of the stream to ensure the final result contains the correct number of documents.

fixes #2200 