### PR TITLE
feat: add rand and trunc expressions

### DIFF
--- a/api-report/firestore.api.md
+++ b/api-report/firestore.api.md
@@ -1094,6 +1094,9 @@ abstract class Expression implements firestore.Pipelines.Expression, HasUserData
     abstract _toProto(serializer: Serializer): api.IValue;
     toUpper(): FunctionExpression;
     trim(valueToTrim?: string | Expression | Uint8Array | Buffer): FunctionExpression;
+    trunc(): FunctionExpression;
+    trunc(decimalPlaces: number): FunctionExpression;
+    trunc(decimalPlaces: Expression): FunctionExpression;
     // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
     // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
     type(): FunctionExpression;
@@ -1923,6 +1926,8 @@ declare namespace Pipelines {
         ln,
         round,
         sqrt,
+        rand,
+        trunc,
         stringReverse,
         abs,
         arraySum,
@@ -2272,6 +2277,9 @@ export class QuerySnapshot<AppModelType = firestore.DocumentData, DbModelType ex
 }
 
 // @beta
+function rand(): FunctionExpression;
+
+// @beta
 function regexContains(fieldName: string, pattern: string): BooleanExpression;
 
 // @beta
@@ -2613,6 +2621,18 @@ function trim(fieldName: string, valueToTrim?: string | Expression): FunctionExp
 
 // @beta
 function trim(stringExpression: Expression, valueToTrim?: string | Expression): FunctionExpression;
+
+// @beta
+function trunc(fieldName: string): FunctionExpression;
+
+// @beta
+function trunc(expression: Expression): FunctionExpression;
+
+// @beta
+function trunc(fieldName: string, decimalPlaces: number | Expression): FunctionExpression;
+
+// @beta
+function trunc(expression: Expression, decimalPlaces: number | Expression): FunctionExpression;
 
 // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
 // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"

--- a/dev/src/pipelines/expression.ts
+++ b/dev/src/pipelines/expression.ts
@@ -2109,6 +2109,59 @@ export abstract class Expression
 
   /**
    * @beta
+   * Creates an expression that truncates the numeric value to an integer.
+   *
+   * @example
+   * ```typescript
+   * // Truncate the 'rating' field.
+   * field("rating").trunc();
+   * ```
+   *
+   * @returns A new `Expression` representing the truncated value.
+   */
+  trunc(): FunctionExpression;
+
+  /**
+   * @beta
+   * Creates an expression that truncates a numeric value to the specified number of decimal places.
+   *
+   * @example
+   * ```typescript
+   * // Truncate the value of the 'rating' field to two decimal places.
+   * field("rating").trunc(2);
+   * ```
+   *
+   * @param decimalPlaces A constant specifying the truncation precision in decimal places.
+   * @returns A new `Expression` representing the truncated value.
+   */
+  trunc(decimalPlaces: number): FunctionExpression;
+
+  /**
+   * @beta
+   * Creates an expression that truncates a numeric value to the specified number of decimal places.
+   *
+   * @example
+   * ```typescript
+   * // Truncate the value of the 'rating' field to two decimal places.
+   * field("rating").trunc(constant(2));
+   * ```
+   *
+   * @param decimalPlaces An expression specifying the truncation precision in decimal places.
+   * @returns A new `Expression` representing the truncated value.
+   */
+  trunc(decimalPlaces: Expression): FunctionExpression;
+  trunc(decimalPlaces?: number | Expression): FunctionExpression {
+    if (decimalPlaces === undefined) {
+      return new FunctionExpression('trunc', [this]);
+    }
+    return new FunctionExpression('trunc', [
+      this,
+      valueToDefaultExpr(decimalPlaces),
+    ]);
+  }
+
+  /**
+   * @beta
    * Creates an expression that rounds a numeric value to the nearest whole number.
    *
    * ```typescript
@@ -7574,6 +7627,22 @@ export function pow(
 
 /**
  * @beta
+ * Creates an expression that generates a random number between 0.0 and 1.0 but not including 1.0.
+ *
+ * @example
+ * ```typescript
+ * // Generate a random number between 0.0 and 1.0.
+ * rand();
+ * ```
+ *
+ * @returns A new `Expression` representing the rand operation.
+ */
+export function rand(): FunctionExpression {
+  return new FunctionExpression('rand', []);
+}
+
+/**
+ * @beta
  * Creates an expression that rounds a numeric value to the nearest whole number.
  *
  * ```typescript
@@ -7642,6 +7711,84 @@ export function round(
     return fieldOrExpression(expr).round();
   } else {
     return fieldOrExpression(expr).round(valueToDefaultExpr(decimalPlaces));
+  }
+}
+
+/**
+ * @beta
+ * Creates an expression that truncates the numeric value of a field to an integer.
+ *
+ * @example
+ * ```typescript
+ * // Truncate the value of the 'rating' field.
+ * trunc("rating");
+ * ```
+ *
+ * @param fieldName The name of the field containing the number to truncate.
+ * @returns A new `Expression` representing the truncated value.
+ */
+export function trunc(fieldName: string): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that truncates the numeric value of an expression to an integer.
+ *
+ * @example
+ * ```typescript
+ * // Truncate the value of the 'rating' field.
+ * trunc(field("rating"));
+ * ```
+ *
+ * @param expression - An expression evaluating to a numeric value, which will be truncated.
+ * @returns A new `Expression` representing the truncated value.
+ */
+export function trunc(expression: Expression): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that truncates a numeric value to the specified number of decimal places.
+ *
+ * @example
+ * ```typescript
+ * // Truncate the value of the 'rating' field to two decimal places.
+ * trunc("rating", 2);
+ * ```
+ *
+ * @param fieldName The name of the field to truncate.
+ * @param decimalPlaces A constant or expression specifying the truncation precision in decimal places.
+ * @returns A new `Expression` representing the truncated value.
+ */
+export function trunc(
+  fieldName: string,
+  decimalPlaces: number | Expression,
+): FunctionExpression;
+
+/**
+ * @beta
+ * Creates an expression that truncates a numeric value to the specified number of decimal places.
+ *
+ * @example
+ * ```typescript
+ * // Truncate the value of the 'rating' field to two decimal places.
+ * trunc(field("rating"), constant(2));
+ * ```
+ *
+ * @param expression - An expression evaluating to a numeric value, which will be truncated.
+ * @param decimalPlaces - A constant or expression specifying the truncation precision in decimal places.
+ * @returns A new `Expression` representing the truncated value.
+ */
+export function trunc(
+  expression: Expression,
+  decimalPlaces: number | Expression,
+): FunctionExpression;
+export function trunc(
+  expr: Expression | string,
+  decimalPlaces?: number | Expression,
+): FunctionExpression {
+  if (decimalPlaces === undefined) {
+    return fieldOrExpression(expr).trunc();
+  } else {
+    return fieldOrExpression(expr).trunc(valueToDefaultExpr(decimalPlaces));
   }
 }
 

--- a/dev/src/pipelines/expression.ts
+++ b/dev/src/pipelines/expression.ts
@@ -838,7 +838,7 @@ export abstract class Expression
    * field("email").regexFind("@.+")
    * ```
    *
-   * @param pattern - The regular expression to search for.
+   * @param pattern The regular expression to search for.
    * @returns A new `Expression` representing the regular expression find function.
    */
   regexFind(pattern: string): FunctionExpression;
@@ -856,7 +856,7 @@ export abstract class Expression
    * field("email").regexFind(field("domain"))
    * ```
    *
-   * @param pattern - The regular expression to search for.
+   * @param pattern The regular expression to search for.
    * @returns A new `Expression` representing the regular expression find function.
    */
   regexFind(pattern: Expression): FunctionExpression;
@@ -881,7 +881,7 @@ export abstract class Expression
    * field("content").regexFindAll("#[A-Za-z0-9_]+")
    * ```
    *
-   * @param pattern - The regular expression to search for.
+   * @param pattern The regular expression to search for.
    * @returns A new `Expression` that evaluates to an array of matched substrings.
    */
   regexFindAll(pattern: string): FunctionExpression;
@@ -900,7 +900,7 @@ export abstract class Expression
    * field("content").regexFindAll(field("names"))
    * ```
    *
-   * @param pattern - The regular expression to search for.
+   * @param pattern The regular expression to search for.
    * @returns A new `Expression` that evaluates to an array of matched substrings.
    */
   regexFindAll(pattern: Expression): FunctionExpression;
@@ -1288,9 +1288,9 @@ export abstract class Expression
    * field("address").mapSet("city", "San Francisco");
    * ```
    *
-   * @param key - The key to set. Must be a string or a constant string expression.
-   * @param value - The value to set.
-   * @param moreKeyValues - Additional key-value pairs to set.
+   * @param key The key to set. Must be a string or a constant string expression.
+   * @param value The value to set.
+   * @param moreKeyValues Additional key-value pairs to set.
    * @returns A new `Expression` representing the map with the entries set.
    */
   mapSet(
@@ -3364,7 +3364,7 @@ export class BooleanField extends BooleanExpression {
  * countIf(field("is_active").equal(true)).as("numActiveDocuments");
  * ```
  *
- * @param booleanExpr - The boolean expression to evaluate on each input.
+ * @param booleanExpr The boolean expression to evaluate on each input.
  * @returns A new `AggregateFunction` representing the 'countIf' aggregation.
  */
 export function countIf(booleanExpr: BooleanExpression): AggregateFunction {
@@ -5786,8 +5786,8 @@ export function regexContains(
  * regexFind("email", "@[A-Za-z0-9.-]+");
  * ```
  *
- * @param fieldName - The name of the field containing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param fieldName The name of the field containing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` representing the regular expression find function.
  */
 export function regexFind(
@@ -5809,8 +5809,8 @@ export function regexFind(
  * regexFind("email", field("pattern"));
  * ```
  *
- * @param fieldName - The name of the field containing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param fieldName The name of the field containing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` representing the regular expression find function.
  */
 export function regexFind(
@@ -5832,8 +5832,8 @@ export function regexFind(
  * regexFind(field("email"), "@[A-Za-z0-9.-]+");
  * ```
  *
- * @param stringExpression - The expression representing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param stringExpression The expression representing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` representing the regular expression find function.
  */
 export function regexFind(
@@ -5855,8 +5855,8 @@ export function regexFind(
  * regexFind(field("email"), field("pattern"));
  * ```
  *
- * @param stringExpression - The expression representing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param stringExpression The expression representing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` representing the regular expression find function.
  */
 export function regexFind(
@@ -5886,8 +5886,8 @@ export function regexFind(
  * regexFindAll("content", "#[A-Za-z0-9_]+");
  * ```
  *
- * @param fieldName - The name of the field containing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param fieldName The name of the field containing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` that evaluates to an array of matched substrings.
  */
 export function regexFindAll(
@@ -5909,8 +5909,8 @@ export function regexFindAll(
  * regexFindAll("content", field("pattern"));
  * ```
  *
- * @param fieldName - The name of the field containing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param fieldName The name of the field containing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` that evaluates to an array of matched substrings.
  */
 export function regexFindAll(
@@ -5932,8 +5932,8 @@ export function regexFindAll(
  * regexFindAll(field("comment"), "@[A-Za-z0-9_]+");
  * ```
  *
- * @param stringExpression - The expression representing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param stringExpression The expression representing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` that evaluates to an array of matched substrings.
  */
 export function regexFindAll(
@@ -5955,8 +5955,8 @@ export function regexFindAll(
  * regexFindAll(field("comment"), field("pattern"));
  * ```
  *
- * @param stringExpression - The expression representing the string to search.
- * @param pattern - The regular expression to search for.
+ * @param stringExpression The expression representing the string to search.
+ * @param pattern The regular expression to search for.
  * @returns A new `Expression` that evaluates to an array of matched substrings.
  */
 export function regexFindAll(
@@ -6504,10 +6504,10 @@ export function mapGet(
  * mapSet("address", "city", "San Francisco");
  * ```
  *
- * @param mapField - The map field to set entries in.
- * @param key - The key to set. Must be a string or a constant string expression.
- * @param value - The value to set.
- * @param moreKeyValues - Additional key-value pairs to set.
+ * @param mapField The map field to set entries in.
+ * @param key The key to set. Must be a string or a constant string expression.
+ * @param value The value to set.
+ * @param moreKeyValues Additional key-value pairs to set.
  * @returns A new `Expression` representing the map with the entries set.
  */
 export function mapSet(
@@ -6531,10 +6531,10 @@ export function mapSet(
  * mapSet(map({"state": "California"}), "city", "San Francisco");
  * ```
  *
- * @param mapExpression - The expression representing the map.
- * @param key - The key to set. Must be a string or a constant string expression.
- * @param value - The value to set.
- * @param moreKeyValues - Additional key-value pairs to set.
+ * @param mapExpression The expression representing the map.
+ * @param key The key to set. Must be a string or a constant string expression.
+ * @param value The value to set.
+ * @param moreKeyValues Additional key-value pairs to set.
  * @returns A new `Expression` representing the map with the entries set.
  */
 export function mapSet(
@@ -6566,7 +6566,7 @@ export function mapSet(
  * mapKeys("address");
  * ```
  *
- * @param mapField - The map field to get the keys of.
+ * @param mapField The map field to get the keys of.
  * @returns A new `Expression` representing the keys of the map.
  */
 export function mapKeys(mapField: string): FunctionExpression;
@@ -6585,7 +6585,7 @@ export function mapKeys(mapField: string): FunctionExpression;
  * mapKeys(map({"city": "San Francisco"}));
  * ```
  *
- * @param mapExpression - The expression representing the map to get the keys of.
+ * @param mapExpression The expression representing the map to get the keys of.
  * @returns A new `Expression` representing the keys of the map.
  */
 export function mapKeys(mapExpression: Expression): FunctionExpression;
@@ -6607,7 +6607,7 @@ export function mapKeys(fieldOrExpr: string | Expression): FunctionExpression {
  * mapValues("address");
  * ```
  *
- * @param mapField - The map field to get the values of.
+ * @param mapField The map field to get the values of.
  * @returns A new `Expression` representing the values of the map.
  */
 export function mapValues(mapField: string): FunctionExpression;
@@ -6626,7 +6626,7 @@ export function mapValues(mapField: string): FunctionExpression;
  * mapValues(map({"city": "San Francisco"}));
  * ```
  *
- * @param mapExpression - The expression representing the map to get the values of.
+ * @param mapExpression The expression representing the map to get the values of.
  * @returns A new `Expression` representing the values of the map.
  */
 export function mapValues(mapExpression: Expression): FunctionExpression;
@@ -6652,7 +6652,7 @@ export function mapValues(
  * mapEntries("address");
  * ```
  *
- * @param mapField - The map field to get the entries of.
+ * @param mapField The map field to get the entries of.
  * @returns A new `Expression` representing the entries of the map.
  */
 export function mapEntries(mapField: string): FunctionExpression;
@@ -6673,7 +6673,7 @@ export function mapEntries(mapField: string): FunctionExpression;
  * mapEntries(map({"city": "San Francisco"}));
  * ```
  *
- * @param mapExpression - The expression representing the map to get the entries of.
+ * @param mapExpression The expression representing the map to get the entries of.
  * @returns A new `Expression` representing the entries of the map.
  */
 export function mapEntries(mapExpression: Expression): FunctionExpression;
@@ -7739,7 +7739,7 @@ export function trunc(fieldName: string): FunctionExpression;
  * trunc(field("rating"));
  * ```
  *
- * @param expression - An expression evaluating to a numeric value, which will be truncated.
+ * @param expression An expression evaluating to a numeric value, which will be truncated.
  * @returns A new `Expression` representing the truncated value.
  */
 export function trunc(expression: Expression): FunctionExpression;
@@ -7773,8 +7773,8 @@ export function trunc(
  * trunc(field("rating"), constant(2));
  * ```
  *
- * @param expression - An expression evaluating to a numeric value, which will be truncated.
- * @param decimalPlaces - A constant or expression specifying the truncation precision in decimal places.
+ * @param expression An expression evaluating to a numeric value, which will be truncated.
+ * @param decimalPlaces A constant or expression specifying the truncation precision in decimal places.
  * @returns A new `Expression` representing the truncated value.
  */
 export function trunc(

--- a/dev/src/pipelines/index.ts
+++ b/dev/src/pipelines/index.ts
@@ -116,6 +116,8 @@ export {
   ln,
   round,
   sqrt,
+  rand,
+  trunc,
   stringReverse,
   abs,
   arraySum,

--- a/types/firestore.d.ts
+++ b/types/firestore.d.ts
@@ -4796,6 +4796,47 @@ declare namespace FirebaseFirestore {
       pow(exponent: number): FunctionExpression;
       /**
        * @beta
+       * Creates an expression that truncates the numeric value to an integer.
+       *
+       * @example
+       * ```typescript
+       * // Truncate the 'rating' field.
+       * field("rating").trunc();
+       * ```
+       *
+       * @returns A new `Expression` representing the truncated value.
+       */
+      trunc(): FunctionExpression;
+      /**
+       * @beta
+       * Creates an expression that truncates a numeric value to the specified number of decimal places.
+       *
+       * @example
+       * ```typescript
+       * // Truncate the value of the 'rating' field to two decimal places.
+       * field("rating").trunc(2);
+       * ```
+       *
+       * @param decimalPlaces A constant specifying the truncation precision in decimal places.
+       * @returns A new `Expression` representing the truncated value.
+       */
+      trunc(decimalPlaces: number): FunctionExpression;
+      /**
+       * @beta
+       * Creates an expression that truncates a numeric value to the specified number of decimal places.
+       *
+       * @example
+       * ```typescript
+       * // Truncate the value of the 'rating' field to two decimal places.
+       * field("rating").trunc(constant(2));
+       * ```
+       *
+       * @param decimalPlaces An expression specifying the truncation precision in decimal places.
+       * @returns A new `Expression` representing the truncated value.
+       */
+      trunc(decimalPlaces: Expression): FunctionExpression;
+      /**
+       * @beta
        * Creates an expression that rounds a numeric value to the nearest whole number.
        *
        * @example
@@ -9761,6 +9802,19 @@ declare namespace FirebaseFirestore {
     export function ln(fieldName: string): FunctionExpression;
     /**
      * @beta
+     * Creates an expression that generates a random number between 0.0 and 1.0 but not including 1.0.
+     *
+     * @example
+     * ```typescript
+     * // Generate a random number between 0.0 and 1.0.
+     * rand();
+     * ```
+     *
+     * @returns A new {@code Expression} representing the rand operation.
+     */
+    export function rand(): FunctionExpression;
+    /**
+     * @beta
      * Creates an expression that rounds a numeric value to the nearest whole number.
      *
      * ```typescript
@@ -9817,6 +9871,70 @@ declare namespace FirebaseFirestore {
      * @returns A new `Expr` representing the rounded value.
      */
     export function round(
+      expression: Expression,
+      decimalPlaces: number | Expression,
+    ): FunctionExpression;
+    /**
+     * @beta
+     * Creates an expression that truncates the numeric value of a field to an integer.
+     *
+     * @example
+     * ```typescript
+     * // Truncate the value of the 'rating' field.
+     * trunc("rating");
+     * ```
+     *
+     * @param fieldName The name of the field containing the number to truncate.
+     * @returns A new {@code Expression} representing the truncated value.
+     */
+    export function trunc(fieldName: string): FunctionExpression;
+    /**
+     * @beta
+     * Creates an expression that truncates the numeric value of an expression to an integer.
+     *
+     * @example
+     * ```typescript
+     * // Truncate the value of the 'rating' field.
+     * trunc(field("rating"));
+     * ```
+     *
+     * @param expression - An expression evaluating to a numeric value, which will be truncated.
+     * @returns A new {@code Expression} representing the truncated value.
+     */
+    export function trunc(expression: Expression): FunctionExpression;
+    /**
+     * @beta
+     * Creates an expression that truncates a numeric value to the specified number of decimal places.
+     *
+     * @example
+     * ```typescript
+     * // Truncate the value of the 'rating' field to two decimal places.
+     * trunc("rating", 2);
+     * ```
+     *
+     * @param fieldName The name of the field to truncate.
+     * @param decimalPlaces A constant or expression specifying the truncation precision in decimal places.
+     * @returns A new {@code Expression} representing the truncated value.
+     */
+    export function trunc(
+      fieldName: string,
+      decimalPlaces: number | Expression,
+    ): FunctionExpression;
+    /**
+     * @beta
+     * Creates an expression that truncates a numeric value to the specified number of decimal places.
+     *
+     * @example
+     * ```typescript
+     * // Truncate the value of the 'rating' field to two decimal places.
+     * trunc(field("rating"), constant(2));
+     * ```
+     *
+     * @param expression - An expression evaluating to a numeric value, which will be truncated.
+     * @param decimalPlaces - A constant or expression specifying the truncation precision in decimal places.
+     * @returns A new {@code Expression} representing the truncated value.
+     */
+    export function trunc(
       expression: Expression,
       decimalPlaces: number | Expression,
     ): FunctionExpression;


### PR DESCRIPTION
Adds support for the arithmetic pipeline expressions: `rand` and `trunc`.

ported from https://github.com/firebase/firebase-js-sdk/pull/9498