### PR TITLE
feat: Enable tracing via OpenTelemetry.

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -792,8 +792,7 @@ export class Firestore implements firestore.Firestore {
   }
 
   private newTraceUtilInstance(settings: firestore.Settings): TraceUtil {
-    // Take the tracing option from the settings.
-    let createEnabledInstance = settings.openTelemetryOptions?.enableTracing;
+    let createEnabledInstance = true;
 
     // The environment variable can override options to enable/disable telemetry collection.
     if ('FIRESTORE_ENABLE_TRACING' in process.env) {

--- a/dev/src/reference/query-util.ts
+++ b/dev/src/reference/query-util.ts
@@ -180,6 +180,7 @@ export class QueryUtil<
     const tag = requestTag();
     const startTime = Date.now();
     const isExplain = explainOptions !== undefined;
+    const methodName = 'runQuery';
 
     let numDocumentsReceived = 0;
     let lastReceivedDocument: QueryDocumentSnapshot<
@@ -245,6 +246,11 @@ export class QueryUtil<
 
         if (proto.done) {
           logger('QueryUtil._stream', tag, 'Trigger Logical Termination.');
+          this._firestore._traceUtil
+            .currentSpan()
+            .addEvent(
+              `Firestore.${methodName}: Received RunQueryResponse.Done.`
+            );
           backendStream.unpipe(stream);
           backendStream.resume();
           backendStream.end();
@@ -265,7 +271,6 @@ export class QueryUtil<
         let streamActive: Deferred<boolean>;
         do {
           streamActive = new Deferred<boolean>();
-          const methodName = 'runQuery';
 
           this._firestore._traceUtil
             .currentSpan()

--- a/dev/src/telemetry/disabled-trace-util.ts
+++ b/dev/src/telemetry/disabled-trace-util.ts
@@ -16,6 +16,10 @@
 import {Attributes, TraceUtil} from './trace-util';
 import {Span} from './span';
 
+/**
+ * @private
+ * @internal
+ */
 export class DisabledTraceUtil implements TraceUtil {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   startSpan(name: string): Span {

--- a/dev/src/telemetry/enabled-trace-util.ts
+++ b/dev/src/telemetry/enabled-trace-util.ts
@@ -47,7 +47,7 @@ export class EnabledTraceUtil implements TraceUtil {
 
   constructor(settings: Settings) {
     let provider: TracerProvider | undefined =
-      settings.openTelemetryOptions?.tracerProvider;
+      settings.openTelemetry?.tracerProvider;
 
     // If a TracerProvider has not been given to us, we try to use the global one.
     if (!provider) {

--- a/dev/src/telemetry/enabled-trace-util.ts
+++ b/dev/src/telemetry/enabled-trace-util.ts
@@ -65,7 +65,7 @@ export class EnabledTraceUtil implements TraceUtil {
       this.tracer = this.tracerProvider.getTracer(libName, libVersion);
     } catch (e) {
       throw new Error(
-        "the given value for 'tracerProvider' does not implement the TracerProvider interface."
+        "The object provided for 'tracerProvider' does not conform to the TracerProvider interface."
       );
     }
 

--- a/dev/src/telemetry/span.ts
+++ b/dev/src/telemetry/span.ts
@@ -17,6 +17,10 @@
 import {Span as OpenTelemetrySpan} from '@opentelemetry/api';
 import {Attributes} from './trace-util';
 
+/**
+ * @private
+ * @internal
+ */
 export class Span {
   constructor(private span?: OpenTelemetrySpan) {}
 

--- a/dev/src/telemetry/trace-util.ts
+++ b/dev/src/telemetry/trace-util.ts
@@ -16,9 +16,18 @@
 
 import {Span} from './span';
 
+/**
+ * @private
+ * @internal
+ */
 export interface Attributes {
   [attributeKey: string]: AttributeValue | undefined;
 }
+
+/**
+ * @private
+ * @internal
+ */
 export declare type AttributeValue =
   | string
   | number
@@ -67,6 +76,10 @@ export const ATTRIBUTE_KEY_TRANSACTION_TYPE = 'transaction_type';
 export const ATTRIBUTE_KEY_ATTEMPTS_ALLOWED = 'attempts_allowed';
 export const ATTRIBUTE_KEY_ATTEMPTS_REMAINING = 'attempts_remaining';
 
+/**
+ * @private
+ * @internal
+ */
 export interface TraceUtil {
   startActiveSpan<F extends (span: Span) => unknown>(
     name: string,

--- a/dev/system-test/tracing.ts
+++ b/dev/system-test/tracing.ts
@@ -30,7 +30,7 @@ import {
   Context as OpenTelemetryContext,
 } from '@opentelemetry/api';
 import {TraceExporter} from '@google-cloud/opentelemetry-cloud-trace-exporter';
-import {Settings} from '@google-cloud/firestore';
+import {FirestoreOpenTelemetryOptions, Settings} from '@google-cloud/firestore';
 import {
   AlwaysOnSampler,
   BatchSpanProcessor,
@@ -95,13 +95,6 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 setLogFunction((msg: string) => {
   console.log(`LOG: ${msg}`);
 });
-
-// TODO(tracing): This should be moved to firestore.d.ts when we want to
-//  release the feature.
-export interface FirestoreOpenTelemetryOptions {
-  enableTracing?: boolean;
-  tracerProvider?: any;
-}
 
 interface TestConfig {
   // In-Memory tests check trace correctness by inspecting traces in memory by
@@ -192,7 +185,6 @@ describe('Tracing Tests', () => {
     tracerProvider: TracerProvider
   ): FirestoreOpenTelemetryOptions {
     const options: FirestoreOpenTelemetryOptions = {
-      enableTracing: true,
       tracerProvider: undefined,
     };
 
@@ -920,6 +912,7 @@ describe('Tracing Tests', () => {
       await runFirestoreOperationInRootSpan(async () => {
         const query = firestore.collectionGroup('foo');
         let numPartitions = 0;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for await (const partition of query.getPartitions(3)) {
           numPartitions++;
         }

--- a/dev/system-test/tracing.ts
+++ b/dev/system-test/tracing.ts
@@ -881,7 +881,6 @@ describe('Tracing Tests', () => {
         'RunQuery',
         'Firestore.runQuery: Start',
         'Firestore.runQuery: First response received',
-        'Firestore.runQuery: Received RunQueryResponse.Done.',
         'Firestore.runQuery: Completed',
       ]);
     });

--- a/dev/system-test/tracing.ts
+++ b/dev/system-test/tracing.ts
@@ -277,7 +277,7 @@ describe('Tracing Tests', () => {
 
     const settings: Settings = {
       preferRest: testConfig.preferRest,
-      openTelemetryOptions: getOpenTelemetryOptions(tracerProvider),
+      openTelemetry: getOpenTelemetryOptions(tracerProvider),
     };
 
     // Named-database tests use an environment variable to specify the database ID. Add it to the settings.

--- a/dev/test/tracing.ts
+++ b/dev/test/tracing.ts
@@ -17,11 +17,15 @@ import {createInstance} from './util/helpers';
 import {expect} from 'chai';
 import {DisabledTraceUtil} from '../src/telemetry/disabled-trace-util';
 import {EnabledTraceUtil} from '../src/telemetry/enabled-trace-util';
+import {NodeTracerProvider} from '@opentelemetry/sdk-trace-node';
+import {ProxyTracerProvider, trace} from '@opentelemetry/api';
 
 describe('Firestore Tracing Controls', () => {
   let originalEnvVarValue: string | undefined;
 
   beforeEach(() => {
+    // Remove any prior global OpenTelemetry registrations.
+    trace.disable();
     originalEnvVarValue = process.env.FIRESTORE_ENABLE_TRACING;
   });
 
@@ -33,116 +37,152 @@ describe('Firestore Tracing Controls', () => {
     }
   });
 
-  it('default firestore settings have tracing disabled', async () => {
+  it('default firestore settings, no env var', async () => {
     const firestore = await createInstance();
-    expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
-  });
-
-  it('no openTelemetryOptions results in tracing disabled', async () => {
-    const firestore = await createInstance(undefined, {
-      openTelemetryOptions: undefined,
-    });
-    expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
-  });
-
-  it('openTelemetryOptions.enableTracing controls the tracing feature', async () => {
-    let firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
-        enableTracing: undefined,
-      },
-    });
-    expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
-
-    firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
-        enableTracing: false,
-      },
-    });
-    expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
-
-    firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
-        enableTracing: true,
-      },
-    });
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
   });
 
   /// Tests to make sure environment variable can override settings.
 
-  it('env var disabled, default firestore settings', async () => {
+  it('default firestore settings, env var disabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'OFF';
     const firestore = await createInstance();
     expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
   });
 
-  it('env var enabled, default firestore settings', async () => {
+  it('default firestore settings, env var enabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'ON';
     const firestore = await createInstance();
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
   });
 
-  it('env var disabled, no openTelemetryOptions', async () => {
+  it('no openTelemetryOptions, no env var', async () => {
+    const firestore = await createInstance(undefined, {
+      openTelemetryOptions: undefined,
+    });
+    expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
+
+    const firestore2 = await createInstance(undefined, {
+      openTelemetryOptions: {
+        tracerProvider: undefined,
+      },
+    });
+    expect(firestore2._traceUtil instanceof EnabledTraceUtil).to.be.true;
+  });
+
+  it('no openTelemetryOptions, env var disabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'OFF';
     const firestore = await createInstance(undefined, {
       openTelemetryOptions: undefined,
     });
     expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
+
+    const firestore2 = await createInstance(undefined, {
+      openTelemetryOptions: {
+        tracerProvider: undefined,
+      },
+    });
+    expect(firestore2._traceUtil instanceof DisabledTraceUtil).to.be.true;
   });
 
-  it('env var enabled, no openTelemetryOptions', async () => {
+  it('no openTelemetryOptions, env var enabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'ON';
     const firestore = await createInstance(undefined, {
       openTelemetryOptions: undefined,
     });
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
+
+    const firestore2 = await createInstance(undefined, {
+      openTelemetryOptions: {
+        tracerProvider: undefined,
+      },
+    });
+    expect(firestore2._traceUtil instanceof EnabledTraceUtil).to.be.true;
   });
 
-  it('env var disabled, with openTelemetryOptions.enableTracing', async () => {
+  it('valid tracerProvider, no env var', async () => {
+    const firestore = await createInstance(undefined, {
+      openTelemetryOptions: {
+        tracerProvider: new NodeTracerProvider(),
+      },
+    });
+    expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
+  });
+
+  it('valid tracerProvider, env var disabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'OFF';
-    let firestore = await createInstance(undefined, {
+    const firestore = await createInstance(undefined, {
       openTelemetryOptions: {
-        enableTracing: undefined,
-      },
-    });
-    expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
-
-    firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
-        enableTracing: false,
-      },
-    });
-    expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
-
-    firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
-        enableTracing: true,
+        tracerProvider: new NodeTracerProvider(),
       },
     });
     expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
   });
 
-  it('env var enabled, with openTelemetryOptions.enableTracing', async () => {
+  it('valid tracerProvider, env var enabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'ON';
-    let firestore = await createInstance(undefined, {
+    const firestore = await createInstance(undefined, {
       openTelemetryOptions: {
-        enableTracing: undefined,
+        tracerProvider: new NodeTracerProvider(),
       },
     });
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
+  });
 
-    firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
-        enableTracing: false,
-      },
-    });
-    expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
+  it('uses the tracerProvider passed to it', async () => {
+    const myTracerProvider = new NodeTracerProvider();
 
-    firestore = await createInstance(undefined, {
+    // Make another tracer provider the global tracer provider.
+    const globalTracerProvider = new NodeTracerProvider();
+    globalTracerProvider.register();
+
+    const firestore = await createInstance(undefined, {
       openTelemetryOptions: {
-        enableTracing: true,
+        tracerProvider: myTracerProvider,
       },
     });
+
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
+    // Make sure the SDK uses the one that was given to it, not the global one.
+    expect(
+      (firestore._traceUtil as EnabledTraceUtil).tracerProvider ===
+        myTracerProvider
+    ).to.be.true;
+    expect(
+      (firestore._traceUtil as EnabledTraceUtil).tracerProvider !==
+        globalTracerProvider
+    ).to.be.true;
+  });
+
+  it('uses the global tracerProvider if nothing was passed to it', async () => {
+    // Make another tracer provider the global tracer provider.
+    const globalTracerProvider = new NodeTracerProvider();
+    globalTracerProvider.register();
+
+    const firestore = await createInstance();
+
+    expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
+    const enabledTraceUtil: EnabledTraceUtil =
+      firestore._traceUtil as EnabledTraceUtil;
+    // Since a TracerProvider is not provided to the SDK directly, the SDK obtains
+    // the tracer provider from the global `TraceAPI`. The `TraceAPI` returns a
+    // `ProxyTracerProvider` instance. To check equality, we need to compare our
+    // `globalTracerProvider` with the proxy's delegate.
+    const tracerProviderUsed = enabledTraceUtil.tracerProvider;
+    const actual = (tracerProviderUsed as ProxyTracerProvider).getDelegate();
+    expect(actual === globalTracerProvider).to.be.true;
+  });
+
+  it('Generates an error if the given tracerProvider is not valid', async () => {
+    try {
+      await createInstance(undefined, {
+        openTelemetryOptions: {tracerProvider: 123},
+      });
+    } catch (e) {
+      expect(
+        e.toString() ===
+          "the given value for 'tracerProvider' does not implement the TracerProvider interface"
+      );
+    }
   });
 });

--- a/dev/test/tracing.ts
+++ b/dev/test/tracing.ts
@@ -181,7 +181,7 @@ describe('Firestore Tracing Controls', () => {
     } catch (e) {
       expect(
         e.toString() ===
-          "the given value for 'tracerProvider' does not implement the TracerProvider interface"
+          "The object provided for 'tracerProvider' does not conform to the TracerProvider interface."
       );
     }
   });

--- a/dev/test/tracing.ts
+++ b/dev/test/tracing.ts
@@ -56,44 +56,44 @@ describe('Firestore Tracing Controls', () => {
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
   });
 
-  it('no openTelemetryOptions, no env var', async () => {
+  it('no openTelemetry settings, no env var', async () => {
     const firestore = await createInstance(undefined, {
-      openTelemetryOptions: undefined,
+      openTelemetry: undefined,
     });
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
 
     const firestore2 = await createInstance(undefined, {
-      openTelemetryOptions: {
+      openTelemetry: {
         tracerProvider: undefined,
       },
     });
     expect(firestore2._traceUtil instanceof EnabledTraceUtil).to.be.true;
   });
 
-  it('no openTelemetryOptions, env var disabled', async () => {
+  it('no openTelemetry settings, env var disabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'OFF';
     const firestore = await createInstance(undefined, {
-      openTelemetryOptions: undefined,
+      openTelemetry: undefined,
     });
     expect(firestore._traceUtil instanceof DisabledTraceUtil).to.be.true;
 
     const firestore2 = await createInstance(undefined, {
-      openTelemetryOptions: {
+      openTelemetry: {
         tracerProvider: undefined,
       },
     });
     expect(firestore2._traceUtil instanceof DisabledTraceUtil).to.be.true;
   });
 
-  it('no openTelemetryOptions, env var enabled', async () => {
+  it('no openTelemetry settings, env var enabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'ON';
     const firestore = await createInstance(undefined, {
-      openTelemetryOptions: undefined,
+      openTelemetry: undefined,
     });
     expect(firestore._traceUtil instanceof EnabledTraceUtil).to.be.true;
 
     const firestore2 = await createInstance(undefined, {
-      openTelemetryOptions: {
+      openTelemetry: {
         tracerProvider: undefined,
       },
     });
@@ -102,7 +102,7 @@ describe('Firestore Tracing Controls', () => {
 
   it('valid tracerProvider, no env var', async () => {
     const firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
+      openTelemetry: {
         tracerProvider: new NodeTracerProvider(),
       },
     });
@@ -112,7 +112,7 @@ describe('Firestore Tracing Controls', () => {
   it('valid tracerProvider, env var disabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'OFF';
     const firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
+      openTelemetry: {
         tracerProvider: new NodeTracerProvider(),
       },
     });
@@ -122,7 +122,7 @@ describe('Firestore Tracing Controls', () => {
   it('valid tracerProvider, env var enabled', async () => {
     process.env.FIRESTORE_ENABLE_TRACING = 'ON';
     const firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
+      openTelemetry: {
         tracerProvider: new NodeTracerProvider(),
       },
     });
@@ -137,7 +137,7 @@ describe('Firestore Tracing Controls', () => {
     globalTracerProvider.register();
 
     const firestore = await createInstance(undefined, {
-      openTelemetryOptions: {
+      openTelemetry: {
         tracerProvider: myTracerProvider,
       },
     });
@@ -176,7 +176,7 @@ describe('Firestore Tracing Controls', () => {
   it('Generates an error if the given tracerProvider is not valid', async () => {
     try {
       await createInstance(undefined, {
-        openTelemetryOptions: {tracerProvider: 123},
+        openTelemetry: {tracerProvider: 123},
       });
     } catch (e) {
       expect(

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -482,7 +482,7 @@ declare namespace FirebaseFirestore {
      *
      * Even if a Global TracerProvider has been registered, users can still
      * disable this client's span creation by passing in a "no-op" tracer provider
-     * here, or by setting the `FIRESTORE_ENABLE_TRACING=OFF` environment variable.
+     * here, or by setting the `FIRESTORE_ENABLE_TRACING` environment variable to `OFF` or `FALSE`.
      */
     tracerProvider?: any;
   }

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -461,7 +461,31 @@ declare namespace FirebaseFirestore {
      */
     preferRest?: boolean;
 
+    /**
+     * Settings related to telemetry collection by this client.
+     * @beta
+     */
+    openTelemetryOptions?: FirestoreOpenTelemetryOptions;
+
     [key: string]: any; // Accept other properties, such as GRPC settings.
+  }
+
+  /**
+   * Options to configure telemetry collection.
+   * This is a 'beta' interface and may change in backwards incompatible ways.
+   * @beta
+   */
+  export interface FirestoreOpenTelemetryOptions {
+    /**
+     * The SDK will use this OpenTelemetry TracerProvider to create spans.
+     * If not provided, the SDK will attempt to use the Global TracerProvider if
+     * one has been registered. In the absence of both, the SDK will not create
+     * trace spans.
+     * Even if a Global TracerProvider has been registered, one can still disable
+     * this client's span creation by passing in a "no-op" tracer provider here,
+     * or by setting the `FIRESTORE_ENABLE_TRACING=OFF` environment variable.
+     */
+    tracerProvider?: any;
   }
 
   /** Options to configure a read-only transaction. */

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -477,13 +477,12 @@ declare namespace FirebaseFirestore {
    */
   export interface FirestoreOpenTelemetryOptions {
     /**
-     * The SDK will use this OpenTelemetry TracerProvider to create spans.
-     * If not provided, the SDK will attempt to use the Global TracerProvider if
-     * one has been registered. In the absence of both, the SDK will not create
-     * trace spans.
-     * Even if a Global TracerProvider has been registered, one can still disable
-     * this client's span creation by passing in a "no-op" tracer provider here,
-     * or by setting the `FIRESTORE_ENABLE_TRACING=OFF` environment variable.
+     * The OpenTelemetry TracerProvider instance that the SDK should use to
+     * create trace spans. If not provided, the SDK will use the Global TracerProvider.
+     *
+     * Even if a Global TracerProvider has been registered, users can still
+     * disable this client's span creation by passing in a "no-op" tracer provider
+     * here, or by setting the `FIRESTORE_ENABLE_TRACING=OFF` environment variable.
      */
     tracerProvider?: any;
   }

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -465,7 +465,7 @@ declare namespace FirebaseFirestore {
      * Settings related to telemetry collection by this client.
      * @beta
      */
-    openTelemetryOptions?: FirestoreOpenTelemetryOptions;
+    openTelemetry?: FirestoreOpenTelemetryOptions;
 
     [key: string]: any; // Accept other properties, such as GRPC settings.
   }


### PR DESCRIPTION
This PR enables the feature that allows users to capture Firestore trace spans by setting up an OpenTelemetry tracer and passing it to Firestore settings via `settings.openTelemetry` [or setting up a global OpenTelemetry tracer]. The feature can be disabled by setting the `FIRESTORE_ENABLE_TRACING` environment variable to `OFF` or `FALSE`.