### PR TITLE
fix: close default BulkWriter upon terminate.

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1487,7 +1487,11 @@ export class Firestore implements firestore.Firestore {
    *
    * @return A Promise that resolves when the client is terminated.
    */
-  terminate(): Promise<void> {
+  async terminate(): Promise<void> {
+    if (this._bulkWriter) {
+      await this._bulkWriter.close();
+      this._bulkWriter = undefined;
+    }
     if (this.registeredListenersCount > 0 || this.bulkWritersCount > 0) {
       return Promise.reject(
         'All onSnapshot() listeners must be unsubscribed, and all BulkWriter ' +

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -6967,7 +6967,11 @@ describe('BulkWriter class', () => {
     writer = firestore.bulkWriter();
   });
 
-  afterEach(() => verifyInstance(firestore));
+  afterEach(async () => {
+    await writer.close();
+    await verifyInstance(firestore);
+    await firestore.terminate();
+  });
 
   it('has create() method', async () => {
     const ref = randomCol.doc('doc1');
@@ -7131,6 +7135,7 @@ describe('BulkWriter class', () => {
       });
       await firestore.recursiveDelete(randomCol, bulkWriter);
       expect(callbackCount).to.equal(6);
+      await bulkWriter.close();
     });
   });
 

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -133,7 +133,7 @@ export function deleteOp(doc: string): api.IWrite {
   return remove(doc).writes![0];
 }
 
-describe('BulkWriter', () => {
+describe.only('BulkWriter', () => {
   let firestore: Firestore;
   let requestCounter: number;
   let opCount: number;
@@ -488,7 +488,9 @@ describe('BulkWriter', () => {
     expect(() => bulkWriter.create(doc, {})).to.throw(expected);
     expect(() => bulkWriter.update(doc, {})).to.throw(expected);
     expect(() => bulkWriter.flush()).to.throw(expected);
-    expect(() => bulkWriter.close()).to.throw(expected);
+
+    // Calling close() multiple times is allowed.
+    await bulkWriter.close();
   });
 
   it('send writes to the same documents in the different batches', async () => {

--- a/dev/test/bulk-writer.ts
+++ b/dev/test/bulk-writer.ts
@@ -133,7 +133,7 @@ export function deleteOp(doc: string): api.IWrite {
   return remove(doc).writes![0];
 }
 
-describe.only('BulkWriter', () => {
+describe('BulkWriter', () => {
   let firestore: Firestore;
   let requestCounter: number;
   let opCount: number;


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-firestore/issues/2273