### PR TITLE
chore: replace old nodejs teams with cloud-sdk-nodejs-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/firestore-dpe @googleapis/api-firestore
-.github/auto-approve.yml @googleapis/github-automation/
+*     @googleapis/cloud-sdk-nodejs-team @googleapis/firestore-dpe @googleapis/api-firestore
+.github/auto-approve.yml @googleapis/cloud-sdk-platform-team/


### PR DESCRIPTION
Bug ID: b/479541676