### PR TITLE
Fix Firestore SDK not limiting results when given `limit(0)`

### DIFF
--- a/dev/src/reference/query-util.ts
+++ b/dev/src/reference/query-util.ts
@@ -344,7 +344,7 @@ export class QueryUtil<
                   // call to `requestStream()` will backoff should the restart
                   // fail before delivering any results.
                   let newQuery: Query<AppModelType, DbModelType>;
-                  if (!this._queryOptions.limit) {
+                  if (this._queryOptions.limit === undefined) {
                     newQuery = query;
                   } else {
                     const newLimit =

--- a/dev/src/reference/query.ts
+++ b/dev/src/reference/query.ts
@@ -1439,7 +1439,7 @@ export class Query<
     structuredQuery.startAt = this.toCursor(this._queryOptions.startAt);
     structuredQuery.endAt = this.toCursor(this._queryOptions.endAt);
 
-    if (this._queryOptions.limit) {
+    if (this._queryOptions.limit !== undefined) {
       structuredQuery.limit = {value: this._queryOptions.limit};
     }
 

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -1915,6 +1915,23 @@ describe('limit() interface', () => {
     query = query.limit(1).limit(2).limit(3);
     await query.get();
   });
+
+  // Regression test: This test currently fails because limit(0) is not
+  // serialized in the query proto (limit(0) is falsy in JavaScript).
+  // This test is expected to fail until the fix is applied.
+  it('handles limit(0) correctly', async () => {
+    const overrides: ApiOverride = {
+      runQuery: request => {
+        queryEquals(request, limit(0));
+        return emptyQueryStream();
+      },
+    };
+
+    firestore = await createInstance(overrides);
+    let query: Query = firestore.collection('collectionId');
+    query = query.limit(0);
+    await query.get();
+  });
 });
 
 describe('limitToLast() interface', () => {

--- a/dev/test/query.ts
+++ b/dev/test/query.ts
@@ -1916,9 +1916,6 @@ describe('limit() interface', () => {
     await query.get();
   });
 
-  // Regression test: This test currently fails because limit(0) is not
-  // serialized in the query proto (limit(0) is falsy in JavaScript).
-  // This test is expected to fail until the fix is applied.
   it('handles limit(0) correctly', async () => {
     const overrides: ApiOverride = {
       runQuery: request => {


### PR DESCRIPTION
## Description

Opening this PR to sense check if this can be worked on to get merged. This PR fixes googleapis/google-cloud-node#7382 where the Firestore SDK doesn't seem to apply the limit clause when `limit(0)` is given.

## Impact

The change should allow the Firestore SDK to handle `limit(0)` properly, i.e., returning an empty array as expected.

## Testing

Unit test added. But I'm not familiar with the codebase so I'm not sure if that alone is sufficient.

## Additional Information

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-firestore/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes googleapis/google-cloud-node#7382 🦕
