### PR TITLE
Fix: Use lazy encoding for utf-8 encoded string comparison

### DIFF
--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -273,7 +273,9 @@ export function compareUtf8Strings(left: string, right: string): number {
           Buffer.from(leftBytes),
           Buffer.from(rightBytes)
         );
-        if (comp !== 0) return comp;
+        if (comp !== 0) {
+          return comp;
+        }
       }
     }
   }

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -270,16 +270,7 @@ export function compareUtf8Strings(left: string, right: string): number {
         // UTF-8 encoded byte comparison, substring 2 indexes to cover surrogate pairs
         const leftBytes = encoder.encode(left.substring(i, i + 2));
         const rightBytes = encoder.encode(right.substring(i, i + 2));
-        for (
-          let j = 0;
-          j < Math.min(leftBytes.length, rightBytes.length);
-          j++
-        ) {
-          const comparison = primitiveComparator(leftBytes[j], rightBytes[j]);
-          if (comparison !== 0) {
-            return comparison;
-          }
-        }
+        return compareBlobs(Buffer.from(leftBytes), Buffer.from(rightBytes));
       }
     }
 

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -4086,6 +4086,20 @@ describe('Query class', () => {
     });
 
     describe('sort unicode strings', () => {
+      const expectedDocs = [
+        'b',
+        'a',
+        'h',
+        'i',
+        'c',
+        'f',
+        'e',
+        'd',
+        'g',
+        'k',
+        'j',
+      ];
+
       it('snapshot listener sorts unicode strings same as server', async () => {
         const collection = await testCollectionWithDocs({
           a: {value: 'Łukasiewicz'},
@@ -4095,10 +4109,13 @@ describe('Query class', () => {
           e: {value: 'Ｐ'},
           f: {value: '︒'},
           g: {value: '🐵'},
+          h: {value: '你好'},
+          i: {value: '你顥'},
+          j: {value: '😁'},
+          k: {value: '😀'},
         });
 
         const query = collection.orderBy('value');
-        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
 
         const getSnapshot = await query.get();
         expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
@@ -4123,10 +4140,13 @@ describe('Query class', () => {
           e: {value: ['Ｐ']},
           f: {value: ['︒']},
           g: {value: ['🐵']},
+          h: {value: ['你好']},
+          i: {value: ['你顥']},
+          j: {value: ['😁']},
+          k: {value: ['😀']},
         });
 
         const query = collection.orderBy('value');
-        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
 
         const getSnapshot = await query.get();
         expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
@@ -4151,10 +4171,13 @@ describe('Query class', () => {
           e: {value: {foo: 'Ｐ'}},
           f: {value: {foo: '︒'}},
           g: {value: {foo: '🐵'}},
+          h: {value: {foo: '你好'}},
+          i: {value: {foo: '你顥'}},
+          j: {value: {foo: '😁'}},
+          k: {value: {foo: '😀'}},
         });
 
         const query = collection.orderBy('value');
-        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
 
         const getSnapshot = await query.get();
         expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
@@ -4179,10 +4202,13 @@ describe('Query class', () => {
           e: {value: {Ｐ: true}},
           f: {value: {'︒': true}},
           g: {value: {'🐵': true}},
+          h: {value: {你好: true}},
+          i: {value: {你顥: true}},
+          j: {value: {'😁': true}},
+          k: {value: {'😀': true}},
         });
 
         const query = collection.orderBy('value');
-        const expectedDocs = ['b', 'a', 'c', 'f', 'e', 'd', 'g'];
 
         const getSnapshot = await query.get();
         expect(getSnapshot.docs.map(d => d.id)).to.deep.equal(expectedDocs);
@@ -4207,17 +4233,25 @@ describe('Query class', () => {
           Ｐ: {value: true},
           '︒': {value: true},
           '🐵': {value: true},
+          你好: {value: true},
+          你顥: {value: true},
+          '😁': {value: true},
+          '😀': {value: true},
         });
 
         const query = collection.orderBy(FieldPath.documentId());
         const expectedDocs = [
           'Sierpiński',
           'Łukasiewicz',
+          '你好',
+          '你顥',
           '岩澤',
           '︒',
           'Ｐ',
           '🄟',
           '🐵',
+          '😀',
+          '😁',
         ];
 
         const getSnapshot = await query.get();

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -284,3 +284,238 @@ describe('Order', () => {
     }
   });
 });
+
+class StringPair {
+  constructor(public s1: string, public s2: string) {}
+}
+
+class StringPairGenerator {
+  constructor(private stringGenerator: StringGenerator) {}
+
+  next(): StringPair {
+    const prefix = this.stringGenerator.next();
+    const s1 = prefix + this.stringGenerator.next();
+    const s2 = prefix + this.stringGenerator.next();
+    return new StringPair(s1, s2);
+  }
+}
+
+class StringGenerator {
+  private static readonly DEFAULT_SURROGATE_PAIR_PROBABILITY = 0.33;
+  private static readonly DEFAULT_MAX_LENGTH = 20;
+
+  // The first Unicode code point that is in the basic multilingual plane ("BMP") and,
+  // therefore requires 1 UTF-16 code unit to be represented in UTF-16.
+  private static readonly MIN_BMP_CODE_POINT = 0x00000000;
+
+  // The last Unicode code point that is in the basic multilingual plane ("BMP") and,
+  // therefore requires 1 UTF-16 code unit to be represented in UTF-16.
+  private static readonly MAX_BMP_CODE_POINT = 0x0000ffff;
+
+  // The first Unicode code point that is outside of the basic multilingual plane ("BMP") and,
+  // therefore requires 2 UTF-16 code units, a surrogate pair, to be represented in UTF-16.
+  private static readonly MIN_SUPPLEMENTARY_CODE_POINT = 0x00010000;
+
+  // The last Unicode code point that is outside of the basic multilingual plane ("BMP") and,
+  // therefore requires 2 UTF-16 code units, a surrogate pair, to be represented in UTF-16.
+  private static readonly MAX_SUPPLEMENTARY_CODE_POINT = 0x0010ffff;
+
+  private readonly rnd: Random;
+  private readonly surrogatePairProbability: number;
+  private readonly maxLength: number;
+
+  constructor(seed: number);
+  constructor(rnd: Random, surrogatePairProbability: number, maxLength: number);
+  constructor(
+      seedOrRnd: number | Random,
+      surrogatePairProbability?: number,
+      maxLength?: number
+  ) {
+    if (typeof seedOrRnd === 'number') {
+      this.rnd = new Random(seedOrRnd);
+      this.surrogatePairProbability =
+          StringGenerator.DEFAULT_SURROGATE_PAIR_PROBABILITY;
+      this.maxLength = StringGenerator.DEFAULT_MAX_LENGTH;
+    } else {
+      this.rnd = seedOrRnd;
+      this.surrogatePairProbability = StringGenerator.validateProbability(
+          'surrogate pair',
+          surrogatePairProbability!
+      );
+      this.maxLength = StringGenerator.validateLength(
+          'maximum string',
+          maxLength!
+      );
+    }
+  }
+
+  private static validateProbability(
+      name: string,
+      probability: number
+  ): number {
+    if (!Number.isFinite(probability)) {
+      throw new Error(
+          `invalid ${name} probability: ${probability} (must be between 0.0 and 1.0, inclusive)`
+      );
+    } else if (probability < 0.0) {
+      throw new Error(
+          `invalid ${name} probability: ${probability} (must be greater than or equal to zero)`
+      );
+    } else if (probability > 1.0) {
+      throw new Error(
+          `invalid ${name} probability: ${probability} (must be less than or equal to 1)`
+      );
+    }
+    return probability;
+  }
+
+  private static validateLength(name: string, length: number): number {
+    if (length < 0) {
+      throw new Error(
+          `invalid ${name} length: ${length} (must be greater than or equal to zero)`
+      );
+    }
+    return length;
+  }
+
+  next(): string {
+    const length = this.rnd.nextInt(this.maxLength + 1);
+    const sb = new StringBuilder();
+    while (sb.length() < length) {
+      const codePoint = this.nextCodePoint();
+      sb.appendCodePoint(codePoint);
+    }
+    return sb.toString();
+  }
+
+  private isNextSurrogatePair(): boolean {
+    return StringGenerator.nextBoolean(this.rnd, this.surrogatePairProbability);
+  }
+
+  private static nextBoolean(rnd: Random, probability: number): boolean {
+    if (probability === 0.0) {
+      return false;
+    } else if (probability === 1.0) {
+      return true;
+    } else {
+      return rnd.nextFloat() < probability;
+    }
+  }
+
+  private nextCodePoint(): number {
+    if (this.isNextSurrogatePair()) {
+      return this.nextSurrogateCodePoint();
+    } else {
+      return this.nextNonSurrogateCodePoint();
+    }
+  }
+
+  private nextSurrogateCodePoint(): number {
+    const highSurrogateMin = 0xd800;
+    const highSurrogateMax = 0xdbff;
+    const lowSurrogateMin = 0xdc00;
+    const lowSurrogateMax = 0xdfff;
+
+    const highSurrogate = this.nextCodePointRange(
+        highSurrogateMin,
+        highSurrogateMax
+    );
+    const lowSurrogate = this.nextCodePointRange(
+        lowSurrogateMin,
+        lowSurrogateMax
+    );
+
+    return (highSurrogate - 0xd800) * 0x400 + (lowSurrogate - 0xdc00) + 0x10000;
+  }
+
+  private nextNonSurrogateCodePoint(): number {
+    return this.nextCodePointRange(
+        StringGenerator.MIN_BMP_CODE_POINT,
+        StringGenerator.MAX_BMP_CODE_POINT
+    );
+  }
+
+  private nextCodePointRange(min: number, max: number): number {
+    const rangeSize = max - min + 1;
+    const offset = this.rnd.nextInt(rangeSize);
+    return min + offset;
+  }
+}
+
+class Random {
+  private seed: number;
+
+  constructor(seed: number) {
+    this.seed = seed;
+  }
+
+  nextInt(max: number): number {
+    this.seed = (this.seed * 9301 + 49297) % 233280;
+    const rnd = this.seed / 233280;
+    return Math.floor(rnd * max);
+  }
+
+  nextFloat(): number {
+    this.seed = (this.seed * 9301 + 49297) % 233280;
+    return this.seed / 233280;
+  }
+}
+
+class StringBuilder {
+  private buffer: string[] = [];
+
+  append(str: string): StringBuilder {
+    this.buffer.push(str);
+    return this;
+  }
+
+  appendCodePoint(codePoint: number): StringBuilder {
+    this.buffer.push(String.fromCodePoint(codePoint));
+    return this;
+  }
+
+  toString(): string {
+    return this.buffer.join('');
+  }
+
+  length(): number {
+    return this.buffer.join('').length;
+  }
+}
+
+describe.only('CompareUtf8Strings', () => {
+  it('testCompareUtf8Strings', () => {
+    const errors = [];
+    const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+    let passCount = 0;
+    const stringGenerator = new StringGenerator(new Random(seed), 0.33, 20);
+    const stringPairGenerator = new StringPairGenerator(stringGenerator);
+
+    for (let i = 0; i < 1000000 && errors.length < 10; i++) {
+      const { s1, s2 } = stringPairGenerator.next();
+
+      const actual = order.compareUtf8Strings(s1, s2);
+      const expected = Buffer.from(s1, 'utf8').compare(Buffer.from(s2, 'utf8'));
+
+      if (actual === expected) {
+        passCount++;
+      } else {
+        errors.push(
+            `compareUtf8Strings(s1="${s1}", s2="${s2}") returned ${actual}, ` +
+            `but expected ${expected} (i=${i}, s1.length=${s1.length}, s2.length=${s2.length})`
+        );
+      }
+    }
+
+    if (errors.length > 0) {
+      console.error(
+          `${errors.length} test cases failed, ${passCount} test cases passed, seed=${seed};`
+      );
+      errors.forEach((error, index) =>
+          console.error(`errors[${index}]: ${error}`)
+      );
+      throw new Error('Test failed');
+    }
+  }).timeout(20000);
+});
+

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -286,7 +286,10 @@ describe('Order', () => {
 });
 
 class StringPair {
-  constructor(public s1: string, public s2: string) {}
+  constructor(
+    readonly s1: string,
+    readonly s2: string
+  ) {}
 }
 
 class StringPairGenerator {
@@ -327,43 +330,43 @@ class StringGenerator {
   constructor(seed: number);
   constructor(rnd: Random, surrogatePairProbability: number, maxLength: number);
   constructor(
-      seedOrRnd: number | Random,
-      surrogatePairProbability?: number,
-      maxLength?: number
+    seedOrRnd: number | Random,
+    surrogatePairProbability?: number,
+    maxLength?: number
   ) {
     if (typeof seedOrRnd === 'number') {
       this.rnd = new Random(seedOrRnd);
       this.surrogatePairProbability =
-          StringGenerator.DEFAULT_SURROGATE_PAIR_PROBABILITY;
+        StringGenerator.DEFAULT_SURROGATE_PAIR_PROBABILITY;
       this.maxLength = StringGenerator.DEFAULT_MAX_LENGTH;
     } else {
       this.rnd = seedOrRnd;
       this.surrogatePairProbability = StringGenerator.validateProbability(
-          'surrogate pair',
-          surrogatePairProbability!
+        'surrogate pair',
+        surrogatePairProbability!
       );
       this.maxLength = StringGenerator.validateLength(
-          'maximum string',
-          maxLength!
+        'maximum string',
+        maxLength!
       );
     }
   }
 
   private static validateProbability(
-      name: string,
-      probability: number
+    name: string,
+    probability: number
   ): number {
     if (!Number.isFinite(probability)) {
       throw new Error(
-          `invalid ${name} probability: ${probability} (must be between 0.0 and 1.0, inclusive)`
+        `invalid ${name} probability: ${probability} (must be between 0.0 and 1.0, inclusive)`
       );
     } else if (probability < 0.0) {
       throw new Error(
-          `invalid ${name} probability: ${probability} (must be greater than or equal to zero)`
+        `invalid ${name} probability: ${probability} (must be greater than or equal to zero)`
       );
     } else if (probability > 1.0) {
       throw new Error(
-          `invalid ${name} probability: ${probability} (must be less than or equal to 1)`
+        `invalid ${name} probability: ${probability} (must be less than or equal to 1)`
       );
     }
     return probability;
@@ -372,7 +375,7 @@ class StringGenerator {
   private static validateLength(name: string, length: number): number {
     if (length < 0) {
       throw new Error(
-          `invalid ${name} length: ${length} (must be greater than or equal to zero)`
+        `invalid ${name} length: ${length} (must be greater than or equal to zero)`
       );
     }
     return length;
@@ -417,12 +420,12 @@ class StringGenerator {
     const lowSurrogateMax = 0xdfff;
 
     const highSurrogate = this.nextCodePointRange(
-        highSurrogateMin,
-        highSurrogateMax
+      highSurrogateMin,
+      highSurrogateMax
     );
     const lowSurrogate = this.nextCodePointRange(
-        lowSurrogateMin,
-        lowSurrogateMax
+      lowSurrogateMin,
+      lowSurrogateMax
     );
 
     return (highSurrogate - 0xd800) * 0x400 + (lowSurrogate - 0xdc00) + 0x10000;
@@ -430,8 +433,8 @@ class StringGenerator {
 
   private nextNonSurrogateCodePoint(): number {
     return this.nextCodePointRange(
-        StringGenerator.MIN_BMP_CODE_POINT,
-        StringGenerator.MAX_BMP_CODE_POINT
+      StringGenerator.MIN_BMP_CODE_POINT,
+      StringGenerator.MAX_BMP_CODE_POINT
     );
   }
 
@@ -483,7 +486,7 @@ class StringBuilder {
   }
 }
 
-describe.only('CompareUtf8Strings', () => {
+describe('CompareUtf8Strings', () => {
   it('testCompareUtf8Strings', () => {
     const errors = [];
     const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
@@ -492,7 +495,7 @@ describe.only('CompareUtf8Strings', () => {
     const stringPairGenerator = new StringPairGenerator(stringGenerator);
 
     for (let i = 0; i < 1000000 && errors.length < 10; i++) {
-      const { s1, s2 } = stringPairGenerator.next();
+      const {s1, s2} = stringPairGenerator.next();
 
       const actual = order.compareUtf8Strings(s1, s2);
       const expected = Buffer.from(s1, 'utf8').compare(Buffer.from(s2, 'utf8'));
@@ -501,7 +504,7 @@ describe.only('CompareUtf8Strings', () => {
         passCount++;
       } else {
         errors.push(
-            `compareUtf8Strings(s1="${s1}", s2="${s2}") returned ${actual}, ` +
+          `compareUtf8Strings(s1="${s1}", s2="${s2}") returned ${actual}, ` +
             `but expected ${expected} (i=${i}, s1.length=${s1.length}, s2.length=${s2.length})`
         );
       }
@@ -509,13 +512,12 @@ describe.only('CompareUtf8Strings', () => {
 
     if (errors.length > 0) {
       console.error(
-          `${errors.length} test cases failed, ${passCount} test cases passed, seed=${seed};`
+        `${errors.length} test cases failed, ${passCount} test cases passed, seed=${seed};`
       );
       errors.forEach((error, index) =>
-          console.error(`errors[${index}]: ${error}`)
+        console.error(`errors[${index}]: ${error}`)
       );
       throw new Error('Test failed');
     }
   }).timeout(20000);
 });
-

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -307,22 +307,6 @@ class StringGenerator {
   private static readonly DEFAULT_SURROGATE_PAIR_PROBABILITY = 0.33;
   private static readonly DEFAULT_MAX_LENGTH = 20;
 
-  // The first Unicode code point that is in the basic multilingual plane ("BMP") and,
-  // therefore requires 1 UTF-16 code unit to be represented in UTF-16.
-  private static readonly MIN_BMP_CODE_POINT = 0x00000000;
-
-  // The last Unicode code point that is in the basic multilingual plane ("BMP") and,
-  // therefore requires 1 UTF-16 code unit to be represented in UTF-16.
-  private static readonly MAX_BMP_CODE_POINT = 0x0000ffff;
-
-  // The first Unicode code point that is outside of the basic multilingual plane ("BMP") and,
-  // therefore requires 2 UTF-16 code units, a surrogate pair, to be represented in UTF-16.
-  private static readonly MIN_SUPPLEMENTARY_CODE_POINT = 0x00010000;
-
-  // The last Unicode code point that is outside of the basic multilingual plane ("BMP") and,
-  // therefore requires 2 UTF-16 code units, a surrogate pair, to be represented in UTF-16.
-  private static readonly MAX_SUPPLEMENTARY_CODE_POINT = 0x0010ffff;
-
   private readonly rnd: Random;
   private readonly surrogatePairProbability: number;
   private readonly maxLength: number;
@@ -432,10 +416,12 @@ class StringGenerator {
   }
 
   private nextNonSurrogateCodePoint(): number {
-    return this.nextCodePointRange(
-      StringGenerator.MIN_BMP_CODE_POINT,
-      StringGenerator.MAX_BMP_CODE_POINT
-    );
+    let codePoint;
+    do {
+      codePoint = this.nextCodePointRange(0, 0xffff); // BMP range
+    } while (codePoint >= 0xd800 && codePoint <= 0xdfff); // Exclude surrogate range
+
+    return codePoint;
   }
 
   private nextCodePointRange(min: number, max: number): number {

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -487,7 +487,7 @@ class StringBuilder {
 }
 
 describe('CompareUtf8Strings', () => {
-  it('testCompareUtf8Strings', () => {
+  it('compareUtf8Strings should return correct results', () => {
     const errors = [];
     const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     let passCount = 0;

--- a/dev/test/order.ts
+++ b/dev/test/order.ts
@@ -326,40 +326,33 @@ class StringGenerator {
     } else {
       this.rnd = seedOrRnd;
       this.surrogatePairProbability = StringGenerator.validateProbability(
-        'surrogate pair',
         surrogatePairProbability!
       );
-      this.maxLength = StringGenerator.validateLength(
-        'maximum string',
-        maxLength!
-      );
+      this.maxLength = StringGenerator.validateLength(maxLength!);
     }
   }
 
-  private static validateProbability(
-    name: string,
-    probability: number
-  ): number {
+  private static validateProbability(probability: number): number {
     if (!Number.isFinite(probability)) {
       throw new Error(
-        `invalid ${name} probability: ${probability} (must be between 0.0 and 1.0, inclusive)`
+        `invalid surrogate pair probability: ${probability} (must be between 0.0 and 1.0, inclusive)`
       );
     } else if (probability < 0.0) {
       throw new Error(
-        `invalid ${name} probability: ${probability} (must be greater than or equal to zero)`
+        `invalid surrogate pair probability: ${probability} (must be greater than or equal to zero)`
       );
     } else if (probability > 1.0) {
       throw new Error(
-        `invalid ${name} probability: ${probability} (must be less than or equal to 1)`
+        `invalid surrogate pair probability: ${probability} (must be less than or equal to 1)`
       );
     }
     return probability;
   }
 
-  private static validateLength(name: string, length: number): number {
+  private static validateLength(length: number): number {
     if (length < 0) {
       throw new Error(
-        `invalid ${name} length: ${length} (must be greater than or equal to zero)`
+        `invalid maximum string length: ${length} (must be greater than or equal to zero)`
       );
     }
     return length;


### PR DESCRIPTION
The previous [fix](https://github.com/googleapis/nodejs-firestore/pull/2299 ) created a performance issue due to expensive UTF-8 encoding. Update `compareUtf8Strings` to use lazy encoding instead.