### PR TITLE
ci: fix flaky "docs" github action by configuring retry and concurrency for linkinator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,3 +58,6 @@ jobs:
       - uses: JustinBeckwith/linkinator-action@v1
         with:
           paths: docs/
+          retry: true
+          verbosity: INFO
+          concurrency: 1


### PR DESCRIPTION
The "docs" github action is flakily failing for me all the time due to HTTP 429 and 403 errors, like this:

```
[error][429] https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md
[error][403] https://www.npmjs.com/package/@google-cloud/datastore
[error][403] https://www.npmjs.org/package/@google-cloud/firestore
[error]Detected 3 broken links.
```

(source: https://github.com/googleapis/nodejs-firestore/actions/runs/17870934346/job/50951987435?pr=2420)

Re-running the "docs" action usually fixes these transient errors, but then _other_ links fail. It can take anywhere from 2 to 10 re-runs before all of the checks pass.

This PR changes the "linkinator" github action to use settings that are less likely to produce such false positives.