### PR TITLE
fix: Export `regexFind` and `regexFindAll` functions to public API

### DIFF
--- a/api-report/firestore.api.md
+++ b/api-report/firestore.api.md
@@ -1845,6 +1845,8 @@ declare namespace Pipelines {
         or,
         regexContains,
         regexMatch,
+        regexFind,
+        regexFindAll,
         startsWith,
         stringConcat,
         subtract,
@@ -2282,6 +2284,30 @@ function regexContains(stringExpression: Expression, pattern: string): BooleanEx
 
 // @beta
 function regexContains(stringExpression: Expression, pattern: Expression): BooleanExpression;
+
+// @beta
+function regexFind(fieldName: string, pattern: string): FunctionExpression;
+
+// @beta
+function regexFind(fieldName: string, pattern: Expression): FunctionExpression;
+
+// @beta
+function regexFind(stringExpression: Expression, pattern: string): FunctionExpression;
+
+// @beta
+function regexFind(stringExpression: Expression, pattern: Expression): FunctionExpression;
+
+// @beta
+function regexFindAll(fieldName: string, pattern: string): FunctionExpression;
+
+// @beta
+function regexFindAll(fieldName: string, pattern: Expression): FunctionExpression;
+
+// @beta
+function regexFindAll(stringExpression: Expression, pattern: string): FunctionExpression;
+
+// @beta
+function regexFindAll(stringExpression: Expression, pattern: Expression): FunctionExpression;
 
 // @beta
 function regexMatch(fieldName: string, pattern: string): BooleanExpression;

--- a/dev/src/pipelines/index.ts
+++ b/dev/src/pipelines/index.ts
@@ -38,6 +38,8 @@ export {
   or,
   regexContains,
   regexMatch,
+  regexFind,
+  regexFindAll,
   startsWith,
   stringConcat,
   subtract,

--- a/dev/system-test/pipeline.ts
+++ b/dev/system-test/pipeline.ts
@@ -82,6 +82,8 @@ import {
   or,
   regexContains,
   regexMatch,
+  regexFind,
+  regexFindAll,
   startsWith,
   stringConcat,
   subtract,
@@ -145,7 +147,6 @@ import {getTestDb, getTestRoot} from './firestore';
 
 import {Firestore as InternalFirestore} from '../src';
 import {ServiceError} from 'google-gax';
-import {regexFind, regexFindAll} from '../src/pipelines/expression';
 
 use(chaiAsPromised);
 


### PR DESCRIPTION
Follow up to https://github.com/googleapis/nodejs-firestore/pull/2474.

The `regexFind` and `regexFindAll` standalone expression functions were not exported to the public API by mistake. This PR exports them to the public API and updates the import path in the tests.
