### PR TITLE
fix: Do not send page size with auto-paginate. Fixes warnings in listCollections and listDocuments.

### DIFF
--- a/dev/src/reference/collection-reference.ts
+++ b/dev/src/reference/collection-reference.ts
@@ -183,10 +183,6 @@ export class CollectionReference<
             parent: parentPath.formattedName,
             collectionId: this.id,
             showMissing: true,
-            // Setting `pageSize` to an arbitrarily large value lets the backend cap
-            // the page size (currently to 300). Note that the backend rejects
-            // MAX_INT32 (b/146883794).
-            pageSize: Math.pow(2, 16) - 1,
             mask: {fieldPaths: []},
           };
 

--- a/dev/src/reference/document-reference.ts
+++ b/dev/src/reference/document-reference.ts
@@ -267,10 +267,6 @@ export class DocumentReference<
         return this.firestore.initializeIfNeeded(tag).then(() => {
           const request: api.IListCollectionIdsRequest = {
             parent: this.formattedName,
-            // Setting `pageSize` to an arbitrarily large value lets the backend cap
-            // the page size (currently to 300). Note that the backend rejects
-            // MAX_INT32 (b/146883794).
-            pageSize: Math.pow(2, 16) - 1,
           };
           return this._firestore
             .request<

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -796,8 +796,8 @@ describe('CollectionReference class', () => {
     const documentRefs = await randomCol.listDocuments();
 
     const actualDocIds = documentRefs
-        .map(dr => dr.id)
-        .sort((a, b) => a.localeCompare(b));
+      .map(dr => dr.id)
+      .sort((a, b) => a.localeCompare(b));
 
     expect(actualDocIds).to.deep.equal(expectedResults);
   });
@@ -1195,11 +1195,13 @@ describe('DocumentReference class', () => {
   });
 
   it('has listCollections() method', () => {
-    const collections = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+    const collections: string[] = [];
     const promises: Array<Promise<{}>> = [];
 
-    for (const collection of collections) {
-      promises.push(randomCol.doc(`doc/${collection}/doc`).create({}));
+    for (let i = 0; i < 400; i++) {
+      const collectionId = i.toString().padStart(3, '0');
+      promises.push(randomCol.doc(`doc/${collectionId}/doc`).create({}));
+      collections.push(collectionId);
     }
 
     return Promise.all(promises)

--- a/dev/system-test/firestore.ts
+++ b/dev/system-test/firestore.ts
@@ -783,6 +783,25 @@ describe('CollectionReference class', () => {
     expect(missingDocs.map(doc => doc.id)).to.have.members(['b']);
   });
 
+  it('lists documents (more than the max page size)', async () => {
+    const batch = firestore.batch();
+    const expectedResults = [];
+    for (let i = 0; i < 400; i++) {
+      const docRef = randomCol.doc(`${i}`.padStart(3, '0'));
+      batch.set(docRef, {id: i});
+      expectedResults.push(docRef.id);
+    }
+    await batch.commit();
+
+    const documentRefs = await randomCol.listDocuments();
+
+    const actualDocIds = documentRefs
+        .map(dr => dr.id)
+        .sort((a, b) => a.localeCompare(b));
+
+    expect(actualDocIds).to.deep.equal(expectedResults);
+  });
+
   it('supports withConverter()', async () => {
     const ref = await firestore
       .collection('col')

--- a/dev/test/collection.ts
+++ b/dev/test/collection.ts
@@ -156,7 +156,6 @@ describe('Collection interface', () => {
           parent: `${DATABASE_ROOT}/documents/a/b`,
           collectionId: 'c',
           showMissing: true,
-          pageSize: 65535,
           mask: {fieldPaths: []},
         });
 

--- a/dev/test/document.ts
+++ b/dev/test/document.ts
@@ -2223,7 +2223,6 @@ describe('listCollections() method', () => {
       listCollectionIds: request => {
         expect(request).to.deep.eq({
           parent: `projects/${PROJECT_ID}/databases/(default)/documents/coll/doc`,
-          pageSize: 65535,
         });
 
         return response(['second', 'first']);

--- a/dev/test/index.ts
+++ b/dev/test/index.ts
@@ -1064,7 +1064,6 @@ describe('listCollections() method', () => {
       listCollectionIds: request => {
         expect(request).to.deep.eq({
           parent: `projects/${PROJECT_ID}/databases/(default)/documents`,
-          pageSize: 65535,
         });
 
         return response(['first', 'second']);


### PR DESCRIPTION
Fixes #2335 

See also https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#auto-pagination
