### PR TITLE
fix: Update `tsconfig.json` with ES2020 as target.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "outDir": "build",
+    "target": "es2020",
     "lib": [
-      "es2016",
+      "es2020",
       "dom"
     ],
     "useUnknownInCatchVariables": false,


### PR DESCRIPTION
The SDK has been [using](https://github.com/search?q=repo%3Agoogleapis%2Fnodejs-firestore%20bigint&type=code) `BigInt` for a long time without explicitly having `target: "es2020"` in the `tsconfig.json` file. Based on my research, ES2016 did not include BigInt. I suspect that the omission of `target` in `tsconfig.json` had resulted in es2020 to be used implicitly.

Also note that Firebase Admin Node sdk [uses](https://github.com/firebase/firebase-admin-node/blob/master/tsconfig.json#L4) es2020.