### PR TITLE
fix: Improve performance of the UTF-8 string comparison logic

### DIFF
--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -294,7 +294,7 @@ export function compareUtf8Strings(left: string, right: string): number {
 const MIN_SURROGATE = 0xd800;
 const MAX_SURROGATE = 0xdfff;
 
-export function isSurrogate(s: string): boolean {
+function isSurrogate(s: string): boolean {
   const c = s.charCodeAt(0);
   return c >= MIN_SURROGATE && c <= MAX_SURROGATE;
 }

--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -281,8 +281,8 @@ export function compareUtf8Strings(left: string, right: string): number {
       return isSurrogate(leftChar) === isSurrogate(rightChar)
         ? primitiveComparator(leftChar, rightChar)
         : isSurrogate(leftChar)
-        ? 1
-        : -1;
+          ? 1
+          : -1;
     }
   }
 


### PR DESCRIPTION
This PR optimizes the UTF-8 string comparison logic to improve performance and simplify the algorithm. It achieves this by directly comparing UTF-16 code units and handling surrogate pairs appropriately. The changes result in faster string comparisons without sacrificing correctness, with the added benefit of a simpler and more readable algorithm.

### Highlights

* **Performance Improvement**: Improves the performance of UTF-8 string comparison logic, bringing it back to near its original speed before a previous fix introduced a performance degradation.
* **Algorithm Simplification**: The performance improvements also happily led to a simplification of the algorithm.
* **UTF-16 Code Unit Comparison**: The comparison logic now directly compares UTF-16 code units for efficiency, leveraging the way UTF-8 and UTF-16 represent Unicode code points.
* **Surrogate Handling**: The code handles surrogate pairs correctly, ensuring that strings containing surrogates are ordered appropriately relative to non-surrogate strings.

The semantics of the UTF-8 string comparison logic were originally fixed by #2275, but this fix caused a material performance degradation, which was then improved by #2299 The performance was, however, still suboptimal, and this PR further improves the speed back to close to its original speed and, serendipitously, simplifies the algorithm too.

This commit is a port of https://github.com/firebase/firebase-js-sdk/pull/9143