### PR TITLE
fix: correctly escape field paths with multiple backslashes or backticks

### DIFF
--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -621,7 +621,7 @@ export class FieldPath extends Path<FieldPath> implements firestore.FieldPath {
       .map(str => {
         return UNESCAPED_FIELD_NAME_RE.test(str)
           ? str
-          : '`' + str.replace('\\', '\\\\').replace('`', '\\`') + '`';
+          : '`' + str.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`';
       })
       .join('.');
   }

--- a/dev/test/path.ts
+++ b/dev/test/path.ts
@@ -68,9 +68,23 @@ describe('ResourcePath', () => {
 
 describe('FieldPath', () => {
   it('encodes field names', () => {
-    const components = [['foo'], ['foo', 'bar'], ['.', '`'], ['\\']];
+    const components = [
+      ['foo'],
+      ['foo', 'bar'],
+      ['.', '`'],
+      ['\\'],
+      ['\\\\'],
+      ['``'],
+    ];
 
-    const results = ['foo', 'foo.bar', '`.`.`\\``', '`\\\\`'];
+    const results = [
+      'foo',
+      'foo.bar',
+      '`.`.`\\``',
+      '`\\\\`',
+      '`\\\\\\\\`',
+      '`\\`\\``',
+    ];
 
     for (let i = 0; i < components.length; ++i) {
       expect(new FieldPath(...components[i]).toString()).to.equal(results[i]);


### PR DESCRIPTION
Previously, only the first backslash and backtick was being escaped. This broke `update` and `set (merge)` calls when a field path contained multiple backslashes.

`replaceAll` is an alternative here, but I think a global regex has better compatibility with older versions of Node.

Fixes #2019 🦕
