### PR TITLE
FIX: sort strings in UTF-8 encoded byte order

### DIFF
--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -214,7 +214,7 @@ function compareObjects(left: ApiMapValue, right: ApiMapValue): number {
   leftKeys.sort();
   rightKeys.sort();
   for (let i = 0; i < leftKeys.length && i < rightKeys.length; i++) {
-    const keyComparison = primitiveComparator(leftKeys[i], rightKeys[i]);
+    const keyComparison = compareUtf8Strings(leftKeys[i], rightKeys[i]);
     if (keyComparison !== 0) {
       return keyComparison;
     }
@@ -252,10 +252,10 @@ function stringToUTF8Bytes(str: string): Uint8Array {
   return new TextEncoder().encode(str);
 }
 
-function compareUTF8bytes(left: string, right: string): number {
+export function compareUtf8Strings(left: string, right: string): number {
   const leftBytes = stringToUTF8Bytes(left);
   const rightBytes = stringToUTF8Bytes(right);
-  return Buffer.compare(Buffer.from(leftBytes), Buffer.from(rightBytes));
+  return compareBlobs(Buffer.from(leftBytes), Buffer.from(rightBytes));
 }
 
 /*!
@@ -279,7 +279,7 @@ export function compare(left: api.IValue, right: api.IValue): number {
     case TypeOrder.BOOLEAN:
       return primitiveComparator(left.booleanValue!, right.booleanValue!);
     case TypeOrder.STRING:
-      return compareUTF8bytes(left.stringValue!, right.stringValue!);
+      return compareUtf8Strings(left.stringValue!, right.stringValue!);
     case TypeOrder.NUMBER:
       return compareNumberProtos(left, right);
     case TypeOrder.TIMESTAMP:

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -248,7 +248,7 @@ function compareVectors(left: ApiMapValue, right: ApiMapValue): number {
   return compareArrays(leftArray, rightArray);
 }
 
-function stringToUTF8Bytes(str: string): Uint8Array {
+function stringToUtf8Bytes(str: string): Uint8Array {
   return new TextEncoder().encode(str);
 }
 
@@ -258,8 +258,8 @@ function stringToUTF8Bytes(str: string): Uint8Array {
  * @internal
  */
 export function compareUtf8Strings(left: string, right: string): number {
-  const leftBytes = stringToUTF8Bytes(left);
-  const rightBytes = stringToUTF8Bytes(right);
+  const leftBytes = stringToUtf8Bytes(left);
+  const rightBytes = stringToUtf8Bytes(right);
   return compareBlobs(Buffer.from(leftBytes), Buffer.from(rightBytes));
 }
 

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -252,6 +252,11 @@ function stringToUTF8Bytes(str: string): Uint8Array {
   return new TextEncoder().encode(str);
 }
 
+/*!
+ * Compare strings in UTF-8 encoded byte order
+ * @private
+ * @internal
+ */
 export function compareUtf8Strings(left: string, right: string): number {
   const leftBytes = stringToUTF8Bytes(left);
   const rightBytes = stringToUTF8Bytes(right);

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -248,6 +248,16 @@ function compareVectors(left: ApiMapValue, right: ApiMapValue): number {
   return compareArrays(leftArray, rightArray);
 }
 
+function stringToUTF8Bytes(str: string): Uint8Array {
+  return new TextEncoder().encode(str);
+}
+
+function compareUTF8bytes(left: string, right: string): number {
+  const leftBytes = stringToUTF8Bytes(left);
+  const rightBytes = stringToUTF8Bytes(right);
+  return Buffer.compare(Buffer.from(leftBytes), Buffer.from(rightBytes));
+}
+
 /*!
  * @private
  * @internal
@@ -269,7 +279,7 @@ export function compare(left: api.IValue, right: api.IValue): number {
     case TypeOrder.BOOLEAN:
       return primitiveComparator(left.booleanValue!, right.booleanValue!);
     case TypeOrder.STRING:
-      return primitiveComparator(left.stringValue!, right.stringValue!);
+      return compareUTF8bytes(left.stringValue!, right.stringValue!);
     case TypeOrder.NUMBER:
       return compareNumberProtos(left, right);
     case TypeOrder.TIMESTAMP:

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -17,6 +17,7 @@
 import * as firestore from '@google-cloud/firestore';
 
 import {google} from '../protos/firestore_v1_proto_api';
+import {compareUtf8Strings} from './order';
 
 import {isObject} from './util';
 import {
@@ -191,7 +192,7 @@ abstract class Path<T> {
       );
     } else {
       // both non-numeric
-      return this.compareStrings(lhs, rhs);
+      return compareUtf8Strings(lhs, rhs);
     }
   }
 

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -191,7 +191,7 @@ abstract class Path<T> {
         this.extractNumericId(rhs)
       );
     } else {
-      // both string
+      // both non-numeric
       return compareUtf8Strings(lhs, rhs);
     }
   }

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -216,16 +216,6 @@ abstract class Path<T> {
     }
   }
 
-  private compareStrings(lhs: string, rhs: string): number {
-    if (lhs < rhs) {
-      return -1;
-    } else if (lhs > rhs) {
-      return 1;
-    } else {
-      return 0;
-    }
-  }
-
   /**
    * Returns a copy of the underlying segments.
    *

--- a/dev/src/path.ts
+++ b/dev/src/path.ts
@@ -17,7 +17,7 @@
 import * as firestore from '@google-cloud/firestore';
 
 import {google} from '../protos/firestore_v1_proto_api';
-import {compareUtf8Strings} from './order';
+import {compareUtf8Strings, primitiveComparator} from './order';
 
 import {isObject} from './util';
 import {
@@ -171,7 +171,7 @@ abstract class Path<T> {
         return comparison;
       }
     }
-    return Math.sign(this.segments.length - other.segments.length);
+    return primitiveComparator(this.segments.length, other.segments.length);
   }
 
   private compareSegments(lhs: string, rhs: string): number {
@@ -191,7 +191,7 @@ abstract class Path<T> {
         this.extractNumericId(rhs)
       );
     } else {
-      // both non-numeric
+      // both string
       return compareUtf8Strings(lhs, rhs);
     }
   }

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -4085,34 +4085,162 @@ describe('Query class', () => {
       });
     });
 
-    it('snapshot listener sorts query by unicode strings same way as server', async () => {
-      const collection = await testCollectionWithDocs({
-        a: {value: 'Łukasiewicz'},
-        b: {value: 'Sierpiński'},
-        c: {value: '岩澤'},
-        d: {value: '🄟'},
-        e: {value: 'Ｐ'},
-        f: {value: '︒'},
-        g: {value: '🐵'},
+    describe('sort unicode strings', () => {
+      it('snapshot listener sorts query by unicode strings same as server', async () => {
+        const collection = await testCollectionWithDocs({
+          a: {value: 'Łukasiewicz'},
+          b: {value: 'Sierpiński'},
+          c: {value: '岩澤'},
+          d: {value: '🄟'},
+          e: {value: 'Ｐ'},
+          f: {value: '︒'},
+          g: {value: '🐵'},
+        });
+
+        const query = collection.orderBy('value');
+        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
+
+        const getSnapshot = await query.get();
+        expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
+
+        const unsubscribe = query.onSnapshot(snapshot =>
+          currentDeferred.resolve(snapshot)
+        );
+
+        const watchSnapshot = await waitForSnapshot();
+        // Compare the snapshot (including sort order) of a snapshot
+        snapshotsEqual(watchSnapshot, {
+          docs: getSnapshot.docs,
+          docChanges: getSnapshot.docChanges(),
+        });
+        unsubscribe();
       });
 
-      const query = collection.orderBy("value");
-      const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
+      it('snapshot listener sorts query by unicode strings in array same as server', async () => {
+        const collection = await testCollectionWithDocs({
+          a: {value: ['Łukasiewicz']},
+          b: {value: ['Sierpiński']},
+          c: {value: ['岩澤']},
+          d: {value: ['🄟']},
+          e: {value: ['Ｐ']},
+          f: {value: ['︒']},
+          g: {value: ['🐵']},
+        });
 
-      const getSnapshot = await query.get();
-      expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
+        const query = collection.orderBy('value');
+        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
 
-      const unsubscribe = query.onSnapshot(snapshot =>
-        currentDeferred.resolve(snapshot)
-      );
+        const getSnapshot = await query.get();
+        expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
 
-      const watchSnapshot = await waitForSnapshot();
-      // Compare the snapshot (including sort order) of a snapshot
-      snapshotsEqual(watchSnapshot, {
-        docs: getSnapshot.docs,
-        docChanges: getSnapshot.docChanges(),
+        const unsubscribe = query.onSnapshot(snapshot =>
+          currentDeferred.resolve(snapshot)
+        );
+
+        const watchSnapshot = await waitForSnapshot();
+        snapshotsEqual(watchSnapshot, {
+          docs: getSnapshot.docs,
+          docChanges: getSnapshot.docChanges(),
+        });
+        unsubscribe();
       });
-      unsubscribe();
+
+      it('snapshot listener sorts query by unicode strings in map same as server', async () => {
+        const collection = await testCollectionWithDocs({
+          a: {value: {foo: 'Łukasiewicz'}},
+          b: {value: {foo: 'Sierpiński'}},
+          c: {value: {foo: '岩澤'}},
+          d: {value: {foo: '🄟'}},
+          e: {value: {foo: 'Ｐ'}},
+          f: {value: {foo: '︒'}},
+          g: {value: {foo: '🐵'}},
+        });
+
+        const query = collection.orderBy('value');
+        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
+
+        const getSnapshot = await query.get();
+        expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
+
+        const unsubscribe = query.onSnapshot(snapshot =>
+          currentDeferred.resolve(snapshot)
+        );
+
+        const watchSnapshot = await waitForSnapshot();
+        // Compare the snapshot (including sort order) of a snapshot
+        snapshotsEqual(watchSnapshot, {
+          docs: getSnapshot.docs,
+          docChanges: getSnapshot.docChanges(),
+        });
+        unsubscribe();
+      });
+      it('snapshot listener sorts query by unicode strings in map key same as server', async () => {
+        const collection = await testCollectionWithDocs({
+          a: {value: {Łukasiewicz: true}},
+          b: {value: {Sierpiński: true}},
+          c: {value: {岩澤: true}},
+          d: {value: {'🄟': true}},
+          e: {value: {Ｐ: true}},
+          f: {value: {'︒': true}},
+          g: {value: {'🐵': true}},
+        });
+
+        const query = collection.orderBy('value');
+        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
+
+        const getSnapshot = await query.get();
+        expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
+
+        const unsubscribe = query.onSnapshot(snapshot =>
+          currentDeferred.resolve(snapshot)
+        );
+
+        const watchSnapshot = await waitForSnapshot();
+        // Compare the snapshot (including sort order) of a snapshot
+        snapshotsEqual(watchSnapshot, {
+          docs: getSnapshot.docs,
+          docChanges: getSnapshot.docChanges(),
+        });
+        unsubscribe();
+      });
+
+      it('snapshot listener sorts query by unicode strings in document key same as server', async () => {
+        const collection = await testCollectionWithDocs({
+          Łukasiewicz: {value: true},
+          Sierpiński: {value: true},
+          岩澤: {value: true},
+          '🄟': {value: true},
+          Ｐ: {value: true},
+          '︒': {value: true},
+          '🐵': {value: true},
+        });
+
+        const query = collection.orderBy('value');
+        const expectedDocs = [
+          'Sierpiński',
+          'Łukasiewicz',
+          '岩澤',
+          '︒',
+          'Ｐ',
+          '🄟',
+          '🐵',
+        ];
+
+        const getSnapshot = await query.get();
+        expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
+
+        const unsubscribe = query.onSnapshot(snapshot =>
+          currentDeferred.resolve(snapshot)
+        );
+
+        const watchSnapshot = await waitForSnapshot();
+        // Compare the snapshot (including sort order) of a snapshot
+        snapshotsEqual(watchSnapshot, {
+          docs: getSnapshot.docs,
+          docChanges: getSnapshot.docChanges(),
+        });
+        unsubscribe();
+      });
     });
   });
 

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -4086,7 +4086,7 @@ describe('Query class', () => {
     });
 
     describe('sort unicode strings', () => {
-      it('snapshot listener sorts query by unicode strings same as server', async () => {
+      it('snapshot listener sorts unicode strings same as server', async () => {
         const collection = await testCollectionWithDocs({
           a: {value: 'Łukasiewicz'},
           b: {value: 'Sierpiński'},
@@ -4106,9 +4106,7 @@ describe('Query class', () => {
         const unsubscribe = query.onSnapshot(snapshot =>
           currentDeferred.resolve(snapshot)
         );
-
         const watchSnapshot = await waitForSnapshot();
-        // Compare the snapshot (including sort order) of a snapshot
         snapshotsEqual(watchSnapshot, {
           docs: getSnapshot.docs,
           docChanges: getSnapshot.docChanges(),
@@ -4116,7 +4114,7 @@ describe('Query class', () => {
         unsubscribe();
       });
 
-      it('snapshot listener sorts query by unicode strings in array same as server', async () => {
+      it('snapshot listener sorts unicode strings in array same as server', async () => {
         const collection = await testCollectionWithDocs({
           a: {value: ['Łukasiewicz']},
           b: {value: ['Sierpiński']},
@@ -4136,7 +4134,6 @@ describe('Query class', () => {
         const unsubscribe = query.onSnapshot(snapshot =>
           currentDeferred.resolve(snapshot)
         );
-
         const watchSnapshot = await waitForSnapshot();
         snapshotsEqual(watchSnapshot, {
           docs: getSnapshot.docs,
@@ -4145,7 +4142,7 @@ describe('Query class', () => {
         unsubscribe();
       });
 
-      it('snapshot listener sorts query by unicode strings in map same as server', async () => {
+      it('snapshot listener sorts unicode strings in map same as server', async () => {
         const collection = await testCollectionWithDocs({
           a: {value: {foo: 'Łukasiewicz'}},
           b: {value: {foo: 'Sierpiński'}},
@@ -4165,16 +4162,15 @@ describe('Query class', () => {
         const unsubscribe = query.onSnapshot(snapshot =>
           currentDeferred.resolve(snapshot)
         );
-
         const watchSnapshot = await waitForSnapshot();
-        // Compare the snapshot (including sort order) of a snapshot
         snapshotsEqual(watchSnapshot, {
           docs: getSnapshot.docs,
           docChanges: getSnapshot.docChanges(),
         });
         unsubscribe();
       });
-      it('snapshot listener sorts query by unicode strings in map key same as server', async () => {
+
+      it('snapshot listener sorts unicode strings in map key same as server', async () => {
         const collection = await testCollectionWithDocs({
           a: {value: {Łukasiewicz: true}},
           b: {value: {Sierpiński: true}},
@@ -4194,9 +4190,7 @@ describe('Query class', () => {
         const unsubscribe = query.onSnapshot(snapshot =>
           currentDeferred.resolve(snapshot)
         );
-
         const watchSnapshot = await waitForSnapshot();
-        // Compare the snapshot (including sort order) of a snapshot
         snapshotsEqual(watchSnapshot, {
           docs: getSnapshot.docs,
           docChanges: getSnapshot.docChanges(),
@@ -4204,7 +4198,7 @@ describe('Query class', () => {
         unsubscribe();
       });
 
-      it('snapshot listener sorts query by unicode strings in document key same as server', async () => {
+      it('snapshot listener sorts unicode strings in document key same as server', async () => {
         const collection = await testCollectionWithDocs({
           Łukasiewicz: {value: true},
           Sierpiński: {value: true},
@@ -4215,7 +4209,7 @@ describe('Query class', () => {
           '🐵': {value: true},
         });
 
-        const query = collection.orderBy('value');
+        const query = collection.orderBy(FieldPath.documentId());
         const expectedDocs = [
           'Sierpiński',
           'Łukasiewicz',
@@ -4232,9 +4226,7 @@ describe('Query class', () => {
         const unsubscribe = query.onSnapshot(snapshot =>
           currentDeferred.resolve(snapshot)
         );
-
         const watchSnapshot = await waitForSnapshot();
-        // Compare the snapshot (including sort order) of a snapshot
         snapshotsEqual(watchSnapshot, {
           docs: getSnapshot.docs,
           docChanges: getSnapshot.docChanges(),


### PR DESCRIPTION
Strings should be sorted in UTF-8 encoded byte order. Public document: https://cloud.google.com/firestore/docs/concepts/data-types#data_types

SDK sorts strings using built in comparator method, which sorts lexicographically, and leads to mismatch between server and sdk when special characters are present. This PR fixes the string order mismatches on document field, map key, and document key.