### PR TITLE
chore: replace old teams with cloud-sdk-nodejs-team and firestore-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 
-# The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs @googleapis/firestore-dpe @googleapis/api-firestore
+# The cloud-sdk-nodejs-team team is the default owner for nodejs repositories.
+* @googleapis/cloud-sdk-nodejs-team @googleapis/firestore-team
 .github/auto-approve.yml @googleapis/github-automation/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 
 # The cloud-sdk-nodejs-team team is the default owner for nodejs repositories.
 * @googleapis/cloud-sdk-nodejs-team @googleapis/firestore-team
-.github/auto-approve.yml @googleapis/github-automation/
+.github/auto-approve.yml @googleapis/cloud-sdk-platform-team

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,9 +15,5 @@ branchProtectionRules:
       - windows
       - OwlBot Post Processor
 permissionRules:
-  - team: yoshi-admins
-    permission: admin
-  - team: jsteam-admins
-    permission: admin
   - team: jsteam
     permission: push

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,5 +15,9 @@ branchProtectionRules:
       - windows
       - OwlBot Post Processor
 permissionRules:
+  - team: yoshi-admins
+    permission: admin
+  - team: jsteam-admins
+    permission: admin
   - team: jsteam
     permission: push

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-  "codeowner_team": "@googleapis/firestore-dpe",
+  "codeowner_team": "@googleapis/firestore-team @googleapis/cloud-sdk-nodejs-team",
   "language": "nodejs",
   "api_id": "firestore.googleapis.com",
   "name_pretty": "Cloud Firestore",


### PR DESCRIPTION
This PR replaces the old api-firestore with firestore-team, yoshi-nodejs with cloud-sdk-nodejs-team, and removes firestore-dpe.

b/478003109

As part of this change, we are also removing admin permissions from the repository settings in .github/sync-repo-settings.yaml. Teams that previously had admin access have been removed or updated to have push access.