### PR TITLE
feat: adding gcp resource name span attribute

### DIFF
--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -1556,7 +1556,10 @@ export class Firestore implements firestore.Firestore {
 
         // If the project ID was undefined when the TraceUtil was set up, we
         // need to record it.
-        this._traceUtil.recordProjectId(this.projectId);
+        this._traceUtil.recordProjectIdAndResourceName(
+          this.projectId,
+          this.databaseId,
+        );
       } catch (err) {
         logger(
           'Firestore.initializeIfNeeded',

--- a/dev/src/telemetry/disabled-trace-util.ts
+++ b/dev/src/telemetry/disabled-trace-util.ts
@@ -42,5 +42,5 @@ export class DisabledTraceUtil implements TraceUtil {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  recordProjectId(projectId: string): void {}
+  recordProjectIdAndResourceName(projectId: string, databaseId: string): void {}
 }

--- a/dev/src/telemetry/trace-util.ts
+++ b/dev/src/telemetry/trace-util.ts
@@ -75,6 +75,7 @@ export const ATTRIBUTE_KEY_IS_RETRY_WITH_CURSOR = 'retry_query_with_cursor';
 export const ATTRIBUTE_KEY_TRANSACTION_TYPE = 'transaction_type';
 export const ATTRIBUTE_KEY_ATTEMPTS_ALLOWED = 'attempts_allowed';
 export const ATTRIBUTE_KEY_ATTEMPTS_REMAINING = 'attempts_remaining';
+export const ATTRIBUTE_GCP_RESOURCE_NAME = 'gcp.resource.name';
 
 /**
  * @private
@@ -90,5 +91,5 @@ export interface TraceUtil {
 
   currentSpan(): Span;
 
-  recordProjectId(projectId: string): void;
+  recordProjectIdAndResourceName(projectId: string, databaseId: string): void;
 }

--- a/dev/system-test/tracing.ts
+++ b/dev/system-test/tracing.ts
@@ -44,6 +44,7 @@ import {
 import {setLogFunction, Firestore} from '../src';
 import {verifyInstance} from '../test/util/helpers';
 import {
+  ATTRIBUTE_GCP_RESOURCE_NAME,
   ATTRIBUTE_KEY_DOC_COUNT,
   ATTRIBUTE_SETTINGS_PREFIX,
   SPAN_NAME_AGGREGATION_QUERY_GET,
@@ -778,6 +779,10 @@ describe('Tracing Tests', () => {
         'Firestore.batchGetDocuments: First response received',
         'Firestore.batchGetDocuments: Completed',
       ]);
+
+      expectSpanHasAttributes(SPAN_NAME_BATCH_GET_DOCUMENTS, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('document reference create()', async () => {
@@ -790,6 +795,10 @@ describe('Tracing Tests', () => {
         SPAN_NAME_DOC_REF_CREATE,
         SPAN_NAME_BATCH_COMMIT,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_BATCH_COMMIT, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('document reference delete()', async () => {
@@ -802,6 +811,10 @@ describe('Tracing Tests', () => {
         SPAN_NAME_DOC_REF_DELETE,
         SPAN_NAME_BATCH_COMMIT,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_BATCH_COMMIT, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('document reference set()', async () => {
@@ -814,6 +827,10 @@ describe('Tracing Tests', () => {
         SPAN_NAME_DOC_REF_SET,
         SPAN_NAME_BATCH_COMMIT,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_BATCH_COMMIT, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('document reference update()', async () => {
@@ -830,6 +847,10 @@ describe('Tracing Tests', () => {
         SPAN_NAME_DOC_REF_UPDATE,
         SPAN_NAME_BATCH_COMMIT,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_BATCH_COMMIT, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('document reference list collections', async () => {
@@ -841,6 +862,10 @@ describe('Tracing Tests', () => {
         SPAN_NAME_TEST_ROOT,
         SPAN_NAME_DOC_REF_LIST_COLLECTIONS,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_DOC_REF_LIST_COLLECTIONS, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('aggregate query get()', async () => {
@@ -867,6 +892,10 @@ describe('Tracing Tests', () => {
         SPAN_NAME_DOC_REF_CREATE,
         SPAN_NAME_BATCH_COMMIT,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_BATCH_COMMIT, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('collection reference list documents', async () => {
@@ -878,6 +907,10 @@ describe('Tracing Tests', () => {
         SPAN_NAME_TEST_ROOT,
         SPAN_NAME_COL_REF_LIST_DOCUMENTS,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_COL_REF_LIST_DOCUMENTS, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('query get()', async () => {
@@ -892,6 +925,10 @@ describe('Tracing Tests', () => {
         'Firestore.runQuery: First response received',
         'Firestore.runQuery: Completed',
       ]);
+
+      expectSpanHasAttributes(SPAN_NAME_QUERY_GET, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('firestore getAll()', async () => {
@@ -907,6 +944,10 @@ describe('Tracing Tests', () => {
         'Firestore.batchGetDocuments: First response received',
         'Firestore.batchGetDocuments: Completed',
       ]);
+
+      expectSpanHasAttributes(SPAN_NAME_BATCH_GET_DOCUMENTS, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('transaction', async () => {
@@ -929,26 +970,50 @@ describe('Tracing Tests', () => {
         SPAN_NAME_TRANSACTION_RUN,
         SPAN_NAME_TRANSACTION_GET_DOCUMENT,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_TRANSACTION_GET_DOCUMENT, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
+
       expectSpanHierarchy(
         SPAN_NAME_TEST_ROOT,
         SPAN_NAME_TRANSACTION_RUN,
         SPAN_NAME_TRANSACTION_GET_DOCUMENTS,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_TRANSACTION_GET_DOCUMENTS, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
+
       expectSpanHierarchy(
         SPAN_NAME_TEST_ROOT,
         SPAN_NAME_TRANSACTION_RUN,
         SPAN_NAME_TRANSACTION_GET_QUERY,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_TRANSACTION_GET_QUERY, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
+
       expectSpanHierarchy(
         SPAN_NAME_TEST_ROOT,
         SPAN_NAME_TRANSACTION_RUN,
         SPAN_NAME_TRANSACTION_GET_AGGREGATION_QUERY,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_TRANSACTION_GET_AGGREGATION_QUERY, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
+
       expectSpanHierarchy(
         SPAN_NAME_TEST_ROOT,
         SPAN_NAME_TRANSACTION_RUN,
         SPAN_NAME_TRANSACTION_COMMIT,
       );
+
+      expectSpanHasAttributes(SPAN_NAME_TRANSACTION_COMMIT, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('batch', async () => {
@@ -974,6 +1039,9 @@ describe('Tracing Tests', () => {
 
       await waitForCompletedSpans(2);
       expectSpanHierarchy(SPAN_NAME_TEST_ROOT, SPAN_NAME_PARTITION_QUERY);
+      expectSpanHasAttributes(SPAN_NAME_PARTITION_QUERY, {
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
+      });
     });
 
     it('bulk writer', async () => {
@@ -992,6 +1060,7 @@ describe('Tracing Tests', () => {
       expectSpanHierarchy(SPAN_NAME_TEST_ROOT, SPAN_NAME_BULK_WRITER_COMMIT);
       expectSpanHasAttributes(SPAN_NAME_BULK_WRITER_COMMIT, {
         [ATTRIBUTE_KEY_DOC_COUNT]: 5,
+        [ATTRIBUTE_GCP_RESOURCE_NAME]: `//firestore.googleapis.com/projects/${firestore.projectId}/databases/${firestore.databaseId}`,
       });
     });
   }


### PR DESCRIPTION
Adding a new span attribute called gcp.resource.name which contains an identifier to a particular firestore database in the following format:

```
//firestore.googleapis.com/projects/{project}/databases/{database_id}
```

Example:
```
//firestore.googleapis.com/projects/my_project/databases/(default)
```