### PR TITLE
Fix: sort document reference by long type id 

### DIFF
--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -185,16 +185,13 @@ abstract class Path<T> {
       return 1;
     } else if (isLhsNumeric && isRhsNumeric) {
       // both numeric
-      return Math.sign(this.extractNumericId(lhs) - this.extractNumericId(rhs));
+      return this.compareNumbers(
+        this.extractNumericId(lhs),
+        this.extractNumericId(rhs)
+      );
     } else {
       // both non-numeric
-      if (lhs < rhs) {
-        return -1;
-      }
-      if (lhs > rhs) {
-        return 1;
-      }
-      return 0;
+      return this.compareStrings(lhs, rhs);
     }
   }
 
@@ -203,9 +200,29 @@ abstract class Path<T> {
     return segment.startsWith('__id') && segment.endsWith('__');
   }
 
-  //  Extracts the numeric value from a numeric ID segment.
-  private extractNumericId(segment: string): number {
-    return parseInt(segment.substring(4, segment.length - 2), 10);
+  //  Extracts the long number from a numeric ID segment.
+  private extractNumericId(segment: string): bigint {
+    return BigInt(segment.substring(4, segment.length - 2));
+  }
+
+  private compareNumbers(lhs: bigint, rhs: bigint): number {
+    if (lhs < rhs) {
+      return -1;
+    } else if (lhs > rhs) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  private compareStrings(lhs: string, rhs: string): number {
+    if (lhs < rhs) {
+      return -1;
+    } else if (lhs > rhs) {
+      return 1;
+    } else {
+      return 0;
+    }
   }
 
   /**

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -170,7 +170,7 @@ abstract class Path<T> {
         return comparison;
       }
     }
-    return this.segments.length - other.segments.length;
+    return Math.sign(this.segments.length - other.segments.length);
   }
 
   private compareSegments(lhs: string, rhs: string): number {
@@ -185,7 +185,7 @@ abstract class Path<T> {
       return 1;
     } else if (isLhsNumeric && isRhsNumeric) {
       // both numeric
-      return this.extractNumericId(lhs) - this.extractNumericId(rhs);
+      return Math.sign(this.extractNumericId(lhs) - this.extractNumericId(rhs));
     } else {
       // both non-numeric
       if (lhs < rhs) {

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -170,7 +170,10 @@ abstract class Path<T> {
         return comparison;
       }
     }
-    return Math.sign(this.segments.length - other.segments.length);
+    return this.compareNumbers(
+      BigInt(this.segments.length),
+      BigInt(other.segments.length)
+    );
   }
 
   private compareSegments(lhs: string, rhs: string): number {

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -170,10 +170,7 @@ abstract class Path<T> {
         return comparison;
       }
     }
-    return this.compareNumbers(
-      BigInt(this.segments.length),
-      BigInt(other.segments.length)
-    );
+    return Math.sign(this.segments.length - other.segments.length);
   }
 
   private compareSegments(lhs: string, rhs: string): number {

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3925,6 +3925,7 @@ describe('Query class', () => {
       batch.set(randomCol.doc('__id-2__'), {a: 1});
       batch.set(randomCol.doc('__id1_'), {a: 1});
       batch.set(randomCol.doc('_id1__'), {a: 1});
+      batch.set(randomCol.doc('__id'), {a: 1});
       // largest long number
       batch.set(randomCol.doc('__id9223372036854775807__'), {a: 1});
       batch.set(randomCol.doc('__id9223372036854775806__'), {a: 1});
@@ -3946,6 +3947,7 @@ describe('Query class', () => {
         '7',
         'A',
         'Aa',
+        '__id',
         '__id1_',
         '_id1__',
         'a',
@@ -3979,6 +3981,7 @@ describe('Query class', () => {
       batch.set(randomCol.doc('__id-2__'), {a: 1});
       batch.set(randomCol.doc('__id1_'), {a: 1});
       batch.set(randomCol.doc('_id1__'), {a: 1});
+      batch.set(randomCol.doc('__id'), {a: 1});
       // largest long number
       batch.set(randomCol.doc('__id9223372036854775807__'), {a: 1});
       batch.set(randomCol.doc('__id9223372036854775806__'), {a: 1});

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3913,6 +3913,87 @@ describe('Query class', () => {
       unsubscribe();
     });
 
+    it('snapshot listener sorts query by DocumentId same way as server', async () => {
+      const batch = firestore.batch();
+
+      batch.set(randomCol.doc('A'), {a: 1});
+      batch.set(randomCol.doc('a'), {a: 1});
+      batch.set(randomCol.doc('Aa'), {a: 1});
+      batch.set(randomCol.doc('7'), {a: 1});
+      batch.set(randomCol.doc('12'), {a: 1});
+      batch.set(randomCol.doc('__id7__'), {a: 1});
+      batch.set(randomCol.doc('__id12__'), {a: 1});
+      batch.set(randomCol.doc('__id1_'), {a: 1});
+      batch.set(randomCol.doc('_id1__'), {a: 1});
+      await batch.commit();
+
+      const query = randomCol.orderBy(FieldPath.documentId());
+      const expectedDocs = [
+        '__id7__',
+        '__id12__',
+        '12',
+        '7',
+        'A',
+        'Aa',
+        '__id1_',
+        '_id1__',
+        'a',
+      ];
+
+      const getSnapshot = await query.get();
+      expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
+
+      const unsubscribe = query.onSnapshot(snapshot =>
+        currentDeferred.resolve(snapshot)
+      );
+
+      const watchSnapshot = await waitForSnapshot();
+      // Compare the snapshot (including sort order) of a snapshot
+      // from Query.onSnapshot() to an actual snapshot from Query.get()
+      snapshotsEqual(watchSnapshot, {
+        docs: getSnapshot.docs,
+        docChanges: getSnapshot.docChanges(),
+      });
+      unsubscribe();
+    });
+
+    it('snapshot listener sorts filtered query by DocumentId same way as server', async () => {
+      const batch = firestore.batch();
+
+      batch.set(randomCol.doc('A'), {a: 1});
+      batch.set(randomCol.doc('a'), {a: 1});
+      batch.set(randomCol.doc('Aa'), {a: 1});
+      batch.set(randomCol.doc('7'), {a: 1});
+      batch.set(randomCol.doc('12'), {a: 1});
+      batch.set(randomCol.doc('__id7__'), {a: 1});
+      batch.set(randomCol.doc('__id12__'), {a: 1});
+      batch.set(randomCol.doc('__id1_'), {a: 1});
+      batch.set(randomCol.doc('_id1__'), {a: 1});
+      await batch.commit();
+
+      const query = randomCol
+        .where(FieldPath.documentId(), '>', '__id7__')
+        .where(FieldPath.documentId(), '<=', 'A')
+        .orderBy(FieldPath.documentId());
+      const expectedDocs = ['__id12__', '12', '7', 'A'];
+
+      const getSnapshot = await query.get();
+      expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
+
+      const unsubscribe = query.onSnapshot(snapshot =>
+        currentDeferred.resolve(snapshot)
+      );
+
+      const watchSnapshot = await waitForSnapshot();
+      // Compare the snapshot (including sort order) of a snapshot
+      // from Query.onSnapshot() to an actual snapshot from Query.get()
+      snapshotsEqual(watchSnapshot, {
+        docs: getSnapshot.docs,
+        docChanges: getSnapshot.docChanges(),
+      });
+      unsubscribe();
+    });
+
     it('SDK orders vector field same way as backend', async () => {
       // We validate that the SDK orders the vector field the same way as the backend
       // by comparing the sort order of vector fields from a Query.get() and

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3915,7 +3915,6 @@ describe('Query class', () => {
 
     it('snapshot listener sorts query by DocumentId same way as server', async () => {
       const batch = firestore.batch();
-
       batch.set(randomCol.doc('A'), {a: 1});
       batch.set(randomCol.doc('a'), {a: 1});
       batch.set(randomCol.doc('Aa'), {a: 1});
@@ -3923,14 +3922,22 @@ describe('Query class', () => {
       batch.set(randomCol.doc('12'), {a: 1});
       batch.set(randomCol.doc('__id7__'), {a: 1});
       batch.set(randomCol.doc('__id12__'), {a: 1});
+      batch.set(randomCol.doc('__id-2__'), {a: 1});
       batch.set(randomCol.doc('__id1_'), {a: 1});
       batch.set(randomCol.doc('_id1__'), {a: 1});
+      // largest long number
+      batch.set(randomCol.doc('__id9223372036854775807__'), {a: 1});
+      // smallest long number
+      batch.set(randomCol.doc('__id-9223372036854775808__'), {a: 1});
       await batch.commit();
 
       const query = randomCol.orderBy(FieldPath.documentId());
       const expectedDocs = [
+        '__id-9223372036854775808__',
+        '__id-2__',
         '__id7__',
         '__id12__',
+        '__id9223372036854775807__',
         '12',
         '7',
         'A',
@@ -3959,7 +3966,6 @@ describe('Query class', () => {
 
     it('snapshot listener sorts filtered query by DocumentId same way as server', async () => {
       const batch = firestore.batch();
-
       batch.set(randomCol.doc('A'), {a: 1});
       batch.set(randomCol.doc('a'), {a: 1});
       batch.set(randomCol.doc('Aa'), {a: 1});
@@ -3967,15 +3973,26 @@ describe('Query class', () => {
       batch.set(randomCol.doc('12'), {a: 1});
       batch.set(randomCol.doc('__id7__'), {a: 1});
       batch.set(randomCol.doc('__id12__'), {a: 1});
+      batch.set(randomCol.doc('__id-2__'), {a: 1});
       batch.set(randomCol.doc('__id1_'), {a: 1});
       batch.set(randomCol.doc('_id1__'), {a: 1});
+      // largest long number
+      batch.set(randomCol.doc('__id9223372036854775807__'), {a: 1});
+      // smallest long number
+      batch.set(randomCol.doc('__id-9223372036854775808__'), {a: 1});
       await batch.commit();
 
       const query = randomCol
         .where(FieldPath.documentId(), '>', '__id7__')
         .where(FieldPath.documentId(), '<=', 'A')
         .orderBy(FieldPath.documentId());
-      const expectedDocs = ['__id12__', '12', '7', 'A'];
+      const expectedDocs = [
+        '__id12__',
+        '__id9223372036854775807__',
+        '12',
+        '7',
+        'A',
+      ];
 
       const getSnapshot = await query.get();
       expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -3927,16 +3927,20 @@ describe('Query class', () => {
       batch.set(randomCol.doc('_id1__'), {a: 1});
       // largest long number
       batch.set(randomCol.doc('__id9223372036854775807__'), {a: 1});
+      batch.set(randomCol.doc('__id9223372036854775806__'), {a: 1});
       // smallest long number
       batch.set(randomCol.doc('__id-9223372036854775808__'), {a: 1});
+      batch.set(randomCol.doc('__id-9223372036854775807__'), {a: 1});
       await batch.commit();
 
       const query = randomCol.orderBy(FieldPath.documentId());
       const expectedDocs = [
         '__id-9223372036854775808__',
+        '__id-9223372036854775807__',
         '__id-2__',
         '__id7__',
         '__id12__',
+        '__id9223372036854775806__',
         '__id9223372036854775807__',
         '12',
         '7',
@@ -3956,7 +3960,6 @@ describe('Query class', () => {
 
       const watchSnapshot = await waitForSnapshot();
       // Compare the snapshot (including sort order) of a snapshot
-      // from Query.onSnapshot() to an actual snapshot from Query.get()
       snapshotsEqual(watchSnapshot, {
         docs: getSnapshot.docs,
         docChanges: getSnapshot.docChanges(),
@@ -3978,8 +3981,10 @@ describe('Query class', () => {
       batch.set(randomCol.doc('_id1__'), {a: 1});
       // largest long number
       batch.set(randomCol.doc('__id9223372036854775807__'), {a: 1});
+      batch.set(randomCol.doc('__id9223372036854775806__'), {a: 1});
       // smallest long number
       batch.set(randomCol.doc('__id-9223372036854775808__'), {a: 1});
+      batch.set(randomCol.doc('__id-9223372036854775807__'), {a: 1});
       await batch.commit();
 
       const query = randomCol
@@ -3988,6 +3993,7 @@ describe('Query class', () => {
         .orderBy(FieldPath.documentId());
       const expectedDocs = [
         '__id12__',
+        '__id9223372036854775806__',
         '__id9223372036854775807__',
         '12',
         '7',
@@ -4003,7 +4009,6 @@ describe('Query class', () => {
 
       const watchSnapshot = await waitForSnapshot();
       // Compare the snapshot (including sort order) of a snapshot
-      // from Query.onSnapshot() to an actual snapshot from Query.get()
       snapshotsEqual(watchSnapshot, {
         docs: getSnapshot.docs,
         docChanges: getSnapshot.docChanges(),


### PR DESCRIPTION
Document ID supports strings and well as long integers in the format of  "__id<Long>__" . When sorting documents by document ID, it should be sorted in the following order:
1. Long (numeric order)
2. String (lexicographic order)