### PR TITLE
chore: add autogenerated api-report files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /docs/
 /out/
 /build/
+temp/
+types/tsdoc-metadata.json
 system-test/secrets.js
 system-test/*key.json
 *.lock


### PR DESCRIPTION
When `yarn api-report` is ran, these files are automatically generated. Since these are not tracked by git, they should be added to the `.gitignore`.
